### PR TITLE
configure --enable-gst to turn on gst plugin build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,12 @@ AC_ARG_ENABLE([aiq],
                    [enable Aiq 3A algorithm build, @<:@default=no@:>@]),
     [], [enable_aiq="no"])
 
+AC_ARG_ENABLE([gst],
+    AS_HELP_STRING([--enable-gst],
+                   [enable gstreamer plugin build, @<:@default=no@:>@]),
+    [], [enable_gst="no"])
+AM_CONDITIONAL([ENABLE_GST], [test "$enable_gst" = "yes"])
+
 AC_ARG_ENABLE(libcl,
     AS_HELP_STRING([--enable-libcl],
                    [enable libcl image processor, @<:@default=yes@:>@]),
@@ -113,6 +119,15 @@ AC_CACHE_CHECK([for linux/atomisp.h],
 ])
 
 
+# build gstreamer plugin
+GST_API_VERSION=1.0
+ENABLE_GST=0
+if test "$enable_gst" = "yes"; then
+    ENABLE_GST=1
+    PKG_CHECK_MODULES([GST], [gstreamer-$GST_API_VERSION >= 1.2.3])
+    GST_CFLAGS=`$PKG_CONFIG --cflags gstreamer-$GST_API_VERSION`
+fi
+
 dnl set XCAM_CFLAGS and XCAM_CXXFLAGS
 XCAM_CFLAGS=" -fPIC -DSTDC99 -W -Wall -D_REENTRANT"
 if test "$enable_debug" = "yes"; then
@@ -160,6 +175,7 @@ echo "
      version                    : $XCAM_VERSION
      enable debug               : $enable_debug
      build aiq analyzer         : $enable_aiq
+     build GStreamer plugin     : $enable_gst
      use local aiq              : $use_local_aiq
      use local atomisp          : $use_local_atomisp
      have opencl lib            : $have_libcl

--- a/wrapper/gstreamer/Makefile.am
+++ b/wrapper/gstreamer/Makefile.am
@@ -1,7 +1,5 @@
 lib_LTLIBRARIES = libstub.la
 
-GST_CFLAGS = -I/usr/include/gstreamer-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/lib/glib-2.0/include
-
 PTHREAD_LDFLAGS = -pthread
 
 STUB_CXXFLAGS = -fPIC -std=c++11
@@ -12,6 +10,8 @@ if HAVE_LIBDRM
 STUB_CXXFLAGS += $(LIBDRM_CFLAGS)
 STUB_LIBS += $(LIBDRM_LIBS)
 endif
+
+if ENABLE_GST
 
 libstub_la_SOURCES = stub.cpp bufmap.cpp v4l2dev.cpp fmt.cpp
 
@@ -34,18 +34,7 @@ noinst_HEADERS = stub.h bufmap.h v4l2dev.h fmt.h
 # Note: plugindir is set in configure
 plugindir="\$(libdir)/gstreamer-1.0"
 
-##############################################################################
-# TODO: change libgstxcamsrc.la to something else, e.g. libmysomething.la     #
-##############################################################################
 plugin_LTLIBRARIES = libgstxcamsrc.la
-
-##############################################################################
-# TODO: for the next set of variables, name the prefix if you named the .la, #
-#  e.g. libmysomething.la => libmysomething_la_SOURCES                       #
-#                            libmysomething_la_CFLAGS                        #
-#                            libmysomething_la_LIBADD                        #
-#                            libmysomething_la_LDFLAGS                       #
-##############################################################################
 
 # sources used to compile this plug-in
 libgstxcamsrc_la_SOURCES = gstxcambufferpool.c	\
@@ -65,5 +54,7 @@ libgstxcamsrc_la_LDFLAGS = $(GST_PLUGIN_LDFLAGS)
 libgstxcamsrc_la_LIBTOOLFLAGS = --tag=disable-static
 
 # headers we need but don't want installed
-noinst_HEADERS = gstxcambufferpool.h	\
+noinst_HEADERS += gstxcambufferpool.h	\
 		 gstxcamsrc.h
+
+endif 	# ENABLE_GST


### PR DESCRIPTION
Add enable-gst flag to disable/enable the gst plugin in wrapper/gstreamer/

"./configure --enable-gst" will build the gst plugin.

By default the gst plugin will not be built.
