### PR TITLE
 gstreamer plugin xcamsrc: enable 3A

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,6 +161,7 @@ AC_CONFIG_FILES([Makefile
                  xcore/Makefile
                  wrapper/Makefile
                  wrapper/gstreamer/Makefile
+		 wrapper/gstreamer/interface/Makefile
                  tests/Makefile
                  pkgconfig/Makefile
                  pkgconfig/xcam_core.pc

--- a/wrapper/gstreamer/Makefile.am
+++ b/wrapper/gstreamer/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = interface
+
 lib_LTLIBRARIES = libstub.la
 
 PTHREAD_LDFLAGS = -pthread
@@ -6,15 +8,26 @@ STUB_CXXFLAGS = -fPIC -std=c++11
 STUB_LIBS = \
 		   $(NULL)
 
+XCAMSRC_CXXFLAGS = -fPIC -std=c++11
+XCAMSRC_LIBS = \
+		   $(NULL)
+
 if HAVE_LIBDRM
 STUB_CXXFLAGS += $(LIBDRM_CFLAGS)
 STUB_LIBS += $(LIBDRM_LIBS)
 endif
 
+if HAVE_LIBDRM
+XCAMSRC_CXXFLAGS += $(LIBDRM_CFLAGS)
+XCAMSRC_LIBS += $(LIBDRM_LIBS)
+endif
+
+
 libstub_la_SOURCES = stub.cpp bufmap.cpp v4l2dev.cpp fmt.cpp
 
 libstub_la_CXXFLAGS = -I$(top_builddir)/xcore -I$(top_builddir)/xcore/base \
 			$(GST_CFLAGS) \
+			-I$(top_builddir)/wrapper/gstreamer/interface \
 			 $(STUB_CXXFLAGS)	\
 			 $(NULL)    
 libstub_la_LDFLAGS = \
@@ -35,16 +48,19 @@ plugindir="\$(libdir)/gstreamer-1.0"
 plugin_LTLIBRARIES = libgstxcamsrc.la
 
 # sources used to compile this plug-in
-libgstxcamsrc_la_SOURCES = gstxcambufferpool.c	\
-			   gstxcamsrc.c
+libgstxcamsrc_la_SOURCES = gstxcambufferpool.cpp	\
+			   gstxcamsrc.cpp
 
 # compiler and linker flags used to compile this plugin, set in configure.ac
-libgstxcamsrc_la_CFLAGS = $(GST_CFLAGS)	\
-			  -I$(top_builddir)/xcore -I$(top_builddir)/xcore/base   \
-			  -I$(top_builddir)/wrapper/gstreamer
+libgstxcamsrc_la_CXXFLAGS = -I$(top_builddir)/xcore -I$(top_builddir)/xcore/base   \
+			   $(GST_CFLAGS) $(XCAMSRC_CXXFLAGS)	\
+			  -I$(top_builddir)/wrapper/gstreamer \
+	                  -I$(top_builddir)/wrapper/gstreamer/interface
 
-libgstxcamsrc_la_LIBADD = \
+
+libgstxcamsrc_la_LIBADD = $(XCAMSRC_LIBS) \
 			  $(top_builddir)/wrapper/gstreamer/libstub.la	\
+			  $(top_builddir)/wrapper/gstreamer/interface/libgstxcaminterface.la	    \
 			  $(GST_ALLOCATOR_LIBS)    \
 			  $(GST_VIDEO_LIBS)        \
 			  $(GST_LIBS)

--- a/wrapper/gstreamer/bufmap.h
+++ b/wrapper/gstreamer/bufmap.h
@@ -33,37 +33,34 @@ class BufMap {
 public:
     static SmartPtr<BufMap> instance();
 
-    GstBuffer* gbuf(SmartPtr<V4l2Buffer> &buf) {
-        uint32_t vbuf_idx = buf->get_buf().index;
+    GstBuffer* gbuf(SmartPtr<V4l2BufferProxy> &buf) {
+        uint32_t vbuf_idx = buf->get_v4l2_buf_index();
         if (_v2g.find(vbuf_idx) == _v2g.end()) { //non-existing
             return NULL;
         }
         return _v2g[vbuf_idx];
     }
-    SmartPtr<V4l2Buffer> vbuf(GstBuffer* gbuf) {
+    SmartPtr<V4l2BufferProxy> vbuf(GstBuffer* gbuf) {
         if (_g2v.find(gbuf) == _g2v.end()) { //non-existing
             return NULL;
         }
         return _g2v[gbuf];
     }
-    void setmap(GstBuffer* gbuf, SmartPtr<V4l2Buffer>& buf) {
-        _g2v[gbuf] = buf;
-        _v2g[buf->get_buf().index] = gbuf;
+    void setmap(GstBuffer* gbuf, SmartPtr<V4l2BufferProxy>& buf) {
+        //_g2v[gbuf] = buf;
+        _v2g[buf->get_v4l2_buf_index()] = gbuf;
     }
 
 private:
     XCAM_DEAD_COPY (BufMap);
 
 private:
-    BufMap()
-        : _g2v(std::map<GstBuffer*, SmartPtr<V4l2Buffer> >())
-        , _v2g(std::map<uint32_t, GstBuffer*>())
-    {};
+    BufMap() {};
 
     static SmartPtr<BufMap> _instance;
     static Mutex        _mutex;
 
-    std::map <GstBuffer*, SmartPtr<V4l2Buffer> > _g2v;
+    std::map <GstBuffer*, SmartPtr<V4l2BufferProxy> > _g2v;
     std::map <uint32_t, GstBuffer*> _v2g;
 };
 

--- a/wrapper/gstreamer/gstxcamsrc.cpp
+++ b/wrapper/gstreamer/gstxcamsrc.cpp
@@ -33,6 +33,14 @@
  * </refsect2>
  */
 
+#include "v4l2dev.h"
+#include "stub.h"
+#include "fmt.h"
+
+using namespace XCam;
+
+extern "C" {
+
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
 #endif
@@ -45,59 +53,56 @@
 #include <stdio.h>
 #include <signal.h>
 
-#include "stub.h"
-#include "fmt.h"
 #include "gstxcamsrc.h"
+#include "gstxcaminterface.h"
 
-GST_DEBUG_CATEGORY_STATIC (gst_xcamsrc_debug);
+
+    GST_DEBUG_CATEGORY_STATIC (gst_xcamsrc_debug);
 #define GST_CAT_DEFAULT gst_xcamsrc_debug
 
-#define DEFAULT_BLOCKSIZE   1843200
-#define DEFAULT_CAPTURE_DEVICE  "/dev/video3"
 
-#define DEFAULT_PROP_SENSOR     0
-#define DEFAULT_PROP_CAPTUREMODE    0
-#define DEFAULT_PROP_MEMTYPE        1
-#define DEFAULT_PROP_BUFFERCOUNT    6
-#define DEFAULT_PROP_FPSN       0
-#define DEFAULT_PROP_FPSD       0
-#define DEFAULT_PROP_WIDTH      0
-#define DEFAULT_PROP_HEIGHT     0
-#define DEFAULT_PROP_PIXELFORMAT    0
-#define DEFAULT_PROP_FIELD      0
-#define DEFAULT_PROP_BYTESPERLINE   0
+    enum
+    {
+        PROP_0,
+        PROP_DEVICE,
+        PROP_COLOREFFECT,
+        PROP_SENSOR,
+        PROP_CAPTURE_MODE,
+        PROP_ENABLE_3A,
+        PROP_IO_MODE,
+        PROP_BUFFERCOUNT,
+        PROP_FPSN,
+        PROP_FPSD,
+        PROP_WIDTH,
+        PROP_HEIGHT,
+        PROP_PIXELFORMAT,
+        PROP_FIELD,
+        PROP_BYTESPERLINE
+    };
 
-enum
-{
-    PROP_0,
-    PROP_SENSOR,
-    PROP_CAPTUREMODE,
-    PROP_MEMTYPE,
-    PROP_BUFFERCOUNT,
-    PROP_FPSN,
-    PROP_FPSD,
-    PROP_WIDTH,
-    PROP_HEIGHT,
-    PROP_PIXELFORMAT,
-    PROP_FIELD,
-    PROP_BYTESPERLINE
-};
-
+    static void gst_xcamsrc_xcam_3a_interface_init (GstXCam3AInterface *iface);
 
 #define gst_xcamsrc_parent_class parent_class
-G_DEFINE_TYPE (Gstxcamsrc, gst_xcamsrc, GST_TYPE_PUSH_SRC);
+    G_DEFINE_TYPE_WITH_CODE  (Gstxcamsrc, gst_xcamsrc, GST_TYPE_PUSH_SRC,
+                              G_IMPLEMENT_INTERFACE (GST_TYPE_XCAM_3A_IF,
+                                      gst_xcamsrc_xcam_3a_interface_init));
 
-GstCaps *gst_xcamsrc_get_all_caps (void);
+    GstCaps *gst_xcamsrc_get_all_caps (void);
 
-static void gst_xcamsrc_finalize (GObject * object);
-static void gst_xcamsrc_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec);
-static void gst_xcamsrc_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec);
-static GstCaps* gst_xcamsrc_get_caps (GstBaseSrc *src, GstCaps *filter);
-static gboolean gst_xcamsrc_set_caps (GstBaseSrc *src, GstCaps *caps);
-static gboolean gst_xcamsrc_start (GstBaseSrc *src);
-static gboolean gst_xcamsrc_stop (GstBaseSrc * basesrc);
-static GstFlowReturn gst_xcamsrc_alloc (GstBaseSrc *src, guint64 offset, guint size, GstBuffer **buffer);
-static GstFlowReturn gst_xcamsrc_fill (GstPushSrc *src, GstBuffer *out);
+    static void gst_xcamsrc_finalize (GObject * object);
+    static void gst_xcamsrc_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec);
+    static void gst_xcamsrc_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec);
+    static GstCaps* gst_xcamsrc_get_caps (GstBaseSrc *src, GstCaps *filter);
+    static gboolean gst_xcamsrc_set_caps (GstBaseSrc *src, GstCaps *caps);
+    static gboolean gst_xcamsrc_start (GstBaseSrc *src);
+    static gboolean gst_xcamsrc_stop (GstBaseSrc * basesrc);
+    static GstFlowReturn gst_xcamsrc_alloc (GstBaseSrc *src, guint64 offset, guint size, GstBuffer **buffer);
+    static GstFlowReturn gst_xcamsrc_fill (GstPushSrc *src, GstBuffer *out);
+
+    static gboolean xcamsrc_init (GstPlugin * xcamsrc);
+
+} //extern "C"
+
 
 static void
 gst_xcamsrc_class_init (GstxcamsrcClass * klass)
@@ -116,40 +121,52 @@ gst_xcamsrc_class_init (GstxcamsrcClass * klass)
     gobject_class->set_property = gst_xcamsrc_set_property;
     gobject_class->get_property = gst_xcamsrc_get_property;
 
-    g_object_class_install_property (gobject_class, PROP_SENSOR,
-                                     g_param_spec_int ("sensor", "Sensor id", "Sensor id",
-                                             0, G_MAXINT, DEFAULT_PROP_SENSOR, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+    g_object_class_install_property (gobject_class, PROP_DEVICE,
+                                     g_param_spec_string ("device", "Device", "Device location",
+                                             DEFAULT_PROP_DEVICE_NAME, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
-    g_object_class_install_property (gobject_class, PROP_CAPTUREMODE,
-                                     g_param_spec_int ("capturemode", "capture mode", "capture mode",
-                                             0, G_MAXINT, DEFAULT_PROP_CAPTUREMODE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-    g_object_class_install_property (gobject_class, PROP_MEMTYPE,
-                                     g_param_spec_int ("memtype", "memory type", "memory type",
-                                             0, G_MAXINT, DEFAULT_PROP_MEMTYPE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+    g_object_class_install_property (gobject_class, PROP_COLOREFFECT,
+                                     g_param_spec_int ("coloreffect", "color effect", "0, none\t 1,sky blue\t 2,skin whiten low\t 3,skin whiten\t 4,skin whiten hight\t 5,sepia",
+                                             G_MININT, G_MAXINT, 0, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | GST_PARAM_CONTROLLABLE)));
+
+    g_object_class_install_property (gobject_class, PROP_ENABLE_3A,
+                                     g_param_spec_boolean ("enable-3a", "Enable 3A", "Enable 3A",
+                                             true, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+    g_object_class_install_property (gobject_class, PROP_SENSOR,
+                                     g_param_spec_int ("sensor-id", "Sensor id", "Sensor id to input",
+                                             0, G_MAXINT, DEFAULT_PROP_SENSOR, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS) ));
+
+    g_object_class_install_property (gobject_class, PROP_CAPTURE_MODE,
+                                     g_param_spec_int ("capture-mode", "capture mode", "capture mode",
+                                             0, G_MAXINT, DEFAULT_PROP_CAPTURE_MODE, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS) ));
+    g_object_class_install_property (gobject_class, PROP_IO_MODE,
+                                     g_param_spec_int ("io-mode", "IO mode", "I/O mode",
+                                             0, G_MAXINT, DEFAULT_PROP_IO_MODE, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS) ));
     g_object_class_install_property (gobject_class, PROP_BUFFERCOUNT,
                                      g_param_spec_int ("buffercount", "buffer count", "buffer count",
-                                             0, G_MAXINT, DEFAULT_PROP_BUFFERCOUNT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                             0, G_MAXINT, DEFAULT_PROP_BUFFERCOUNT, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS) ));
     g_object_class_install_property (gobject_class, PROP_FPSN,
                                      g_param_spec_int ("fpsn", "fps n", "fps n",
-                                             0 , G_MAXINT, DEFAULT_PROP_FPSN, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                             0 , G_MAXINT, DEFAULT_PROP_FPSN, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS) ));
     g_object_class_install_property (gobject_class, PROP_FPSD,
                                      g_param_spec_int ("fpsd", "fps d", "fps d",
-                                             0, G_MAXINT, DEFAULT_PROP_FPSD, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                             0, G_MAXINT, DEFAULT_PROP_FPSD, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS) ));
     g_object_class_install_property (gobject_class, PROP_WIDTH,
                                      g_param_spec_int ("width", "width", "width",
-                                             0, G_MAXINT, DEFAULT_PROP_WIDTH, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                             0, G_MAXINT, DEFAULT_PROP_WIDTH, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS) ));
     g_object_class_install_property (gobject_class, PROP_HEIGHT,
                                      g_param_spec_int ("height", "height", "height",
-                                             0, G_MAXINT, DEFAULT_PROP_HEIGHT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                             0, G_MAXINT, DEFAULT_PROP_HEIGHT, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS) ));
     g_object_class_install_property (gobject_class, PROP_PIXELFORMAT,
                                      g_param_spec_int ("pixelformat", "pixelformat", "pixelformat",
-                                             0, G_MAXINT, DEFAULT_PROP_PIXELFORMAT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                             0, G_MAXINT, DEFAULT_PROP_PIXELFORMAT, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS) ));
     g_object_class_install_property (gobject_class, PROP_FIELD,
                                      g_param_spec_int ("field", "field", "field",
-                                             0, G_MAXINT, DEFAULT_PROP_FIELD, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                             0, G_MAXINT, DEFAULT_PROP_FIELD, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS) ));
     g_object_class_install_property (gobject_class, PROP_BYTESPERLINE,
                                      g_param_spec_int ("bytesperline", "bytes perline", "bytes perline",
-                                             0, G_MAXINT, DEFAULT_PROP_BYTESPERLINE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                                             0, G_MAXINT, DEFAULT_PROP_BYTESPERLINE, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS) ));
 
     gst_element_class_set_details_simple(element_class,
                                          "Libxcam Source",
@@ -169,26 +186,25 @@ gst_xcamsrc_class_init (GstxcamsrcClass * klass)
     pushsrc_class->fill = GST_DEBUG_FUNCPTR (gst_xcamsrc_fill);
 }
 
-Gstxcamsrc *g_src;
-
-void handler (int sig)
-{
-    libxcam_stop ();
-    libxcam_close ();
-    exit (1);
-}
-
+// FIXME remove this function?
 static void
 gst_xcamsrc_init (Gstxcamsrc *xcamsrc)
 {
-    g_src = xcamsrc;
-    signal (SIGSEGV, handler);
-    libxcam_set_device_name (DEFAULT_CAPTURE_DEVICE);
+    MainDeviceManager::set_capture_device_name (DEFAULT_CAPTURE_DEVICE);
+    MainDeviceManager::set_event_device_name (DEFAULT_EVENT_DEVICE);
+    MainDeviceManager::set_cpf_file_name (DEFAULT_CPF_FILE_NAME);
+
     gst_base_src_set_format (GST_BASE_SRC (xcamsrc), GST_FORMAT_TIME);
     gst_base_src_set_live (GST_BASE_SRC (xcamsrc), TRUE);
 
-    xcamsrc->_fps_n = 0;
-    xcamsrc->_fps_d = 0;
+    xcamsrc->buf_count = DEFAULT_PROP_BUFFERCOUNT; //8
+    xcamsrc->_fps_n = DEFAULT_PROP_FPSN; //25
+    xcamsrc->_fps_d = DEFAULT_PROP_FPSD; //1
+    xcamsrc->width = DEFAULT_PROP_WIDTH; //1920
+    xcamsrc->height = DEFAULT_PROP_HEIGHT; //1080
+    xcamsrc->pixelformat = V4L2_PIX_FMT_NV12; //420
+    xcamsrc->field = V4L2_FIELD_NONE; //0
+    xcamsrc->bytes_perline = DEFAULT_PROP_BYTESPERLINE; // 3840
 
     gst_base_src_set_blocksize (GST_BASE_SRC (xcamsrc), DEFAULT_BLOCKSIZE);
 }
@@ -196,11 +212,6 @@ gst_xcamsrc_init (Gstxcamsrc *xcamsrc)
 static void
 gst_xcamsrc_finalize (GObject * object)
 {
-    Gstxcamsrc *src = GST_XCAMSRC (object);
-
-    libxcam_stop ();
-    libxcam_close ();
-
     G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 
@@ -221,7 +232,11 @@ static gboolean
 gst_xcamsrc_stop (GstBaseSrc * basesrc)
 {
     Gstxcamsrc *src = GST_XCAMSRC_CAST (basesrc);
-    libxcam_stop ();
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+
+    device_manager->stop();
+    device_manager->get_device()->close ();
+    device_manager->get_sub_device()->close ();
     return TRUE;
 }
 
@@ -232,12 +247,18 @@ gst_xcamsrc_get_caps (GstBaseSrc *src, GstCaps *filter)
     return gst_pad_get_pad_template_caps (GST_BASE_SRC_PAD (xcamsrc));
 }
 
+extern "C" GstBufferPool *
+gst_xcambufferpool_new (Gstxcamsrc *xcamsrc, GstCaps *caps);
+
 static gboolean
 gst_xcamsrc_set_caps (GstBaseSrc *src, GstCaps *caps)
 {
     Gstxcamsrc *xcamsrc = GST_XCAMSRC (src);
 
     guint32 block_size = DEFAULT_BLOCKSIZE;
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<V4l2Device> device = device_manager->get_device();
+
     /**
      * set_sensor_id
      * set_capture_mode
@@ -248,15 +269,19 @@ gst_xcamsrc_set_caps (GstBaseSrc *src, GstCaps *caps)
      * set_format
      *
      **/
-    libxcam_set_framerate (xcamsrc->_fps_n, xcamsrc->_fps_d);
-    libxcam_open ();
-    libxcam_set_format (xcamsrc->width, xcamsrc->height, xcamsrc->pixelformat, xcamsrc->field, xcamsrc->bytes_perline);
+    device->set_buffer_count (xcamsrc->buf_count);
+    device->set_framerate (xcamsrc->_fps_n, xcamsrc->_fps_d);
+    device->open ();
+    device->set_format  (xcamsrc->width, xcamsrc->height, xcamsrc->pixelformat, xcamsrc->field, xcamsrc->bytes_perline);
 
-    libxcam_get_blocksize (&block_size);
+    struct v4l2_format format;
+    device->get_format (format);
+    block_size = format.fmt.pix.sizeimage;
+
     gst_base_src_set_blocksize (GST_BASE_SRC (xcamsrc), block_size);
 
     xcamsrc->duration = gst_util_uint64_scale_int (GST_SECOND, xcamsrc->_fps_d, xcamsrc->_fps_n);
-    xcamsrc->pool = gst_xcambufferpool_new (src, caps);
+    xcamsrc->pool = gst_xcambufferpool_new ((Gstxcamsrc*)src, caps);
 
     gst_buffer_pool_set_active (GST_BUFFER_POOL_CAST (xcamsrc->pool), TRUE);
     return TRUE;
@@ -367,15 +392,21 @@ static void gst_xcamsrc_set_property (GObject *object,
     Gstxcamsrc *src = GST_XCAMSRC (object);
     int val;
     enum v4l2_memory set_val;
+    SmartPtr<V4l2Device> device = DeviceManagerInstance::device_manager_instance()->get_device();
 
     switch (prop_id) {
+    case PROP_DEVICE:
+    case PROP_ENABLE_3A:
+    case PROP_COLOREFFECT:
+        break;
     case PROP_SENSOR:
-        libxcam_set_sensor_id (g_value_get_int (value));
+        device->set_sensor_id (g_value_get_int (value));
         break;
-    case PROP_CAPTUREMODE:
-        libxcam_set_capture_mode (g_value_get_int (value));
+    case PROP_CAPTURE_MODE:
+        val = g_value_get_int (value);
+        device->set_capture_mode (1 << (13 + val));
         break;
-    case PROP_MEMTYPE:
+    case PROP_IO_MODE:
         val = g_value_get_int (value);
         if (val == 1)
             set_val = V4L2_MEMORY_MMAP;
@@ -385,11 +416,10 @@ static void gst_xcamsrc_set_property (GObject *object,
             set_val = V4L2_MEMORY_OVERLAY;
         else
             set_val = V4L2_MEMORY_DMABUF;
-        libxcam_set_mem_type (set_val);
+        device->set_mem_type (set_val);
         break;
     case PROP_BUFFERCOUNT:
         src->buf_count = g_value_get_int (value);
-        libxcam_set_buffer_count (g_value_get_int (value));
         break;
     case PROP_FPSN:
         src->_fps_n = g_value_get_int (value);
@@ -431,6 +461,44 @@ gst_xcamsrc_get_all_caps (void)
     return gst_caps_ref (caps);
 }
 
+static void
+gst_xcamsrc_xcam_3a_interface_init (GstXCam3AInterface *iface)
+{
+    iface->set_white_balance_mode = gst_xcamsrc_set_white_balance_mode;
+    iface->set_awb_speed = gst_xcamsrc_set_awb_speed;
+
+    iface->set_wb_color_temperature_range = gst_xcamsrc_set_wb_color_temperature_range;
+    iface->set_manual_wb_gain = gst_xcamsrc_set_manual_wb_gain;
+
+    iface->set_exposure_mode = gst_xcamsrc_set_exposure_mode;
+    iface->set_ae_metering_mode = gst_xcamsrc_set_ae_metering_mode;
+    iface->set_exposure_window = gst_xcamsrc_set_exposure_window;
+    iface->set_exposure_value_offset = gst_xcamsrc_set_exposure_value_offset;
+    iface->set_ae_speed = gst_xcamsrc_set_ae_speed;
+
+    iface->set_exposure_flicker_mode = gst_xcamsrc_set_exposure_flicker_mode;
+    iface->get_exposure_flicker_mode = gst_xcamsrc_get_exposure_flicker_mode;
+    iface->get_current_exposure_time = gst_xcamsrc_get_current_exposure_time;
+    iface->get_current_analog_gain = gst_xcamsrc_get_current_analog_gain;
+    iface->set_manual_exposure_time = gst_xcamsrc_set_manual_exposure_time;
+    iface->set_manual_analog_gain = gst_xcamsrc_set_manual_analog_gain;
+    iface->set_aperture = gst_xcamsrc_set_aperture;
+    iface->set_max_analog_gain = gst_xcamsrc_set_max_analog_gain;
+    iface->get_max_analog_gain = gst_xcamsrc_get_max_analog_gain;
+    iface->set_exposure_time_range = gst_xcamsrc_set_exposure_time_range;
+    iface->get_exposure_time_range = gst_xcamsrc_get_exposure_time_range;
+    iface->set_dvs = gst_xcamsrc_set_dvs;
+    iface->set_noise_reduction_level = gst_xcamsrc_set_noise_reduction_level;
+    iface->set_temporal_noise_reduction_level = gst_xcamsrc_set_temporal_noise_reduction_level;
+    iface->set_gamma_table = gst_xcamsrc_set_gamma_table;
+    iface->set_gbce = gst_xcamsrc_set_gbce;
+    iface->set_manual_brightness = gst_xcamsrc_set_manual_brightness;
+    iface->set_manual_contrast = gst_xcamsrc_set_manual_contrast;
+    iface->set_manual_hue = gst_xcamsrc_set_manual_hue;
+    iface->set_manual_saturation = gst_xcamsrc_set_manual_saturation;
+    iface->set_manual_sharpness = gst_xcamsrc_set_manual_sharpness;
+    iface->set_night_mode = gst_xcamsrc_set_night_mode;
+}
 
 static gboolean
 xcamsrc_init (GstPlugin * xcamsrc)

--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -25,6 +25,24 @@
 #include <gst/base/gstpushsrc.h>
 #include <linux/videodev2.h>
 
+#define DEFAULT_BLOCKSIZE   1843200
+#define DEFAULT_CAPTURE_DEVICE  "/dev/video3"
+#define DEFAULT_EVENT_DEVICE    "/dev/v4l-subdev6"
+#define DEFAULT_CPF_FILE_NAME   "/etc/atomisp/imx185.cpf"
+
+#define DEFAULT_PROP_DEVICE_NAME    "/dev/video3"
+#define DEFAULT_PROP_SENSOR     0
+#define DEFAULT_PROP_CAPTURE_MODE    0
+#define DEFAULT_PROP_IO_MODE        4
+#define DEFAULT_PROP_BUFFERCOUNT    8
+#define DEFAULT_PROP_FPSN       25
+#define DEFAULT_PROP_FPSD       1
+#define DEFAULT_PROP_WIDTH      1920
+#define DEFAULT_PROP_HEIGHT     1080
+#define DEFAULT_PROP_PIXELFORMAT    V4L2_PIX_FMT_NV12 //420 instead of 0
+#define DEFAULT_PROP_FIELD      V4L2_FIELD_NONE // 0
+#define DEFAULT_PROP_BYTESPERLINE   3840
+
 G_BEGIN_DECLS
 
 /* #defines don't like whitespacey bits */

--- a/wrapper/gstreamer/interface/Makefile.am
+++ b/wrapper/gstreamer/interface/Makefile.am
@@ -1,0 +1,21 @@
+lib_LTLIBRARIES = libgstxcaminterface.la
+
+libgstxcaminterface_la_SOURCES = gstxcaminterface.c
+
+GST_CFLAGS = -I/usr/include/gstreamer-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/lib/glib-2.0/include
+LIBXCAM_CFLAGS = -I/usr/include/xcam -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include 
+
+libgstxcaminterface_la_CFLAGS = \
+				 $(GST_CFLAGS) \
+				 $(LIBXCAM_CFLAGS)
+
+libgstxcaminterface_la_LIBADD = \
+				 $(GST_LIBS) \
+				 $(NULL)
+
+libgstxcaminterfaceincludedir = \
+	$(includedir)/gstreamer-1.0/gst
+
+libgstxcaminterfaceinclude_HEADERS = \
+	gstxcaminterface.h
+

--- a/wrapper/gstreamer/interface/gstxcaminterface.c
+++ b/wrapper/gstreamer/interface/gstxcaminterface.c
@@ -1,0 +1,90 @@
+/*
+ * gstxcaminterface.c - Gstreamer XCam 3A interface
+ *
+ * Copyright (C) 2014 Intel Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Wind Yuan <feng.yuan@intel.com>
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "gstxcaminterface.h"
+#include <string.h>
+
+static void gst_xcam_3a_iface_init (GstXCam3AInterface *iface);
+
+GType
+gst_xcam_3a_interface_get_type (void)
+{
+    static GType gst_xcam_3a_interface_type = 0;
+
+    if (!gst_xcam_3a_interface_type) {
+        static const GTypeInfo gst_xcam_3a_interface_info = {
+            sizeof (GstXCam3AInterface),
+            (GBaseInitFunc) gst_xcam_3a_iface_init,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            0,
+            0,
+            NULL,
+        };
+
+        gst_xcam_3a_interface_type = g_type_register_static (G_TYPE_INTERFACE,
+                                     "GsXCam3AInterface", &gst_xcam_3a_interface_info, 0);
+    }
+    return gst_xcam_3a_interface_type;
+}
+
+static void
+gst_xcam_3a_iface_init (GstXCam3AInterface * iface)
+{
+    /* default virtual functions */
+    iface->set_white_balance_mode = NULL;
+    iface->set_awb_speed = NULL;
+    iface->set_wb_color_temperature_range = NULL;
+    iface->set_manual_wb_gain = NULL;
+    iface->set_exposure_mode = NULL;
+    iface->set_ae_metering_mode = NULL;
+    iface->set_exposure_window = NULL;
+    iface->set_exposure_value_offset = NULL;
+    iface->set_ae_speed = NULL;
+    iface->set_exposure_flicker_mode = NULL;
+    iface->get_exposure_flicker_mode = NULL;
+    iface->get_current_exposure_time = NULL;
+    iface->get_current_analog_gain = NULL;
+    iface->set_manual_exposure_time = NULL;
+    iface->set_manual_analog_gain = NULL;
+    iface->set_aperture = NULL;
+    iface->set_max_analog_gain = NULL;
+    iface->get_max_analog_gain = NULL;
+    iface->set_exposure_time_range = NULL;
+    iface->get_exposure_time_range = NULL;
+    iface->set_dvs = NULL;
+    iface->set_noise_reduction_level = NULL;
+    iface->set_temporal_noise_reduction_level = NULL;
+    iface->set_gamma_table = NULL;
+    iface->set_gbce = NULL;
+    iface->set_manual_brightness = NULL;
+    iface->set_manual_contrast = NULL;
+    iface->set_manual_hue = NULL;
+    iface->set_manual_saturation = NULL;
+    iface->set_manual_sharpness = NULL;
+    iface->set_night_mode = NULL;
+    iface->set_3a_mode = NULL;
+}

--- a/wrapper/gstreamer/interface/gstxcaminterface.h
+++ b/wrapper/gstreamer/interface/gstxcaminterface.h
@@ -1,0 +1,420 @@
+/*
+ * Copyright (C) 2014 Intel Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Wind Yuan <feng.yuan@intel.com>
+ */
+
+/*! \file gstxcaminterface.h
+ * \brief Gstreamer XCam 3A interface
+ *
+ */
+
+#ifndef GST_XCAM_INTERFACE_H
+#define GST_XCAM_INTERFACE_H
+
+#include <gst/gst.h>
+#include <linux/videodev2.h>
+#include <xcam_3a_types.h>
+
+
+G_BEGIN_DECLS
+
+/*! \brief Get GST interface type of XCam 3A interface
+ *
+ * \return    GType    returned by g_type_register_static()
+ */
+#define GST_TYPE_XCAM_3A_IF (gst_xcam_3a_interface_get_type ())
+
+/*! \brief Get GST XCam 3A handle.
+ * See usage of struct _GstXCam3AInterface.
+ *
+ * \return    XCam 3A handle of _GstXCam3A * type
+ */
+#define GST_XCAM_3A(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST ((obj), GST_TYPE_XCAM_3A_IF, GstXCam3A))
+
+/*! \brief Get GST XCam 3A interface
+ *
+ * See usage of struct _GstXCam3AInterface.
+ *
+ * \param[in]    Xcam 3A handle
+ * \return       GstXCam3AInterface*
+ */
+#define GST_XCAM_3A_GET_INTERFACE(inst) \
+  (G_TYPE_INSTANCE_GET_INTERFACE ((inst), GST_TYPE_XCAM_3A_IF, GstXCam3AInterface))
+
+typedef struct _GstXCam3A GstXCam3A;
+typedef struct _GstXCam3AInterface GstXCam3AInterface;
+
+/*! \brief XCam 3A Interface
+ *
+ * Usage:
+ * - GstXCam3A *xcam = GST_XCAM_3A (v4l2src);
+ * - GstXCam3AInterface *xcam_interface = GST_XCAM_3A_GET_INTERFACE (xcam);
+ * - ret = xcam_interface->set_exposure_mode(xcam, XCAM_AE_MODE_AUTO);
+ */
+struct _GstXCam3AInterface {
+    GTypeInterface base; /*!< inherent from GTypeInterface */
+
+    /*! \brief Set white balance mode.
+     * See xcam_3a_set_whitebalance_mode().
+     *
+     * \param[in,out]    xcam    XCam handle
+     * \param[in]        mode    white balance mode
+     * return            0 on success; -1 on error (parameter error)
+     */
+    gboolean (* set_white_balance_mode)         (GstXCam3A *xcam, XCamAwbMode mode);
+
+    /*! \brief set AWB speed.
+     * see xcam_3a_set_awb_speed().
+     *
+     * \param[in,out]    xcam    XCam handle
+     * \param[in,out]    speed   AWB speed; speed meaturement will consider later
+     * return            0 on success; -1 on error
+     */
+    gboolean (* set_awb_speed)                  (GstXCam3A *xcam, double speed);
+
+    /*! \brief Set white balance temperature range.
+     * see xcam_3a_set_awb_color_temperature_range().
+     *
+     * \param[in]    cct_min      0 < cct_min <= cct_max <= 10000; if 0, disable cct range
+     * \param[in]    cct_max      0 < cct_min <= cct_max <= 10000; if 0, disable cct range
+     * \return       0 on success; -1 on error
+     *
+     * Usage:
+     *
+     * - Enable:
+     *     1. set_white_balance_mode(%XCAM_AWB_MODE_MANUAL)
+     *     2. set_wb_color_temperature_range
+     * - Disable:
+     *     set_white_balance_mode(%XCAM_AWB_MODE_AUTO)
+     *
+     */
+    gboolean (* set_wb_color_temperature_range) (GstXCam3A *xcam, guint cct_min, guint cct_max);
+
+    /*! \brief Set manual white balance gain.
+     * see xcam_3a_set_wb_manual_gain().
+     *
+     * \param[in,out]    xcam    XCam handle
+     * \param[in]        gr      GR channel
+     * \param[in]        r       R channel
+     * \param[in]        b       B channel
+     * \param[in]        gb      GB channel
+     *
+     * Usage:
+     *
+     * - Enable:
+     *     1. need gr, r, b, gb => gain value [0.1~4.0];
+     *     2. set_white_balance_mode(xcam, XCAM_AWB_MODE_NOT_SET)
+     * - Disable:
+     *     1. need set gr=0, r=0, b=0, gb=0;
+     *     2. set_white_balance_mode(xcam, mode);  mode != XCAM_AWB_MODE_NOT_SET
+     */
+    gboolean (* set_manual_wb_gain)             (GstXCam3A *xcam, double gr, double r, double b, double gb);
+
+
+    /*! \brief set exposure mode.
+     * see xcam_3a_set_exposure_mode().
+     *
+     * \param[in,out]    xcam    XCam handle
+     * \param[in]        mode    choose from XCAM_AE_MODE_AUTO and XCAM_AE_MODE_MANUAL; others not supported
+     */
+    gboolean (* set_exposure_mode)              (GstXCam3A *xcam, XCamAeMode mode);
+
+    /*! \brief set AE metering mode.
+     * see xcam_3a_set_ae_metering_mode().
+     *
+     * \param[in,out]    xcam    XCam handle
+     * \param[in]        mode    XCAM_AE_METERING_MODE_AUTO, default
+     *                           XCAM_AE_METERING_MODE_SPOT, need set spot window by set_exposure_window
+     *                           XCAM_AE_METERING_MODE_CENTER,  more weight in center
+     */
+    gboolean (* set_ae_metering_mode)           (GstXCam3A *xcam, XCamAeMeteringMode mode);
+
+    /* \brief set exposure window.
+     * see xcam_3a_set_ae_window().
+     *
+     * \param[in,out]    xcam      XCam handle
+     * \param[in]        window    the area to set exposure with. x_end > x_start AND y_end > y_start; only ONE window can be set
+     *
+     * Usage
+     * - Enable:
+     *     set_ae_metering_mode(@xcam, %XCAM_AE_METERING_MODE_SPOT)
+     * - Disable:
+     *     set_ae_metering_mode(@xcam, @mode); #mode != %XCAM_AE_METERING_MODE_SPOT
+     */
+    gboolean (* set_exposure_window)            (GstXCam3A *xcam, XCam3AWindow *window);
+
+    /*! \brief set exposure value offset.
+     * see xcam_3a_set_ae_value_shift().
+     *
+     * \param[in,out]    xcam        XCam handle
+     * \param[in]        ev_offset   -4.0 <= ev_offset <= 4.0; default 0.0
+     */
+    gboolean (* set_exposure_value_offset)      (GstXCam3A *xcam, double ev_offset);
+
+    /*! \brief set  AE speed.
+     * see xcam_3a_set_ae_speed().
+     *
+     * \param[in,out]    xcam        XCam handle
+     * \param[in]        speed       AE speed
+     */
+    gboolean (* set_ae_speed)                   (GstXCam3A *xcam, double speed);
+
+    /*! \brief set exposure flicker mode.
+     * see xcam_3a_set_ae_flicker_mode().
+     *
+     * \param[in,out]    xcam        XCam handle
+     * \param[in]        flicker     XCAM_AE_FLICKER_MODE_AUTO, default
+     *                               XCAM_AE_FLICKER_MODE_50HZ
+     *                               XCAM_AE_FLICKER_MODE_60HZ
+     *                               XCAM_AE_FLICKER_MODE_OFF, outside
+     */
+    gboolean (*set_exposure_flicker_mode)       (GstXCam3A *xcam, XCamFlickerMode flicker);
+
+    /*! \brief get exposure flicker mode.
+     * see xcam_3a_get_ae_flicker_mode().
+     *
+     * \param[in,out]    xcam                XCam handle
+     * \return           XCamFlickerMode     XCAM_AE_FLICKER_MODE_AUTO, default
+     *                                       XCAM_AE_FLICKER_MODE_50HZ
+     *                                       XCAM_AE_FLICKER_MODE_60HZ
+     *                                       XCAM_AE_FLICKER_MODE_OFF, outside
+     */
+    XCamFlickerMode (*get_exposure_flicker_mode)      (GstXCam3A *xcam);
+
+    /*! \brief get current exposure time.
+     * see xcam_3a_get_current_exposure_time().
+     *
+     * \param[in,out]    xcam        XCam handle
+     * \return           current exposure time in microsecond, if return -1, means xcam is not started
+     */
+    gint64   (* get_current_exposure_time)      (GstXCam3A *xcam);
+
+    /*! \brief get current analog gain.
+     * see xcam_3a_get_current_analog_gain().
+     *
+     * \param[in,out]    xcam        XCam handle
+     * \return            current analog gain as multiplier. If return < 0.0 OR return < 1.0,  xcam is not started.
+     */
+    double   (* get_current_analog_gain)        (GstXCam3A *xcam);
+
+    /*! \brief set manual exposure time
+     *
+     * \param[in,out]    xcam          XCam handle
+     * \param[in]        time_in_us    exposure time
+     *
+     * Usage:
+     * - Enable:
+     *      set time_in_us, 0 < time_in_us < 1/fps
+     * - Disable:
+     *     time_in_us = 0
+     */
+    gboolean (* set_manual_exposure_time)       (GstXCam3A *xcam, gint64 time_in_us);
+
+    /*! \brief set manual analog gain.
+     * see  xcam_3a_set_ae_manual_analog_gain().
+     *
+     * \param[in,out]    xcam          XCam handle
+     * \param[in]        gain          analog gain
+     *
+     * Usage:
+     * - Enable:
+     *     set @gain value, 1.0 < @gain
+     * - Disable:
+     *     set @gain = 0.0
+     */
+    gboolean (* set_manual_analog_gain)         (GstXCam3A *xcam, double gain);
+
+    /*! \brief set aperture.
+     * see xcam_3a_set_ae_set_aperture().
+     *
+     * \param[in,out]    xcam            XCam3A handle
+     * \param[in]        fn              AE aperture fn
+     * \return           bool            0 on success
+     */
+    gboolean (* set_aperture)                   (GstXCam3A *xcam, double fn);
+
+    /*! \brief set max analog gain.
+     * see xcam_3a_set_ae_max_analog_gain().
+     *
+     * \param[in,out]    xcam            XCam3A handle
+     * \param[in]        max_gain        max analog gain
+     * \return           gboolen         0 on success
+     */
+    gboolean (* set_max_analog_gain)            (GstXCam3A *xcam, double max_gain);
+
+    /*! \brief get max analog gain.
+     * see xcam_3a_get_ae_max_analog_gain().
+     *
+     * \param[in,out]    xcam            XCam3A handle
+     * \return           max_gain        max analog gain
+     */
+    double   (* get_max_analog_gain)            (GstXCam3A *xcam);
+
+    /*!
+     * \brief set AE time range
+     *
+     * \param[in,out]    xcam            XCam3A handle
+     * \param[in]        min_time_in_us  min time
+     * \param[in]        max_time_in_us  max time
+     * \return           XCam3AStatus    0 on success
+     */
+    gboolean (* set_exposure_time_range)        (GstXCam3A *xcam, gint64 min_time_in_us, gint64 max_time_in_us);
+
+    /*!
+     * \brief XCam3A get AE time range.
+     * Range in [0 ~ 1000000/fps] micro-seconds. see xcam_3a_set_ae_time_range().
+     *
+     * \param[in,out]    xcam            XCam3A handle
+     * \param[out]       min_time_in_us  min time
+     * \param[out]       max_time_in_us  max time
+     * \return           bool            0 on success
+     */
+    gboolean (* get_exposure_time_range)        (GstXCam3A *xcam, gint64 *min_time_in_us, gint64 *max_time_in_us);
+
+    /*! \brief set DVS.
+     *  digital video stabilization. see xcam_3a_enable_dvs().
+     *
+     * \param[in,out]    xcam            XCam3A handle
+     * \param[in]        enable          enable/disable
+     * \return           bool            0 on success
+     */
+    gboolean (* set_dvs)                        (GstXCam3A *xcam, gboolean enable);
+
+    /*! \brief set noice reduction level to BNR and YNR.
+     * see xcam_3a_set_noise_reduction_level().
+     *
+     * \param[in,out]    xcam            XCam3A handle
+     * \param[in]        level           control BNR/YNR gain. 0 <= level <= 255; default level: 128
+     * \return           bool            0 on success
+     */
+    gboolean (*set_noise_reduction_level)       (GstXCam3A *xcam, guint8 level);
+
+    /*! \brief set temporal noice reduction level.
+     * see xcam_3a_set_temporal_noise_reduction_level().
+     *
+     * \param[in,out]    xcam            XCam3A handle
+     * \param[in]        level           control TNR gain. 0 <= level <= 255; default level: 128
+     * \return           bool            0 on success
+     */
+    gboolean (*set_temporal_noise_reduction_level) (GstXCam3A *xcam, guint8 level);
+
+    /*!
+     * \brief set gamma table.
+     * see xcam_3a_set_set_gamma_table().
+     *
+     * \param[in,out]    xcam          XCam3A handle
+     * \param[in]        r_table         red color gamma table
+     * \param[in]        g_table         green color gamma table
+     * \param[in]        b_table         blue color gamma table
+     * \return           bool            0 on success
+     *
+     * Restriction:
+     *     1. can't co-work with manual brightness and contrast,
+     *     2. table size = 256, and values in [0.0~1.0], e.g 0.0, 1.0/256,  2.0/256 ... 255.0/256
+     *
+     * Usage:
+     * - to Disable:
+     *     r_table = NULL && g_table = NULL && b_table=NULL
+     */
+    gboolean (* set_gamma_table)                (GstXCam3A *xcam, double *r_table, double *g_table, double *b_table);
+
+    /*!
+     * \brief enable/disable gbce.
+     * see xcam_3a_enable_gbce().
+     *
+     * \param[in,out]    xcam          XCam3A handle
+     * \param[in]        enable        enable/disable, i.e. TRUE to enable GBCE and otherwise disable GBCE.
+     * \return           bool          0 on success
+     */
+    gboolean (* set_gbce)                       (GstXCam3A *xcam, gboolean enable);
+
+    /*!
+     * \brief set manual brightness.
+     * see xcam_3a_set_manual_brightness().
+     *
+     * \param[in,out]    xcam            XCam3A handle
+     * \param[in]        value           manual brightness, 0 <= value <= 255; default:128
+     * \return           bool            0 on success    */
+    gboolean (* set_manual_brightness)          (GstXCam3A *xcam, guint8 value);
+
+    /*!
+     * \brief set manual contrast.
+     * see xcam_3a_set_manual_contrast().
+     *
+     * \param[in,out]    xcam            XCam3A handle
+     * \param[in]        value           manual contrast, 0 <= value <= 255; default:128
+     * \return           bool            0 on success    */
+    gboolean (* set_manual_contrast)            (GstXCam3A *xcam, guint8 value);
+
+    /*!
+     * \brief set manual hue.
+     * see xcam_3a_set_manual_hue().
+     *
+     * \param[in,out]    xcam            XCam3A handle
+     * \param[in]        value           manual hue, 0 <= value <= 255; default:128
+     * \return           bool            0 on success    */
+    gboolean (* set_manual_hue)                 (GstXCam3A *xcam, guint8 value);
+
+    /*!
+     * \brief set manual saturation.
+     * see xcam_3a_set_manual_saturation().
+     *
+     * \param[in,out]    xcam            XCam3A handle
+     * \param[in]        value           manual saturation, 0 <= value <= 255; default:128
+     * \return           bool            0 on success    */
+    gboolean (* set_manual_saturation)          (GstXCam3A *xcam, guint8 value);
+
+    /*!
+     * \brief set manual sharpness.
+     * see xcam_3a_set_manual_sharpness().
+     *
+     * \param[in,out]    xcam            XCam3A handle
+     * \param[in]        value           manual sharpness, 0 <= value <= 255; default:128
+     * \return           bool            0 on success    */
+    gboolean (* set_manual_sharpness)           (GstXCam3A *xcam, guint8 value);
+
+    /* IR-cut */
+    /*!
+     * \brief enable/disable night mode.
+     * see xcam_3a_enable_night_mode().
+     *
+     * \param[in,out]    xcam          XCam3A handle
+     * \param[in]        enable        enable/disable, i.e. TRUE to enable night mode and otherwise disable night mode.
+     * \return           bool          0 on success
+     */
+    gboolean (* set_night_mode)                 (GstXCam3A *xcam, gboolean enable);
+
+    /*!
+     * \brief enable/disable 3A mode.
+     */
+    gboolean (* set_3a_mode)                 (GstXCam3A *xcam, gboolean enable);
+};
+
+/*! \brief Get GST interface type of XCam 3A interface.
+ * will try to register GsXcam3AInterface with
+ * g_type_register_static() if not done so yet, and in turn return the
+ * interface type it returns.
+ *
+ * \return    GType    XCam 3A interface type returned by g_type_register_static()
+ */
+GType
+gst_xcam_3a_interface_get_type (void);
+
+G_END_DECLS
+
+#endif /* GST_XCAM_INTERFACE_H */

--- a/wrapper/gstreamer/stub.cpp
+++ b/wrapper/gstreamer/stub.cpp
@@ -26,127 +26,25 @@
 
 using namespace XCam;
 
-int libxcam_set_device_name (const char *ch)
+int libxcam_dequeue_buffer (SmartPtr<V4l2BufferProxy> &buf)
 {
-    V4l2Dev::_device_name = ch;
-    return 0;
-}
-
-int libxcam_set_sensor_id (int id)
-{
-    SmartPtr<V4l2Device> device = V4l2Dev::instance();
-    return (int) device->set_sensor_id (id);
-}
-int libxcam_set_capture_mode (uint32_t cap_mode)
-{
-    SmartPtr<V4l2Device> device = V4l2Dev::instance();
-    return (int) device->set_capture_mode (cap_mode);
-}
-int libxcam_set_mem_type (enum v4l2_memory mem_type)
-{
-    SmartPtr<V4l2Device> device = V4l2Dev::instance();
-    return (int) device->set_mem_type (mem_type);
-}
-int libxcam_set_buffer_count (uint32_t buf_count)
-{
-    SmartPtr<V4l2Device> device = V4l2Dev::instance();
-    return (int) device->set_buffer_count (buf_count);
-}
-int libxcam_set_framerate (uint32_t fps_n, uint32_t fps_d)
-{
-    SmartPtr<V4l2Device> device = V4l2Dev::instance();
-    return (int) device->set_framerate (fps_n, fps_d);
-}
-int libxcam_open ()
-{
-    SmartPtr<V4l2Device> device = V4l2Dev::instance();
-    return (int) device->open ();
-}
-int libxcam_close ()
-{
-    SmartPtr<V4l2Device> device = V4l2Dev::instance();
-    return (int) device->close ();
-}
-int libxcam_set_format (uint32_t width, uint32_t height, uint32_t pixelformat, enum v4l2_field field, uint32_t bytes_perline)
-{
-    SmartPtr<V4l2Device> device = V4l2Dev::instance();
-    return (int) device->set_format (width, height, pixelformat, field, bytes_perline);
-}
-int libxcam_get_blocksize (uint32_t *blocksize)
-{
-    SmartPtr<V4l2Device> device = V4l2Dev::instance();
-    struct v4l2_format format;
-    int ret ;
-    ret = (int) device->get_format (format);
-    *blocksize = format.fmt.pix.sizeimage;
-    return ret;
-}
-int libxcam_start ()
-{
-    SmartPtr<V4l2Device> device = V4l2Dev::instance();
-    struct v4l2_format format;
-    device->get_format (format);
-    return (int) device->start();
-}
-
-int libxcam_stop ()
-{
-    SmartPtr<V4l2Device> device = V4l2Dev::instance();
-    return (int) device->stop();
-}
-
-int libxcam_dequeue_buffer (SmartPtr<V4l2Buffer> &buf)
-{
-    SmartPtr<V4l2Device> device = V4l2Dev::instance();
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     int ret;
+    SmartPtr<VideoBuffer> video_buffer;
 
-    ret = device->poll_event (5000);
-    if (ret < 0) {
-        printf ("device(%s) poll event failed\n", device->get_device_name());
-        return -1;
-    } else if (ret == 0) {
-        printf ("device(%s) poll event did not detect events\n", device->get_device_name());
-        return -1;
+    pthread_mutex_lock (&device_manager->bufs_mutex);
+    if (device_manager->bufs.size() == 0) {
+        pthread_cond_wait (&device_manager->bufs_cond, &device_manager->bufs_mutex);
     }
+    video_buffer = device_manager->bufs.front();
+    device_manager->bufs.pop();
+    pthread_mutex_unlock (&device_manager->bufs_mutex);
+    buf = video_buffer.dynamic_cast_ptr<V4l2BufferProxy>();
 
-    ret = device->dequeue_buffer (buf);
-    if (ret != XCAM_RETURN_NO_ERROR) {
-        printf ("device(%s) dequeue buffer failed\n", device->get_device_name() );
-        return ret;
-    }
-
+    pthread_mutex_lock (&device_manager->release_mutex);
+    device_manager->release_bufs.push (video_buffer);
+    pthread_mutex_unlock (&device_manager->release_mutex);
     return (int) XCAM_RETURN_NO_ERROR;
-}
-int libxcam_enqueue_buffer (SmartPtr<V4l2Buffer> &buf)
-{
-    SmartPtr<V4l2Device> device = V4l2Dev::instance();
-    int ret;
-
-    ret = device->queue_buffer (buf);
-    if (ret != XCAM_RETURN_NO_ERROR) {
-        printf ("device(%s) queue buffer failed\n", device->get_device_name());
-        return ret;
-    }
-    return (int) XCAM_RETURN_NO_ERROR;
-}
-
-// FIXME remove the following 4 functions
-GstBuffer* bufmap_2gbuf(SmartPtr<V4l2Buffer> &buf)
-{
-    SmartPtr<BufMap> bufmap = BufMap::instance();
-    return bufmap->gbuf(buf);
-}
-
-SmartPtr<V4l2Buffer> bufmap_2vbuf(GstBuffer* gbuf)
-{
-    SmartPtr<BufMap> bufmap = BufMap::instance();
-    return bufmap->vbuf(gbuf);
-}
-
-void bufmap_setmap(GstBuffer* gbuf, SmartPtr<V4l2Buffer> buf)
-{
-    SmartPtr<BufMap> bufmap = BufMap::instance();
-    bufmap->setmap(gbuf, buf);
 }
 
 GstFlowReturn
@@ -156,22 +54,22 @@ xcam_bufferpool_acquire_buffer (GstBufferPool *bpool, GstBuffer **buffer, GstBuf
     Gstxcambufferpool *pool = GST_XCAMBUFFERPOOL_CAST (bpool);
     Gstxcamsrc *xcamsrc = pool->src;
 
-    SmartPtr<V4l2Buffer> buf;
+    SmartPtr<V4l2BufferProxy> buf;
     libxcam_dequeue_buffer (buf);
 
-    struct v4l2_buffer vbuf = buf->get_buf();
+    SmartPtr<BufMap> bufmap = BufMap::instance();
+    gbuf = bufmap->gbuf(buf);
 
-    gbuf = bufmap_2gbuf(buf);
     if (!gbuf) {
         gbuf = gst_buffer_new();
         GST_BUFFER (gbuf)->pool = (GstBufferPool*) pool;
 
         gst_buffer_append_memory (gbuf,
-                                  gst_dmabuf_allocator_alloc (pool->allocator, vbuf.m.fd, vbuf.length));
-        bufmap_setmap(gbuf, buf);
+                                  gst_dmabuf_allocator_alloc (pool->allocator, buf->get_v4l2_dma_fd(), buf->get_v4l2_buf_length()));
+        bufmap->setmap(gbuf, buf);
     }
 
-    GST_BUFFER_TIMESTAMP (gbuf) = GST_TIMEVAL_TO_TIME (vbuf.timestamp);
+    GST_BUFFER_TIMESTAMP (gbuf) = buf->get_timestamp();
     *buffer = gbuf;
 
     return GST_FLOW_OK;
@@ -180,8 +78,199 @@ xcam_bufferpool_acquire_buffer (GstBufferPool *bpool, GstBuffer **buffer, GstBuf
 void
 xcambufferpool_release_buffer (GstBufferPool *bpool, GstBuffer *gbuf)
 {
-    SmartPtr<V4l2Buffer> buf = bufmap_2vbuf(gbuf);
-    libxcam_enqueue_buffer (buf);
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    pthread_mutex_lock (&device_manager->release_mutex);
+    device_manager->release_bufs.pop();
+    pthread_mutex_unlock (&device_manager->release_mutex);
 }
 
+gboolean gst_xcamsrc_set_white_balance_mode (GstXCam3A *xcam3a, XCamAwbMode mode)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_awb_mode (mode);
+}
+
+gboolean gst_xcamsrc_set_awb_speed (GstXCam3A *xcam3a, double speed)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_awb_speed (speed);
+}
+
+gboolean gst_xcamsrc_set_wb_color_temperature_range (GstXCam3A *xcam3a, guint cct_min, guint cct_max)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_awb_color_temperature_range (cct_min, cct_max);
+}
+gboolean gst_xcamsrc_set_manual_wb_gain (GstXCam3A *xcam3a, double gr, double r, double b, double gb)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_awb_manual_gain (gr, r, b, gb);
+}
+gboolean gst_xcamsrc_set_exposure_mode (GstXCam3A *xcam3a, XCamAeMode mode)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_ae_mode (mode);
+}
+
+gboolean gst_xcamsrc_set_ae_metering_mode (GstXCam3A *xcam3a, XCamAeMeteringMode mode)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_ae_metering_mode (mode);
+}
+gboolean gst_xcamsrc_set_exposure_window (GstXCam3A *xcam3a, XCam3AWindow *window)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_ae_window (window);
+}
+gboolean gst_xcamsrc_set_exposure_value_offset (GstXCam3A *xcam3a, double ev_offset)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_ae_ev_shift (ev_offset);
+}
+gboolean gst_xcamsrc_set_ae_speed (GstXCam3A *xcam3a, double speed)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_ae_speed (speed);
+}
+gboolean gst_xcamsrc_set_exposure_flicker_mode (GstXCam3A *xcam3a, XCamFlickerMode flicker)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_ae_flicker_mode (flicker);
+}
+XCamFlickerMode gst_xcamsrc_get_exposure_flicker_mode (GstXCam3A *xcam3a)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->get_ae_flicker_mode ();
+}
+gint64 gst_xcamsrc_get_current_exposure_time (GstXCam3A *xcam3a)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->get_ae_current_exposure_time ();
+}
+double gst_xcamsrc_get_current_analog_gain (GstXCam3A *xcam3a)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->get_ae_current_analog_gain ();
+}
+gboolean gst_xcamsrc_set_manual_exposure_time (GstXCam3A *xcam3a, gint64 time_in_us)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_ae_manual_exposure_time (time_in_us);
+}
+gboolean gst_xcamsrc_set_manual_analog_gain (GstXCam3A *xcam3a, double gain)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_ae_manual_analog_gain (gain);
+}
+gboolean gst_xcamsrc_set_aperture (GstXCam3A *xcam3a, double fn)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_ae_aperture (fn);
+}
+gboolean gst_xcamsrc_set_max_analog_gain (GstXCam3A *xcam3a, double max_gain)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_ae_max_analog_gain (max_gain);
+}
+double gst_xcamsrc_get_max_analog_gain (GstXCam3A *xcam3a)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->get_ae_max_analog_gain ();
+}
+gboolean gst_xcamsrc_set_exposure_time_range (GstXCam3A *xcam3a, gint64 min_time_in_us, gint64 max_time_in_us)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_ae_exposure_time_range (min_time_in_us, max_time_in_us);
+}
+gboolean gst_xcamsrc_get_exposure_time_range (GstXCam3A *xcam3a, gint64 *min_time_in_us, gint64 *max_time_in_us)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->get_ae_exposure_time_range (min_time_in_us, max_time_in_us);
+}
+gboolean gst_xcamsrc_set_noise_reduction_level (GstXCam3A *xcam3a, guint8 level)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_noise_reduction_level (level);
+}
+gboolean gst_xcamsrc_set_temporal_noise_reduction_level (GstXCam3A *xcam3a, guint8 level)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_temporal_noise_reduction_level (level);
+}
+gboolean gst_xcamsrc_set_gamma_table (GstXCam3A *xcam3a, double *r_table, double *g_table, double *b_table)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_gamma_table (r_table, g_table, b_table);
+}
+gboolean gst_xcamsrc_set_gbce (GstXCam3A *xcam3a, gboolean enable)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_gbce (enable);
+}
+gboolean gst_xcamsrc_set_manual_brightness (GstXCam3A *xcam3a, guint8 value)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_manual_brightness (value);
+}
+gboolean gst_xcamsrc_set_manual_contrast (GstXCam3A *xcam3a, guint8 value)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_manual_contrast (value);
+}
+gboolean gst_xcamsrc_set_manual_hue (GstXCam3A *xcam3a, guint8 value)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_manual_hue (value);
+}
+gboolean gst_xcamsrc_set_manual_saturation (GstXCam3A *xcam3a, guint8 value)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_manual_saturation (value);
+}
+gboolean gst_xcamsrc_set_manual_sharpness (GstXCam3A *xcam3a, guint8 value)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_manual_sharpness (value);
+}
+gboolean gst_xcamsrc_set_dvs (GstXCam3A *xcam3a, gboolean enable)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_dvs (enable);
+}
+gboolean gst_xcamsrc_set_night_mode (GstXCam3A *xcam3a, gboolean enable)
+{
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<X3aAnalyzer> analyzer = device_manager->get_x3a_analyzer ();
+    return analyzer->set_night_mode (enable);
+}
 

--- a/wrapper/gstreamer/stub.h
+++ b/wrapper/gstreamer/stub.h
@@ -28,6 +28,7 @@
 #include <gst/gst.h>
 #include <gst/allocators/allocators.h>
 #include <gst/video/gstvideopool.h>
+#include "gstxcaminterface.h"
 #include "gstxcambufferpool.h"
 
 #ifdef __cplusplus
@@ -39,20 +40,40 @@ enum v4l2_field;
 struct v4l2_format;
 struct v4l2_buffer;
 
-int libxcam_set_device_name (const char* ch);
-int libxcam_set_sensor_id (int id);
-int libxcam_set_capture_mode (uint32_t cap_mode);
-int libxcam_set_mem_type (enum v4l2_memory mem_type);
-int libxcam_set_buffer_count (uint32_t buf_count);
-int libxcam_set_framerate (uint32_t fps_n, uint32_t fps_d);
-int libxcam_open ();
-int libxcam_close ();
-int libxcam_set_format (uint32_t width, uint32_t height, uint32_t pixelformat, enum v4l2_field field, uint32_t bytes_perline);
-int libxcam_get_blocksize (uint32_t *blocksize);
-int libxcam_start ();
-int libxcam_stop ();
 GstFlowReturn xcam_bufferpool_acquire_buffer (GstBufferPool *bpool, GstBuffer **buffer, GstBufferPoolAcquireParams *params);
 void xcambufferpool_release_buffer (GstBufferPool *bpool, GstBuffer *buffer);
+
+gboolean gst_xcamsrc_set_white_balance_mode (GstXCam3A *xcam3a, XCamAwbMode mode);
+gboolean gst_xcamsrc_set_awb_speed (GstXCam3A *xcam3a, double speed);
+gboolean gst_xcamsrc_set_wb_color_temperature_range (GstXCam3A *xcam3a, guint cct_min, guint cct_max);
+gboolean gst_xcamsrc_set_manual_wb_gain (GstXCam3A *xcam3a, double gr, double r, double b, double gb);
+gboolean gst_xcamsrc_set_exposure_mode (GstXCam3A *xcam3a, XCamAeMode mode);
+gboolean gst_xcamsrc_set_ae_metering_mode (GstXCam3A *xcam3a, XCamAeMeteringMode mode);
+gboolean gst_xcamsrc_set_exposure_window (GstXCam3A *xcam3a, XCam3AWindow *window);
+gboolean gst_xcamsrc_set_exposure_value_offset (GstXCam3A *xcam3a, double ev_offset);
+gboolean gst_xcamsrc_set_ae_speed (GstXCam3A *xcam3a, double speed);
+gboolean gst_xcamsrc_set_exposure_flicker_mode (GstXCam3A *xcam3a, XCamFlickerMode flicker);
+XCamFlickerMode gst_xcamsrc_get_exposure_flicker_mode (GstXCam3A *xcam3a);
+gint64 gst_xcamsrc_get_current_exposure_time (GstXCam3A *xcam3a);
+double gst_xcamsrc_get_current_analog_gain (GstXCam3A *xcam3a);
+gboolean gst_xcamsrc_set_manual_exposure_time (GstXCam3A *xcam3a, gint64 time_in_us);
+gboolean gst_xcamsrc_set_manual_analog_gain (GstXCam3A *xcam3a, double gain);
+gboolean gst_xcamsrc_set_aperture (GstXCam3A *xcam3a, double fn);
+gboolean gst_xcamsrc_set_max_analog_gain (GstXCam3A *xcam3a, double max_gain);
+double gst_xcamsrc_get_max_analog_gain (GstXCam3A *xcam3a);
+gboolean gst_xcamsrc_set_exposure_time_range (GstXCam3A *xcam3a, gint64 min_time_in_us, gint64 max_time_in_us);
+gboolean gst_xcamsrc_get_exposure_time_range (GstXCam3A *xcam3a, gint64 *min_time_in_us, gint64 *max_time_in_us);
+gboolean gst_xcamsrc_set_noise_reduction_level (GstXCam3A *xcam3a, guint8 level);
+gboolean gst_xcamsrc_set_temporal_noise_reduction_level (GstXCam3A *xcam3a, guint8 level);
+gboolean gst_xcamsrc_set_gamma_table (GstXCam3A *xcam3a, double *r_table, double *g_table, double *b_table);
+gboolean gst_xcamsrc_set_gbce (GstXCam3A *xcam3a, gboolean enable);
+gboolean gst_xcamsrc_set_manual_brightness (GstXCam3A *xcam3a, guint8 value);
+gboolean gst_xcamsrc_set_manual_contrast (GstXCam3A *xcam3a, guint8 value);
+gboolean gst_xcamsrc_set_manual_hue (GstXCam3A *xcam3a, guint8 value);
+gboolean gst_xcamsrc_set_manual_saturation (GstXCam3A *xcam3a, guint8 value);
+gboolean gst_xcamsrc_set_manual_sharpness (GstXCam3A *xcam3a, guint8 value);
+gboolean gst_xcamsrc_set_dvs (GstXCam3A *xcam3a, gboolean enable);
+gboolean gst_xcamsrc_set_night_mode (GstXCam3A *xcam3a, gboolean enable);
 
 #ifdef __cplusplus
 }

--- a/wrapper/gstreamer/v4l2dev.cpp
+++ b/wrapper/gstreamer/v4l2dev.cpp
@@ -19,22 +19,88 @@
  */
 
 #include "v4l2dev.h"
-#include "atomisp_device.h"
-
 namespace XCam {
 
-SmartPtr<V4l2Device> V4l2Dev::_device (NULL);
-Mutex V4l2Dev::_mutex;
-const char* V4l2Dev::_device_name (NULL);
+SmartPtr<MainDeviceManager> DeviceManagerInstance::_device_manager (NULL);
+Mutex               DeviceManagerInstance::_device_manager_mutex;
 
-SmartPtr<V4l2Device>
-V4l2Dev::instance ()
+SmartPtr<MainDeviceManager>&
+DeviceManagerInstance::device_manager_instance ()
 {
-    SmartLock lock(_mutex);
-    if (_device.ptr())
-        return _device;
-    _device = new AtomispDevice (_device_name);
-    return _device;
+    SmartLock lock (_device_manager_mutex);
+    if (_device_manager.ptr())
+        return _device_manager;
+
+    _device_manager = new MainDeviceManager;
+    return _device_manager;
+}
+
+
+const char*         MainDeviceManager::_capture_device_name (NULL);
+const char*         MainDeviceManager::_event_device_name (NULL);
+const char*         MainDeviceManager::_cpf_file_name (NULL);
+
+MainDeviceManager::MainDeviceManager()
+{
+    _device = new AtomispDevice (_capture_device_name);
+    _sub_device = new V4l2SubDevice (_event_device_name);
+    _isp_controller = new IspController (_device);
+
+#if HAVE_IA_AIQ
+    _x3a_analyzer = new X3aAnalyzerAiq (_isp_controller, _cpf_file_name);
+#else
+    _x3a_analyzer = new X3aAnalyzerSimple ();
+#endif
+
+    _image_processor = new IspImageProcessor (_isp_controller);
+
+    this->set_capture_device (_device);
+    this->set_event_device (_sub_device);
+    this->set_isp_controller (_isp_controller);
+    this->set_analyzer (_x3a_analyzer);
+    this->add_image_processor (_image_processor);
+}
+
+MainDeviceManager::~MainDeviceManager()
+{}
+
+void
+MainDeviceManager::set_capture_device_name (const char* name)
+{
+    _capture_device_name = name;
+}
+
+void
+MainDeviceManager::set_event_device_name (const char* name)
+{
+    _event_device_name = name;
+}
+
+void
+MainDeviceManager::set_cpf_file_name (const char* name)
+{
+    _cpf_file_name = name;
+}
+
+void
+MainDeviceManager::handle_message (SmartPtr<XCamMessage> &msg)
+{
+    XCAM_UNUSED (msg);
+}
+
+void
+MainDeviceManager::handle_buffer (SmartPtr<VideoBuffer> &buf)
+{
+    pthread_mutex_lock (&bufs_mutex);
+    bufs.push (buf);
+    if (bufs.size() == 1)
+        pthread_cond_signal (&bufs_cond);
+    pthread_mutex_unlock (&bufs_mutex);
+}
+
+SmartPtr<X3aAnalyzer> &
+MainDeviceManager::get_x3a_analyzer () {
+    return _x3a_analyzer;
 }
 
 };

--- a/wrapper/gstreamer/v4l2dev.h
+++ b/wrapper/gstreamer/v4l2dev.h
@@ -26,18 +26,78 @@
 #include "xcam_mutex.h"
 #include "v4l2_buffer_proxy.h"
 #include "v4l2_device.h"
+#include "device_manager.h"
+#include "v4l2dev.h"
+#include "atomisp_device.h"
+#include "device_manager.h"
+#include "isp_controller.h"
+#include "isp_image_processor.h"
+#if HAVE_IA_AIQ
+#include "x3a_analyzer_aiq.h"
+#endif
+#include "x3a_analyzer_simple.h"
+
+
+#include <queue>
+#include <unistd.h>
+#include <pthread.h>
 
 namespace XCam {
 
-class V4l2Dev {
+class DeviceManagerInstance;
+class MainDeviceManager;
+
+class DeviceManagerInstance {
 public:
-    static SmartPtr<V4l2Device> instance();
-    static const char*      _device_name;
+    static SmartPtr<MainDeviceManager>&  device_manager_instance();
 
 private:
-    V4l2Dev ();
-    static SmartPtr<V4l2Device> _device;
-    static Mutex        _mutex;
+    DeviceManagerInstance ();
+    static SmartPtr<MainDeviceManager>  _device_manager;
+    static Mutex            _device_manager_mutex;
+};
+
+class MainDeviceManager
+    : public DeviceManager
+{
+public:
+    MainDeviceManager ();
+    ~MainDeviceManager ();
+
+    SmartPtr<V4l2Device> get_device() {
+        return _device;
+    }
+    SmartPtr<V4l2SubDevice> get_sub_device() {
+        return _sub_device;
+    }
+
+    static void set_capture_device_name (const char*);
+    static void set_event_device_name (const char*);
+    static void set_cpf_file_name (const char*);
+
+    SmartPtr<X3aAnalyzer>& get_x3a_analyzer ();
+
+protected:
+    virtual void handle_message (SmartPtr<XCamMessage> &msg);
+    virtual void handle_buffer (SmartPtr<VideoBuffer> &buf);
+
+public:
+    std::queue< SmartPtr<VideoBuffer> > bufs;
+    pthread_mutex_t         bufs_mutex;
+    pthread_cond_t          bufs_cond;
+    std::queue< SmartPtr<VideoBuffer> > release_bufs;
+    pthread_mutex_t         release_mutex;
+
+private:
+    SmartPtr<V4l2Device>        _device;
+    SmartPtr<V4l2SubDevice>     _sub_device;
+    SmartPtr<IspController>     _isp_controller;
+    SmartPtr<X3aAnalyzer>       _x3a_analyzer;
+    SmartPtr<ImageProcessor>        _image_processor;
+
+    static const char*          _capture_device_name;
+    static const char*          _event_device_name;
+    static const char*          _cpf_file_name;
 };
 
 };


### PR DESCRIPTION
To enable 3A for gst plugin xcamsrc. now the xcamsrc also works with mediapipe.

The libxcam_set_* wrapper functions in stub.cpp are removed.
However I have to keep some gst_xcamsrc_set_* functions, because I'll have to assign them to the function pointer members of GstXCam3AInterface. Any suggestion to avoid this is very welcome :)

Thanks!


