### PR TITLE
atomisp_device: create DrmDisplay on first buffer allocation

### DIFF
--- a/xcore/atomisp_device.cpp
+++ b/xcore/atomisp_device.cpp
@@ -28,7 +28,7 @@ AtomispDevice::AtomispDevice (const char *name)
     : V4l2Device (name)
 {
 #if HAVE_LIBDRM
-    _drm_disp = DrmDisplay::instance ();
+    _drm_disp = NULL;
 #endif
 }
 
@@ -81,6 +81,10 @@ AtomispDevice::allocate_buffer (
     const uint32_t index)
 {
 #if HAVE_LIBDRM
+    if (!_drm_disp.ptr()) {
+        _drm_disp = DrmDisplay::instance ();
+    }
+
     if (get_mem_type () == V4L2_MEMORY_DMABUF && _drm_disp.ptr () != NULL) {
         buf = _drm_disp->create_drm_buf (format, index, get_capture_buf_type ());
         if (!buf.ptr()) {


### PR DESCRIPTION
vaapi sink would fail to set plane, if libxcam opens drm before
vaapi display. Move DrmDislay creation later until buffer
allocation can fix this issue.