### PR TITLE
video buffer: add new format V4L2_PIX_FMT_RGBA32(AB24)

### DIFF
--- a/xcore/cl_demosaic_handler.cpp
+++ b/xcore/cl_demosaic_handler.cpp
@@ -75,7 +75,8 @@ CLBayer2RGBImageHandler::set_output_format (uint32_t fourcc)
         WARNING,
         fourcc == XCAM_PIX_FMT_RGBA64 || fourcc == V4L2_PIX_FMT_RGB24 ||
         fourcc == V4L2_PIX_FMT_XBGR32 || fourcc == V4L2_PIX_FMT_ABGR32 || V4L2_PIX_FMT_BGR32 ||
-        fourcc == V4L2_PIX_FMT_RGB32 || fourcc == V4L2_PIX_FMT_ARGB32 || V4L2_PIX_FMT_XRGB32,
+        //fourcc == V4L2_PIX_FMT_RGB32 || fourcc == V4L2_PIX_FMT_ARGB32 || V4L2_PIX_FMT_XRGB32 ||
+        fourcc == V4L2_PIX_FMT_RGBA32,
         false,
         "CL image handler(%s) doesn't support format(%s) settings",
         get_name (), xcam_fourcc_to_string (fourcc));

--- a/xcore/cl_memory.cpp
+++ b/xcore/cl_memory.cpp
@@ -214,10 +214,16 @@ CLImage::video_info_2_cl_image_desc (
         image_desc.format.image_channel_order = CL_BGRA;
         image_desc.format.image_channel_data_type = CL_UNORM_INT8;
         break;
+        // cl doesn'tn support ARGB32 up to now, how about consider V4L2_PIX_FMT_RGBA32
     case V4L2_PIX_FMT_RGB32:
     case V4L2_PIX_FMT_ARGB32:
     case V4L2_PIX_FMT_XRGB32:
         image_desc.format.image_channel_order = CL_ARGB;
+        image_desc.format.image_channel_data_type = CL_UNORM_INT8;
+        break;
+
+    case V4L2_PIX_FMT_RGBA32:
+        image_desc.format.image_channel_order = CL_RGBA;
         image_desc.format.image_channel_data_type = CL_UNORM_INT8;
         break;
 

--- a/xcore/video_buffer.cpp
+++ b/xcore/video_buffer.cpp
@@ -91,11 +91,13 @@ VideoBufferInfo::init (
         this->offsets [0] = 0;
         image_size = this->strides [0] * aligned_height;
         break;
-        // memory order: BGRA
+        // memory order RGBA 8-8-8-8
+    case V4L2_PIX_FMT_RGBA32:
+        // memory order: BGRA 8-8-8-8
     case V4L2_PIX_FMT_XBGR32:
     case V4L2_PIX_FMT_ABGR32:
     case V4L2_PIX_FMT_BGR32:
-        // memory order: ARGB
+        // memory order: ARGB 8-8-8-8
     case V4L2_PIX_FMT_RGB32:
     case V4L2_PIX_FMT_ARGB32:
     case V4L2_PIX_FMT_XRGB32:

--- a/xcore/video_buffer.h
+++ b/xcore/video_buffer.h
@@ -41,6 +41,10 @@ namespace XCam {
 #define V4L2_PIX_FMT_ARGB32 v4l2_fourcc('B', 'A', '2', '4')
 #endif
 
+#ifndef V4L2_PIX_FMT_RGBA32
+#define V4L2_PIX_FMT_RGBA32 v4l2_fourcc('A', 'B', '2', '4')
+#endif
+
 /*
  * Define special format for 16 bit color
  * every format start with 'X'


### PR DESCRIPTION
 * new format memory order: 8-8-8-8 RGBA
 * RGBA is the most supported format in cl beignet