### PR TITLE
cl: support CLBuffer allocation

### DIFF
--- a/xcore/cl_context.cpp
+++ b/xcore/cl_context.cpp
@@ -350,6 +350,25 @@ CLContext::destroy_mem (cl_mem mem_id)
         clReleaseMemObject (mem_id);
 }
 
+cl_mem
+CLContext::create_buffer (uint32_t size, cl_mem_flags  flags, void *host_ptr)
+{
+    cl_mem mem_id = NULL;
+    cl_int errcode = CL_SUCCESS;
+
+    mem_id = clCreateBuffer (
+                 _context_id, flags,
+                 size, host_ptr,
+                 &errcode);
+
+    XCAM_FAIL_RETURN (
+        WARNING,
+        errcode == CL_SUCCESS,
+        NULL,
+        "create cl buffer failed");
+    return mem_id;
+}
+
 int32_t
 CLContext::export_mem_fd (cl_mem mem_id)
 {

--- a/xcore/cl_context.h
+++ b/xcore/cl_context.h
@@ -45,6 +45,7 @@ class CLContext {
     friend class CLDevice;
     friend class CLKernel;
     friend class CLMemory;
+    friend class CLBuffer;
     friend class CLVaImage;
     friend class CLImage2D;
 
@@ -98,6 +99,9 @@ private:
         cl_mem_flags flags, const cl_image_format& format,
         const cl_image_desc &image_info, void *host_ptr = NULL);
     void destroy_mem (cl_mem mem_id);
+
+    // Buffer
+    cl_mem create_buffer (uint32_t size, cl_mem_flags  flags, void *host_ptr);
 
     int32_t export_mem_fd (cl_mem mem_id);
 

--- a/xcore/cl_memory.cpp
+++ b/xcore/cl_memory.cpp
@@ -87,6 +87,33 @@ bool CLMemory::get_cl_mem_info (
     return true;
 }
 
+CLBuffer::CLBuffer (
+    SmartPtr<CLContext> &context, uint32_t size,
+    cl_mem_flags  flags, void *host_ptr)
+    : CLMemory (context)
+    , _flags (flags)
+    , _size (size)
+{
+    init_buffer (context, size, flags, host_ptr);
+}
+
+bool
+CLBuffer::init_buffer (
+    SmartPtr<CLContext> &context, uint32_t size,
+    cl_mem_flags  flags, void *host_ptr)
+{
+    cl_mem mem_id = NULL;
+
+    mem_id = context->create_buffer (size, flags, host_ptr);
+    if (mem_id == NULL) {
+        XCAM_LOG_WARNING ("CLBuffer create buffer failed");
+        return false;
+    }
+
+    set_mem_id (mem_id);
+    return true;
+}
+
 CLImage::CLImage (SmartPtr<CLContext> &context)
     : CLMemory (context)
 {

--- a/xcore/cl_memory.h
+++ b/xcore/cl_memory.h
@@ -73,6 +73,27 @@ private:
     int32_t               _mem_fd;
 };
 
+class CLBuffer
+    : public CLMemory
+{
+public:
+    explicit CLBuffer (
+        SmartPtr<CLContext> &context, uint32_t size,
+        cl_mem_flags  flags =  CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR,
+        void *host_ptr = NULL);
+
+private:
+    bool init_buffer (
+        SmartPtr<CLContext> &context, uint32_t size,
+        cl_mem_flags  flags, void *host_ptr);
+
+    XCAM_DEAD_COPY (CLBuffer);
+
+private:
+    cl_mem_flags    _flags;
+    uint32_t        _size;
+};
+
 class CLImage
     : public CLMemory
 {


### PR DESCRIPTION
 * cl buffer can be created in CLBuffer constructor, e.g
     SmartPtr<CLBuffer> buffer = new CLBuffer (context, 1024);
     XCAM_ASSERT (buffer->is_valid ());