### PR TITLE
test: fix video buffer init and correct format

### DIFF
--- a/tests/test-cl-image.cpp
+++ b/tests/test-cl-image.cpp
@@ -155,7 +155,7 @@ int main (int argc, char *argv[])
             else if (!strcasecmp (optarg, "ba10"))
                 format = V4L2_PIX_FMT_SGRBG10;
             else if (! strcasecmp (optarg, "rgba"))
-                format = V4L2_PIX_FMT_RGB32;
+                format = V4L2_PIX_FMT_RGBA32;
 
             else
                 print_help (bin_name);
@@ -270,7 +270,7 @@ int main (int argc, char *argv[])
         return -1;
     }
 
-    input_buf_info.init (format, 1920, 1080, 8, 4);
+    input_buf_info.init (format, 1920, 1080);
     display = DrmDisplay::instance ();
     buf_pool = new DrmBoBufferPool (display);
     buf_pool->set_video_info (input_buf_info);

--- a/xcore/cl_demo_handler.cpp
+++ b/xcore/cl_demo_handler.cpp
@@ -43,7 +43,7 @@ CLDemoImageKernel::prepare_arguments (
         image_info.format.image_channel_data_type = CL_UNORM_INT8;
     else if (channel_bits == 16)
         image_info.format.image_channel_data_type = CL_UNORM_INT16;
-    image_info.width = video_info.width;
+    image_info.width = video_info.strides[0] / CLImage::calculate_pixel_bytes (image_info.format);
     image_info.height = (video_info.size / video_info.strides[0]) / 4 * 4;
     image_info.row_pitch = video_info.strides[0];
 


### PR DESCRIPTION
 * test-cl-image, buffer init doesn't need alignment and
   rgba should be format 'V4L2_PIX_FMT_RGBA32'
 * cl_demo: image_info.width should be aligned with stride
   and image channel bytes (to support rgba format copy)