### PR TITLE
adjust hdr_rgb kernel, to fit for V4L2_PIX_FMT_RGBA32 and CL_RGBA when

### DIFF
--- a/cl_kernel/kernel_hdr_rgb.cl
+++ b/cl_kernel/kernel_hdr_rgb.cl
@@ -15,9 +15,9 @@
 "    float4 pixel_in,pixel_out;									"
 "    pixel_in = read_imagef(input, sampler, pos);                             		   "
 "    pixel_out.x = convert_float(HDRTable[convert_int(pixel_in.x*1024)]/1024.0);		"
-"    pixel_out.y = 0.0;											"
-"    pixel_out.z = 0.0;											"
-"    pixel_out.w = 1.0;											"
+"    pixel_out.y = convert_float(HDRTable[convert_int(pixel_in.y*1024)]/1024.0);											"
+"    pixel_out.z = convert_float(HDRTable[convert_int(pixel_in.z*1024)]/1024.0);											"
+"    pixel_out.w = 0.0;											"
 "    write_imagef(output, pos, pixel_out);                                                        "
 "}                                                                                             "
 


### PR DESCRIPTION
 use 'rgba' as the input format.

* fix current kernel only support CL_R as image channel order, for CL_RGBA
G and B channel will always set to 0.