### PR TITLE
correct test script for gstreamer plugin xcamsrc

### DIFF
--- a/tests/test-xcamsrc-camera.sh
+++ b/tests/test-xcamsrc-camera.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-gst-launch-1.0 xcamsrc sensor=0 capturemode=0x4000 memtype=4 buffercount=8 fpsn=25 fpsd=1 width=1920 height=1080 pixelformat=0 field=0 bytesperline=3840 ! video/x-raw, format=NV12, width=1920, height=1080, framerate=30/1 ! queue ! vaapiencode_h264 ! fakesink
+gst-launch-1.0 xcamsrc sensor-id=3 capture-mode=1 io-mode=4 ! video/x-raw, format=NV12, width=1920, height=1080, framerate=30/1 ! queue ! vaapiencode_h264 ! fakesink


### PR DESCRIPTION
In previous versions the gstreamer plugin xcamsrc is already aligned with v4l2src regarding the parameters, and compatible with mediapipe. By this patch the test script is corrected with the new parameter names.
