### PR TITLE
enable set_color_effect in libxcam

### DIFF
--- a/xcore/aiq_handler.cpp
+++ b/xcore/aiq_handler.cpp
@@ -1003,6 +1003,43 @@ AiqCompositor::set_3a_stats (SmartPtr<X3aIspStatistics> &stats)
     return true;
 }
 
+XCamReturn AiqCompositor::convert_color_effect (IspInputParameters &isp_input)
+{
+    AiqCommonHandler *aiq_common = _common_handler.ptr();
+
+    switch (aiq_common->get_color_effect()) {
+    case XCAM_COLOR_EFFECT_NONE:
+        isp_input.effects = ia_isp_effect_none;
+        break;
+    case XCAM_COLOR_EFFECT_SKY_BLUE:
+        isp_input.effects = ia_isp_effect_sky_blue;
+        break;
+    case XCAM_COLOR_EFFECT_SKIN_WHITEN_LOW:
+        isp_input.effects = ia_isp_effect_skin_whiten_low;
+        break;
+    case XCAM_COLOR_EFFECT_SKIN_WHITEN:
+        isp_input.effects = ia_isp_effect_skin_whiten;
+        break;
+    case XCAM_COLOR_EFFECT_SKIN_WHITEN_HIGH:
+        isp_input.effects = ia_isp_effect_skin_whiten_high;
+        break;
+    case XCAM_COLOR_EFFECT_SEPIA:
+        isp_input.effects = ia_isp_effect_sepia;
+        break;
+    case XCAM_COLOR_EFFECT_NEGATIVE:
+        isp_input.effects = ia_isp_effect_negative;
+        break;
+    case XCAM_COLOR_EFFECT_GRAYSCALE:
+        isp_input.effects = ia_isp_effect_grayscale;
+        break;
+    default:
+        isp_input.effects = ia_isp_effect_none;
+        break;
+    }
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
 XCamReturn AiqCompositor::integrate (X3aResultList &results)
 {
     IspInputParameters isp_params;
@@ -1051,6 +1088,8 @@ XCamReturn AiqCompositor::integrate (X3aResultList &results)
     isp_params.manual_hue = (int8_t)(aiq_common->get_hue_unlock() * 128.0);
     isp_params.manual_sharpness = (int8_t)(aiq_common->get_sharpness_unlock() * 128.0);
     isp_params.manual_nr_level = (int8_t)(aiq_common->get_nr_level_unlock() * 128.0);
+
+    convert_color_effect(isp_params);
 
     xcam_mem_clear (&output);
     if (!_adaptor->run (&isp_params, &output)) {

--- a/xcore/aiq_handler.h
+++ b/xcore/aiq_handler.h
@@ -210,6 +210,9 @@ public:
     ia_aiq_gbce_results *get_gbce_result () {
         return _gbce_result;
     }
+    XCamColorEffect get_color_effect() {
+        return _params.color_effect;
+    }
 
 private:
     XCAM_DEAD_COPY (AiqCommonHandler);
@@ -253,6 +256,7 @@ public:
 
     SmartPtr<X3aResult> generate_3a_configs (struct atomisp_parameters *parameters);
     void convert_window_to_ia (const XCam3AWindow &window, ia_rectangle &ia_window);
+    XCamReturn convert_color_effect (IspInputParameters &isp_input);
 
 private:
 

--- a/xcore/base/xcam_3a_types.h
+++ b/xcore/base/xcam_3a_types.h
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * Author: Wind Yuan <feng.yuan@intel.com>
  */
 
@@ -111,16 +111,16 @@ typedef enum {
 } XCamAfMode;
 #endif
 
-/*! \brief XCam3AWindow.  
- * Represents a rectangle area. Could be converted to 
+/*! \brief XCam3AWindow.
+ * Represents a rectangle area. Could be converted to
  * AIQ ia_rectangle, see convert_xcam_to_ia_window().
  */
 typedef struct _XCam3AWindow {
-	int32_t x_start; /*!< X of start point (left-upper corner) */
-	int32_t y_start; /*!< Y of start point (left-upper corner) */
-	int32_t x_end;   /*!< X of end point (right-bottom corner) */
-	int32_t y_end;   /*!< Y of start point (left-upper corner) */
-	int weight;
+    int32_t x_start; /*!< X of start point (left-upper corner) */
+    int32_t y_start; /*!< Y of start point (left-upper corner) */
+    int32_t x_end;   /*!< X of end point (right-bottom corner) */
+    int32_t y_end;   /*!< Y of start point (left-upper corner) */
+    int weight;
 } XCam3AWindow;
 
 typedef struct _XCamExposureResult {
@@ -130,6 +130,17 @@ typedef struct _XCamExposureResult {
     double aperture_fn;
     int32_t iso;
 } XCamExposureResult;
+
+typedef enum {
+    XCAM_COLOR_EFFECT_NONE,
+    XCAM_COLOR_EFFECT_SKY_BLUE,
+    XCAM_COLOR_EFFECT_SKIN_WHITEN_LOW,
+    XCAM_COLOR_EFFECT_SKIN_WHITEN,
+    XCAM_COLOR_EFFECT_SKIN_WHITEN_HIGH,
+    XCAM_COLOR_EFFECT_SEPIA,
+    XCAM_COLOR_EFFECT_NEGATIVE,
+    XCAM_COLOR_EFFECT_GRAYSCALE,
+} XCamColorEffect;
 
 XCAM_END_DECLARE
 

--- a/xcore/base/xcam_params.h
+++ b/xcore/base/xcam_params.h
@@ -91,6 +91,7 @@ typedef struct _XCamCommonParam {
     bool                       enable_dvs;
     bool                       enable_gbce;
     bool                       enable_night_mode;
+    XCamColorEffect            color_effect;
 } XCamCommonParam;
 
 XCAM_END_DECLARE

--- a/xcore/handler_interface.cpp
+++ b/xcore/handler_interface.cpp
@@ -484,4 +484,16 @@ CommonHandler::set_gamma_table (double *r_table, double *g_table, double *b_tabl
     return true;
 }
 
+bool
+CommonHandler::set_color_effect (XCamColorEffect effect)
+{
+    // TODO validate the input
+
+    AnalyzerHandler::HanlderLock lock(this);
+
+    _params.color_effect = effect;
+
+    XCAM_LOG_DEBUG ("common 3A set color effect");
+}
+
 };

--- a/xcore/handler_interface.h
+++ b/xcore/handler_interface.h
@@ -211,6 +211,7 @@ public:
     bool set_manual_saturation (double level);
     bool set_manual_sharpness (double level);
     bool set_gamma_table (double *r_table, double *g_table, double *b_table);
+    bool set_color_effect(XCamColorEffect effect);
 
 protected:
     const XCamCommonParam &get_params_unlock () const {

--- a/xcore/x3a_analyzer.cpp
+++ b/xcore/x3a_analyzer.cpp
@@ -490,6 +490,14 @@ X3aAnalyzer::set_night_mode (bool enable)
     return _common_handler->set_night_mode (enable);
 }
 
+bool
+X3aAnalyzer::set_color_effect (XCamColorEffect type)
+{
+
+    XCAM_ASSERT (_common_handler.ptr());
+    return _common_handler->set_color_effect (type);
+}
+
 /* Picture quality */
 bool
 X3aAnalyzer::set_noise_reduction_level (double level)

--- a/xcore/x3a_analyzer.h
+++ b/xcore/x3a_analyzer.h
@@ -98,6 +98,7 @@ public:
     bool set_manual_saturation (double level);
     bool set_manual_sharpness (double level);
     bool set_gamma_table (double *r_table, double *g_table, double *b_table);
+    bool set_color_effect(XCamColorEffect effect);
 
     uint32_t get_width () const {
         return _width;


### PR DESCRIPTION
Hi Wind,

This is to enable set_color_effect(), which is missing from the current libxcam.

Please do NOT merge this patch. 
I create this PR just to let you take a look, and see if I'm working on the right direction. 

Thank you!
