### PR TITLE
AEC Multi-window metering mode implementation

### DIFF
--- a/wrapper/gstreamer/interface/gstxcaminterface.h
+++ b/wrapper/gstreamer/interface/gstxcaminterface.h
@@ -141,6 +141,7 @@ struct _GstXCam3AInterface {
      * \param[in]        mode    XCAM_AE_METERING_MODE_AUTO, default
      *                           XCAM_AE_METERING_MODE_SPOT, need set spot window by set_exposure_window
      *                           XCAM_AE_METERING_MODE_CENTER,  more weight in center
+     *                           XCAM_AE_METERING_MODE_WEIGHTED_WINDOW,  weighted multi metering window
      */
     gboolean (* set_ae_metering_mode)           (GstXCam3A *xcam, XCamAeMeteringMode mode);
 
@@ -149,6 +150,7 @@ struct _GstXCam3AInterface {
      *
      * \param[in,out]    xcam      XCam handle
      * \param[in]        window    the area to set exposure with. x_end > x_start AND y_end > y_start; only ONE window can be set
+     * \param[in]        count     the number of metering window
      *
      * Usage
      * - Enable:
@@ -156,7 +158,7 @@ struct _GstXCam3AInterface {
      * - Disable:
      *     set_ae_metering_mode(@xcam, @mode); #mode != %XCAM_AE_METERING_MODE_SPOT
      */
-    gboolean (* set_exposure_window)            (GstXCam3A *xcam, XCam3AWindow *window);
+    gboolean (* set_exposure_window)            (GstXCam3A *xcam, XCam3AWindow *window, guint8 count);
 
     /*! \brief set exposure value offset.
      * see xcam_3a_set_ae_value_shift().

--- a/wrapper/gstreamer/stub.cpp
+++ b/wrapper/gstreamer/stub.cpp
@@ -125,11 +125,11 @@ gboolean gst_xcamsrc_set_ae_metering_mode (GstXCam3A *xcam3a, XCamAeMeteringMode
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_ae_metering_mode (mode);
 }
-gboolean gst_xcamsrc_set_exposure_window (GstXCam3A *xcam3a, XCam3AWindow *window)
+gboolean gst_xcamsrc_set_exposure_window (GstXCam3A *xcam3a, XCam3AWindow *window, guint8 count)
 {
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
-    return analyzer->set_ae_window (window);
+    return analyzer->set_ae_window (window, count);
 }
 gboolean gst_xcamsrc_set_exposure_value_offset (GstXCam3A *xcam3a, double ev_offset)
 {

--- a/wrapper/gstreamer/stub.h
+++ b/wrapper/gstreamer/stub.h
@@ -51,7 +51,7 @@ gboolean gst_xcamsrc_set_wb_color_temperature_range (GstXCam3A *xcam3a, guint cc
 gboolean gst_xcamsrc_set_manual_wb_gain (GstXCam3A *xcam3a, double gr, double r, double b, double gb);
 gboolean gst_xcamsrc_set_exposure_mode (GstXCam3A *xcam3a, XCamAeMode mode);
 gboolean gst_xcamsrc_set_ae_metering_mode (GstXCam3A *xcam3a, XCamAeMeteringMode mode);
-gboolean gst_xcamsrc_set_exposure_window (GstXCam3A *xcam3a, XCam3AWindow *window);
+gboolean gst_xcamsrc_set_exposure_window (GstXCam3A *xcam3a, XCam3AWindow *window, guint8 count = 1);
 gboolean gst_xcamsrc_set_exposure_value_offset (GstXCam3A *xcam3a, double ev_offset);
 gboolean gst_xcamsrc_set_ae_speed (GstXCam3A *xcam3a, double speed);
 gboolean gst_xcamsrc_set_exposure_flicker_mode (GstXCam3A *xcam3a, XCamFlickerMode flicker);

--- a/xcore/aiq_handler.cpp
+++ b/xcore/aiq_handler.cpp
@@ -30,6 +30,9 @@
 #define MAX_STATISTICS_WIDTH 150
 #define MAX_STATISTICS_HEIGHT 150
 
+//#define USE_RGBS_GRID_WEIGHTING
+#define USE_HIST_GRID_WEIGHTING
+
 namespace XCam {
 
 struct IspInputParameters {
@@ -407,6 +410,21 @@ bool AiqAeHandler::ensure_ae_metering_mode ()
     case XCAM_AE_METERING_MODE_CENTER:
         _input.metering_mode = ia_aiq_ae_metering_mode_center;
         break;
+    case XCAM_AE_METERING_MODE_WEIGHTED_WINDOW:
+    {
+        _input.metering_mode = ia_aiq_ae_metering_mode_evaluative;
+        const XCam3AWindow & weighted_window = this->get_window_unlock();
+
+        XCAM_LOG_DEBUG ("ensure_ae_metering_mode weighted_window x_start = %d, y_start = %d, x_end = %d, y_end = %d ",
+                         weighted_window.x_start, weighted_window.y_start, weighted_window.x_end, weighted_window.y_end);
+
+        if (weighted_window.x_end > weighted_window.x_start &&
+                weighted_window.y_end > weighted_window.y_start) {
+            _aiq_compositor->convert_window_to_ia(weighted_window, _ia_ae_window);
+            _input.exposure_window = &_ia_ae_window;
+        }
+    }
+    break;
     default:
         XCAM_LOG_ERROR("unsupported ae mode:%d", mode);
         return false;
@@ -642,6 +660,213 @@ AiqAeHandler::get_max_analog_gain ()
         AnalyzerHandler::HanlderLock lock(this);
     }
     return AeHandler::get_max_analog_gain ();
+}
+
+XCamReturn
+AiqAeHandler::set_RGBS_weight_grid (ia_aiq_rgbs_grid **out_rgbs_grid)
+{
+    AnalyzerHandler::HanlderLock lock(this);
+
+    rgbs_grid_block *rgbs_grid_ptr = (*out_rgbs_grid)->blocks_ptr;
+    uint32_t rgbs_grid_index = 0;
+    uint16_t rgbs_grid_width = (*out_rgbs_grid)->grid_width;
+    uint16_t rgbs_grid_height = (*out_rgbs_grid)->grid_height;
+    XCAM_LOG_DEBUG ("rgbs_grid_width = %d, rgbs_grid_height = %d", rgbs_grid_width, rgbs_grid_height);
+
+    uint64_t weight_sum = 0;
+
+    uint32_t image_width = 0;
+    uint32_t image_height = 0;
+    _aiq_compositor->get_size (image_width, image_height);
+    XCAM_LOG_DEBUG ("image_width = %d, image_height = %d", image_width, image_height);
+
+    uint32_t hor_pixels_per_grid = (image_width + (rgbs_grid_width >> 1)) / rgbs_grid_width;
+    uint32_t vert_pixels_per_gird = (image_height + (rgbs_grid_height >> 1)) / rgbs_grid_height;
+    XCAM_LOG_DEBUG ("rgbs grid: %d x %d pixels per grid cell", hor_pixels_per_grid, vert_pixels_per_gird);
+
+    XCam3AWindow weighted_window = this->get_window_unlock ();
+    uint32_t weighted_grid_width = ((weighted_window.x_end - weighted_window.x_start + 1) + (hor_pixels_per_grid >> 1)) / hor_pixels_per_grid;
+    uint32_t weighted_grid_height = ((weighted_window.y_end - weighted_window.y_start + 1) + (vert_pixels_per_gird >> 1)) / vert_pixels_per_gird;
+    XCAM_LOG_DEBUG ("weighted_grid_width = %d, weighted_grid_height = %d", weighted_grid_width, weighted_grid_height);
+
+    uint32_t *weighted_avg_gr = (uint32_t*)xcam_malloc0 (5 * weighted_grid_width * weighted_grid_height * sizeof(uint32_t));
+    if (NULL == weighted_avg_gr) {
+        return XCAM_RETURN_ERROR_MEM;
+    }
+    uint32_t *weighted_avg_r = weighted_avg_gr + (weighted_grid_width * weighted_grid_height);
+    uint32_t *weighted_avg_b = weighted_avg_r + (weighted_grid_width * weighted_grid_height);
+    uint32_t *weighted_avg_gb = weighted_avg_b + (weighted_grid_width * weighted_grid_height);
+    uint32_t *weighted_sat = weighted_avg_gb + (weighted_grid_width * weighted_grid_height);
+
+    for (uint32_t win_index = 0; win_index < XCAM_AE_MAX_METERING_WINDOW_COUNT; win_index++) {
+        XCAM_LOG_DEBUG ("window start point(%d, %d), end point(%d, %d), weight = %d",
+            _params.window_list[win_index].x_start, _params.window_list[win_index].y_start, _params.window_list[win_index].x_end, _params.window_list[win_index].y_end, _params.window_list[win_index].weight);
+
+        if ((_params.window_list[win_index].weight <= 0) ||
+            (_params.window_list[win_index].x_start < 0) ||
+            (_params.window_list[win_index].x_end > image_width) ||
+            (_params.window_list[win_index].y_start < 0) ||
+            (_params.window_list[win_index].y_end > image_height) ||
+            (_params.window_list[win_index].x_start >= _params.window_list[win_index].x_end) ||
+            (_params.window_list[win_index].y_start >= _params.window_list[win_index].y_end) ||
+            (_params.window_list[win_index].x_end - _params.window_list[win_index].x_start > image_width) ||
+            (_params.window_list[win_index].y_end - _params.window_list[win_index].y_start > image_height)) {
+                XCAM_LOG_DEBUG ("skip window index = %d ", win_index);
+                continue;
+        }
+
+        rgbs_grid_index = (_params.window_list[win_index].x_start + (hor_pixels_per_grid >> 1)) / hor_pixels_per_grid + ((_params.window_list[win_index].y_start + (vert_pixels_per_gird >> 1)) / vert_pixels_per_gird) * rgbs_grid_width;
+
+        weight_sum += _params.window_list[win_index].weight;
+        
+        XCAM_LOG_DEBUG ("cumulate rgbs grid statistic, window index = %d ", win_index);
+        for (uint32_t i = 0; i < weighted_grid_height; i++) {
+            for (uint32_t j = 0; j < weighted_grid_width; j++) {
+                weighted_avg_gr[j + i * weighted_grid_width] += rgbs_grid_ptr[rgbs_grid_index + j + i * rgbs_grid_width].avg_gr * _params.window_list[win_index].weight;
+                weighted_avg_r[j + i * weighted_grid_width] += rgbs_grid_ptr[rgbs_grid_index + j + i * rgbs_grid_width].avg_r * _params.window_list[win_index].weight;
+                weighted_avg_b[j + i * weighted_grid_width] += rgbs_grid_ptr[rgbs_grid_index + j + i * rgbs_grid_width].avg_b * _params.window_list[win_index].weight;
+                weighted_avg_gb[j + i * weighted_grid_width] += rgbs_grid_ptr[rgbs_grid_index + j + i * rgbs_grid_width].avg_gb * _params.window_list[win_index].weight;
+                weighted_sat[j + i * weighted_grid_width] += rgbs_grid_ptr[rgbs_grid_index + j + i * rgbs_grid_width].sat * _params.window_list[win_index].weight;
+            }
+        }
+    }
+    XCAM_LOG_DEBUG ("sum of weighing factor = %d ", weight_sum);
+
+    rgbs_grid_index = (weighted_window.x_start + (hor_pixels_per_grid >> 1)) / hor_pixels_per_grid + (weighted_window.y_start + (vert_pixels_per_gird >> 1)) / vert_pixels_per_gird * rgbs_grid_width;
+    for (uint32_t i = 0; i < weighted_grid_height; i++) {
+        for (uint32_t j = 0; j < weighted_grid_width; j++) {
+            rgbs_grid_ptr[rgbs_grid_index + j + i * rgbs_grid_width].avg_gr = weighted_avg_gr[j + i * weighted_grid_width] / weight_sum;
+            rgbs_grid_ptr[rgbs_grid_index + j + i * rgbs_grid_width].avg_r = weighted_avg_r[j + i * weighted_grid_width] / weight_sum;
+            rgbs_grid_ptr[rgbs_grid_index + j + i * rgbs_grid_width].avg_b = weighted_avg_b[j + i * weighted_grid_width] / weight_sum;
+            rgbs_grid_ptr[rgbs_grid_index + j + i * rgbs_grid_width].avg_gb = weighted_avg_gb[j + i * weighted_grid_width] / weight_sum;
+            rgbs_grid_ptr[rgbs_grid_index + j + i * rgbs_grid_width].sat = weighted_sat[j + i * weighted_grid_width] / weight_sum;
+        }
+    }
+
+    xcam_free (weighted_avg_gr);
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+
+XCamReturn
+AiqAeHandler::set_hist_weight_grid (ia_aiq_hist_weight_grid **out_weight_grid)
+{
+    AnalyzerHandler::HanlderLock lock(this);
+
+    uint16_t hist_grid_width = (*out_weight_grid)->width;
+    uint16_t hist_grid_height = (*out_weight_grid)->height;
+    uint32_t hist_grid_index = 0;
+
+    unsigned char* weights_map_ptr = (*out_weight_grid)->weights;
+
+    uint32_t image_width = 0;
+    uint32_t image_height = 0;
+    _aiq_compositor->get_size (image_width, image_height);
+
+    uint32_t hor_pixels_per_grid = (image_width + (hist_grid_width >> 1)) / hist_grid_width;
+    uint32_t vert_pixels_per_gird = (image_height + (hist_grid_height >> 1)) / hist_grid_height;
+    XCAM_LOG_DEBUG ("hist weight grid: %d x %d pixels per grid cell", hor_pixels_per_grid, vert_pixels_per_gird);
+
+    memset (weights_map_ptr, 0, hist_grid_width * hist_grid_height);
+
+    for (uint32_t win_index = 0; win_index < XCAM_AE_MAX_METERING_WINDOW_COUNT; win_index++) {
+        XCAM_LOG_DEBUG ("window start point(%d, %d), end point(%d, %d), weight = %d",
+            _params.window_list[win_index].x_start, _params.window_list[win_index].y_start, _params.window_list[win_index].x_end, _params.window_list[win_index].y_end, _params.window_list[win_index].weight);
+
+        if ((_params.window_list[win_index].weight <= 0) ||
+            (_params.window_list[win_index].weight > 15) ||
+            (_params.window_list[win_index].x_start < 0) ||
+            (_params.window_list[win_index].x_end > image_width) ||
+            (_params.window_list[win_index].y_start < 0) ||
+            (_params.window_list[win_index].y_end > image_height) ||
+            (_params.window_list[win_index].x_start >= _params.window_list[win_index].x_end) ||
+            (_params.window_list[win_index].y_start >= _params.window_list[win_index].y_end) ||
+            (_params.window_list[win_index].x_end - _params.window_list[win_index].x_start > image_width) ||
+            (_params.window_list[win_index].y_end - _params.window_list[win_index].y_start > image_height)) {
+                XCAM_LOG_DEBUG ("skip window index = %d ", win_index);
+                continue;
+        }
+
+        uint32_t weighted_grid_width = ((_params.window_list[win_index].x_end - _params.window_list[win_index].x_start + 1) + (hor_pixels_per_grid >> 1)) / hor_pixels_per_grid;
+        uint32_t weighted_grid_height = ((_params.window_list[win_index].y_end - _params.window_list[win_index].y_start + 1) + (vert_pixels_per_gird >> 1)) / vert_pixels_per_gird;
+
+        hist_grid_index = (_params.window_list[win_index].x_start + (hor_pixels_per_grid >> 1)) / hor_pixels_per_grid + ((_params.window_list[win_index].y_start + (vert_pixels_per_gird >> 1)) / vert_pixels_per_gird) * hist_grid_width;
+
+        for (uint32_t i = 0; i < weighted_grid_height; i++) {
+            for (uint32_t j = 0; j < weighted_grid_width; j++) {
+                weights_map_ptr[hist_grid_index + j + i * hist_grid_width] = _params.window_list[win_index].weight;
+            }
+        }
+    }
+    return XCAM_RETURN_NO_ERROR;
+}
+
+XCamReturn 
+AiqAeHandler::dump_hist_weight_grid (const ia_aiq_hist_weight_grid *weight_grid)
+{
+    XCAM_LOG_DEBUG ("E dump_hist_weight_grid");
+    if (NULL == weight_grid) {
+        return XCAM_RETURN_ERROR_PARAM;
+    }
+
+    uint16_t grid_width = weight_grid->width;
+    uint16_t grid_height = weight_grid->height;
+
+    for (uint32_t i = 0; i < grid_height; i++) {
+        for (uint32_t j = 0; j < grid_width; j++) {
+            printf ("%d  ", weight_grid->weights[j + i * grid_width]);
+        }
+        printf("\n");
+    }
+
+    XCAM_LOG_DEBUG ("X dump_hist_weight_grid");
+    return XCAM_RETURN_NO_ERROR;
+}
+
+XCamReturn 
+AiqAeHandler::dump_RGBS_grid (const ia_aiq_rgbs_grid *rgbs_grid)
+{
+    XCAM_LOG_DEBUG ("E dump_RGBS_grid");
+    if (NULL == rgbs_grid) {
+        return XCAM_RETURN_ERROR_PARAM;
+    }
+
+    uint16_t grid_width = rgbs_grid->grid_width;
+    uint16_t grid_height = rgbs_grid->grid_height;
+
+    printf("AVG B\n");
+    for (uint32_t i = 0; i < grid_height; i++) {
+        for (uint32_t j = 0; j < grid_width; j++) {
+            printf ("%d  ", rgbs_grid->blocks_ptr[j + i * grid_width].avg_b);
+        }
+        printf("\n");
+    }
+    printf("AVG Gb\n");
+    for (uint32_t i = 0; i < grid_height; i++) {
+        for (uint32_t j = 0; j < grid_width; j++) {
+            printf ("%d  ", rgbs_grid->blocks_ptr[j + i * grid_width].avg_gb);
+        }
+        printf("\n");
+    }
+    printf("AVG Gr\n");
+    for (uint32_t i = 0; i < grid_height; i++) {
+        for (uint32_t j = 0; j < grid_width; j++) {
+            printf ("%d  ", rgbs_grid->blocks_ptr[j + i * grid_width].avg_gr);
+        }
+        printf("\n");
+    }
+    printf("AVG R\n");
+    for (uint32_t i = 0; i < grid_height; i++) {
+        for (uint32_t j = 0; j < grid_width; j++) {
+            printf ("%d  ", rgbs_grid->blocks_ptr[j + i * grid_width].avg_r); 
+            //printf ("%d  ", rgbs_grid->blocks_ptr[j + i * grid_width].sat);
+        }
+        printf("\n");
+    }
+
+    XCAM_LOG_DEBUG ("X dump_RGBS_grid");
+    return XCAM_RETURN_NO_ERROR;
 }
 
 AiqAwbHandler::AiqAwbHandler (SmartPtr<AiqCompositor> &aiq_compositor)
@@ -978,8 +1203,20 @@ AiqCompositor::set_3a_stats (SmartPtr<X3aIspStatistics> &stats)
 
     if (_pa_result)
         aiq_stats_input.frame_pa_parameters = _pa_result;
-    if (_ae_handler->is_started())
+
+    if (_ae_handler->is_started()) {
+#ifdef USE_HIST_GRID_WEIGHTING
+        if (XCAM_AE_METERING_MODE_WEIGHTED_WINDOW == _ae_handler->get_metering_mode ()) {
+            ia_aiq_ae_results* ae_result = _ae_handler->get_result ();
+
+            if (XCAM_RETURN_NO_ERROR != _ae_handler->set_hist_weight_grid (&(ae_result->weight_grid))) {
+                XCAM_LOG_ERROR ("ae handler set hist weight grid failed");
+            }
+        }
+#endif
         aiq_stats_input.frame_ae_parameters = _ae_handler->get_result ();
+        //_ae_handler->dump_hist_weight_grid (aiq_stats_input.frame_ae_parameters->weight_grid);
+    }
     //if (_awb_handler->is_started())
     //    aiq_stats_input.frame_awb_parameters = _awb_handler->get_result();
 
@@ -988,6 +1225,14 @@ AiqCompositor::set_3a_stats (SmartPtr<X3aIspStatistics> &stats)
         return false;
     }
 
+    if (XCAM_AE_METERING_MODE_WEIGHTED_WINDOW == _ae_handler->get_metering_mode ()) {
+#ifdef USE_RGBS_GRID_WEIGHTING
+        if (XCAM_RETURN_NO_ERROR != _ae_handler->set_RGBS_weight_grid(&rgbs_grids)) {
+            XCAM_LOG_ERROR ("ae handler update RGBS weighted statistic failed");
+        }
+        //_ae_handler->dump_RGBS_grid (*(aiq_stats_input.rgbs_grids));
+#endif
+    }
     XCAM_LOG_DEBUG ("statistics grid info, width:%u, height:%u, blk_r:%u, blk_b:%u, blk_gr:%u, blk_gb:%u",
                     aiq_stats_input.rgbs_grids[0]->grid_width,
                     aiq_stats_input.rgbs_grids[0]->grid_height,

--- a/xcore/aiq_handler.h
+++ b/xcore/aiq_handler.h
@@ -108,6 +108,11 @@ public:
     virtual double get_current_analog_gain ();
     virtual double get_max_analog_gain ();
 
+    XCamReturn set_RGBS_weight_grid (ia_aiq_rgbs_grid **out_rgbs_grid);
+    XCamReturn set_hist_weight_grid (ia_aiq_hist_weight_grid **out_weight_grid);
+    XCamReturn dump_hist_weight_grid (const ia_aiq_hist_weight_grid *weight_grid);
+    XCamReturn dump_RGBS_grid (const ia_aiq_rgbs_grid *rgbs_grid);
+
 private:
     bool ensure_ia_parameters ();
     bool ensure_ae_mode ();
@@ -239,6 +244,10 @@ public:
     void set_size (uint32_t width, uint32_t height) {
         _width = width;
         _height = height;
+    }
+    void get_size (uint32_t &out_width, uint32_t &out_height) const {
+        out_width = _width;
+        out_height = _height;
     }
     bool open (ia_binary_data &cpf);
     void close ();

--- a/xcore/base/xcam_3a_types.h
+++ b/xcore/base/xcam_3a_types.h
@@ -48,10 +48,13 @@ typedef enum {
     XCAM_AE_MODE_APERTURE_PRIORITY
 } XCamAeMode;
 
+#define XCAM_AE_MAX_METERING_WINDOW_COUNT 6
+
 typedef enum {
     XCAM_AE_METERING_MODE_AUTO,   /*mode_evaluative*/
     XCAM_AE_METERING_MODE_SPOT,   /*window*/
     XCAM_AE_METERING_MODE_CENTER,  /*mode_center*/
+    XCAM_AE_METERING_MODE_WEIGHTED_WINDOW, /* weighted_window */
 } XCamAeMeteringMode;
 
 typedef enum {

--- a/xcore/base/xcam_params.h
+++ b/xcore/base/xcam_params.h
@@ -31,6 +31,7 @@ typedef struct _XCamAeParam {
     XCamAeMode              mode;
     XCamAeMeteringMode      metering_mode;
     XCam3AWindow            window;
+    XCam3AWindow            window_list[XCAM_AE_MAX_METERING_WINDOW_COUNT];
     XCamFlickerMode         flicker_mode;
     /* speed, default 1.0 */
     double                  speed;

--- a/xcore/handler_interface.cpp
+++ b/xcore/handler_interface.cpp
@@ -50,6 +50,8 @@ AeHandler::reset_parameters ()
     _params.window.x_end = 0;
     _params.window.y_end = 0;
     _params.window.weight = 0;
+
+    xcam_mem_clear (_params.window_list);
 }
 
 bool
@@ -84,6 +86,42 @@ AeHandler::set_window (XCam3AWindow *window)
                     window->x_end,
                     window->y_end,
                     window->weight);
+    return true;
+}
+
+bool
+AeHandler::set_window (XCam3AWindow *window, uint8_t count)
+{
+    if (XCAM_AE_MAX_METERING_WINDOW_COUNT < count) {
+        XCAM_LOG_ERROR ("invalid input parameter, window count = %d", count);
+        return false;
+    }
+
+    AnalyzerHandler::HanlderLock lock(this);
+
+    _params.window = *window;
+
+    for (int i = 0; i < count; i++) {
+        XCAM_LOG_DEBUG ("window start point(%d, %d), end point(%d, %d), weight = %d",
+             window[i].x_start, window[i].y_start, window[i].x_end, window[i].y_end, window[i].weight);
+
+        _params.window_list[i] = window[i];
+        if (_params.window.weight < window[i].weight) {
+            _params.window.weight = window[i].weight;
+            _params.window.x_start = window[i].x_start;
+            _params.window.y_start = window[i].y_start;
+            _params.window.x_end = window[i].x_end;
+            _params.window.y_end = window[i].y_end;
+        }
+    }
+
+    XCAM_LOG_DEBUG ("ae set metering mode window [x:%d, y:%d, x_end:%d, y_end:%d, weight:%d]",
+                    _params.window.x_start,
+                    _params.window.y_start,
+                    _params.window.x_end,
+                    _params.window.y_end,
+                    _params.window.weight);
+
     return true;
 }
 

--- a/xcore/handler_interface.h
+++ b/xcore/handler_interface.h
@@ -64,6 +64,7 @@ public:
     bool set_mode (XCamAeMode mode);
     bool set_metering_mode (XCamAeMeteringMode mode);
     bool set_window (XCam3AWindow *window);
+    bool set_window (XCam3AWindow *window, uint8_t count);
     bool set_ev_shift (double ev_shift);
     bool set_speed (double speed);
     bool set_flicker_mode (XCamFlickerMode flicker);
@@ -73,6 +74,10 @@ public:
     bool set_max_analog_gain (double max_gain);
     bool set_exposure_time_range (int64_t min_time_in_us, int64_t max_time_in_us);
     bool get_exposure_time_range (int64_t *min_time_in_us, int64_t *max_time_in_us);
+
+    XCamAeMeteringMode get_metering_mode() const {
+        return _params.metering_mode;
+    }
 
     //virtual functions
     virtual XCamFlickerMode get_flicker_mode ();

--- a/xcore/x3a_analyzer.cpp
+++ b/xcore/x3a_analyzer.cpp
@@ -371,10 +371,10 @@ X3aAnalyzer::set_ae_metering_mode (XCamAeMeteringMode mode)
 }
 
 bool
-X3aAnalyzer::set_ae_window (XCam3AWindow *window)
+X3aAnalyzer::set_ae_window (XCam3AWindow *window, uint8_t count)
 {
     XCAM_ASSERT (_ae_handler.ptr());
-    return _ae_handler->set_window (window);
+    return _ae_handler->set_window (window, count);
 }
 
 bool

--- a/xcore/x3a_analyzer.h
+++ b/xcore/x3a_analyzer.h
@@ -67,7 +67,7 @@ public:
     /* AE */
     bool set_ae_mode (XCamAeMode mode);
     bool set_ae_metering_mode (XCamAeMeteringMode mode);
-    bool set_ae_window (XCam3AWindow *window);
+	bool set_ae_window (XCam3AWindow *window, uint8_t count = 1);
     bool set_ae_ev_shift (double ev_shift);
     bool set_ae_speed (double speed);
     bool set_ae_flicker_mode (XCamFlickerMode flicker);


### PR DESCRIPTION
Mapping user specified Multi metering weighting windows to RGB statistic grid, AEC algorithum uses this information to calculate a weighted histogram to get accurate AEC calculation.

-> User can set multiple arbitrary metering windows (both size and coordinator) inside of image frame dynamically.
-> The maximum metering window count is defined in source code, currently defined as 6, it can be more.
-> Overlap metering window weighting is not supported yet, the last window’s weighting factor will overwrite the former one in the overlapped region.
-> User should assign 0 ~ 15 weighting factor to each metering window, the pixel weighted by 0 will not take into account in AEC calculation.
 