### PR TITLE
Make CL processing features configurable at run time

### DIFF
--- a/wrapper/gstreamer/gstxcamsrc.cpp
+++ b/wrapper/gstreamer/gstxcamsrc.cpp
@@ -310,6 +310,7 @@ gst_xcamsrc_start (GstBaseSrc *src)
         cl_processor = new CL3aImageProcessor ();
         cl_processor->set_stats_callback (device_manager);
         device_manager->add_image_processor (cl_processor);
+        device_manager->set_cl_image_processor (cl_processor);
         break;
 #endif
     default:
@@ -620,6 +621,9 @@ gst_xcamsrc_xcam_3a_interface_init (GstXCam3AInterface *iface)
     iface->set_manual_saturation = gst_xcamsrc_set_manual_saturation;
     iface->set_manual_sharpness = gst_xcamsrc_set_manual_sharpness;
     iface->set_night_mode = gst_xcamsrc_set_night_mode;
+    iface->set_hdr_mode = gst_xcamsrc_set_hdr_mode;
+    iface->set_denoise_mode = gst_xcamsrc_set_denoise_mode;
+    iface->set_gamma_mode = gst_xcamsrc_set_gamma_mode;
 }
 
 static gboolean

--- a/wrapper/gstreamer/interface/gstxcaminterface.c
+++ b/wrapper/gstreamer/interface/gstxcaminterface.c
@@ -87,4 +87,7 @@ gst_xcam_3a_iface_init (GstXCam3AInterface * iface)
     iface->set_manual_sharpness = NULL;
     iface->set_night_mode = NULL;
     iface->set_3a_mode = NULL;
+    iface->set_hdr_mode = NULL;
+    iface->set_denoise_mode = NULL;
+    iface->set_gamma_mode = NULL;
 }

--- a/wrapper/gstreamer/interface/gstxcaminterface.h
+++ b/wrapper/gstreamer/interface/gstxcaminterface.h
@@ -404,7 +404,34 @@ struct _GstXCam3AInterface {
     /*!
      * \brief enable/disable 3A mode.
      */
-    gboolean (* set_3a_mode)                 (GstXCam3A *xcam, gboolean enable);
+    gboolean (* set_3a_mode)                    (GstXCam3A *xcam, gboolean enable);
+
+    /*!
+     * \brief set HDR mode.
+     *
+     * \param[in,out]    xcam          XCam3A handle
+     * \param[in]        mode          0: disable, 1: HDR in RGB color space, 2: HDR in LAB color space
+     * \return           bool          0 on success
+     */
+    gboolean (* set_hdr_mode)                   (GstXCam3A *xcam, guint8 mode);
+
+    /*!
+     * \brief set denoise mode.
+     *
+     * \param[in,out]    xcam          XCam3A handle
+     * \param[in]        mode          0: disable, 1: simple, 2: bilinear
+     * \return           bool          0 on success
+     */
+    gboolean (* set_denoise_mode)               (GstXCam3A *xcam, guint8 mode);
+
+    /*!
+     * \brief set gamma mode.
+     *
+     * \param[in,out]    xcam          XCam3A handle
+     * \param[in]        enable        true: enable, false: disable
+     * \return           bool          0 on success
+     */
+    gboolean (* set_gamma_mode)                 (GstXCam3A *xcam, gboolean enable);
 };
 
 /*! \brief Get GST interface type of XCam 3A interface.

--- a/wrapper/gstreamer/stub.cpp
+++ b/wrapper/gstreamer/stub.cpp
@@ -88,6 +88,7 @@ xcambufferpool_release_buffer (GstBufferPool *bpool, GstBuffer *gbuf)
 
 gboolean gst_xcamsrc_set_white_balance_mode (GstXCam3A *xcam3a, XCamAwbMode mode)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_awb_mode (mode);
@@ -95,6 +96,7 @@ gboolean gst_xcamsrc_set_white_balance_mode (GstXCam3A *xcam3a, XCamAwbMode mode
 
 gboolean gst_xcamsrc_set_awb_speed (GstXCam3A *xcam3a, double speed)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_awb_speed (speed);
@@ -102,18 +104,21 @@ gboolean gst_xcamsrc_set_awb_speed (GstXCam3A *xcam3a, double speed)
 
 gboolean gst_xcamsrc_set_wb_color_temperature_range (GstXCam3A *xcam3a, guint cct_min, guint cct_max)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_awb_color_temperature_range (cct_min, cct_max);
 }
 gboolean gst_xcamsrc_set_manual_wb_gain (GstXCam3A *xcam3a, double gr, double r, double b, double gb)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_awb_manual_gain (gr, r, b, gb);
 }
 gboolean gst_xcamsrc_set_exposure_mode (GstXCam3A *xcam3a, XCamAeMode mode)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_ae_mode (mode);
@@ -121,12 +126,14 @@ gboolean gst_xcamsrc_set_exposure_mode (GstXCam3A *xcam3a, XCamAeMode mode)
 
 gboolean gst_xcamsrc_set_ae_metering_mode (GstXCam3A *xcam3a, XCamAeMeteringMode mode)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_ae_metering_mode (mode);
 }
 gboolean gst_xcamsrc_set_exposure_window (GstXCam3A *xcam3a, XCam3AWindow *window, guint8 count)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
 
@@ -134,146 +141,212 @@ gboolean gst_xcamsrc_set_exposure_window (GstXCam3A *xcam3a, XCam3AWindow *windo
 }
 gboolean gst_xcamsrc_set_exposure_value_offset (GstXCam3A *xcam3a, double ev_offset)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_ae_ev_shift (ev_offset);
 }
 gboolean gst_xcamsrc_set_ae_speed (GstXCam3A *xcam3a, double speed)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_ae_speed (speed);
 }
 gboolean gst_xcamsrc_set_exposure_flicker_mode (GstXCam3A *xcam3a, XCamFlickerMode flicker)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_ae_flicker_mode (flicker);
 }
 XCamFlickerMode gst_xcamsrc_get_exposure_flicker_mode (GstXCam3A *xcam3a)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->get_ae_flicker_mode ();
 }
 gint64 gst_xcamsrc_get_current_exposure_time (GstXCam3A *xcam3a)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->get_ae_current_exposure_time ();
 }
 double gst_xcamsrc_get_current_analog_gain (GstXCam3A *xcam3a)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->get_ae_current_analog_gain ();
 }
 gboolean gst_xcamsrc_set_manual_exposure_time (GstXCam3A *xcam3a, gint64 time_in_us)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_ae_manual_exposure_time (time_in_us);
 }
 gboolean gst_xcamsrc_set_manual_analog_gain (GstXCam3A *xcam3a, double gain)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_ae_manual_analog_gain (gain);
 }
 gboolean gst_xcamsrc_set_aperture (GstXCam3A *xcam3a, double fn)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_ae_aperture (fn);
 }
 gboolean gst_xcamsrc_set_max_analog_gain (GstXCam3A *xcam3a, double max_gain)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_ae_max_analog_gain (max_gain);
 }
 double gst_xcamsrc_get_max_analog_gain (GstXCam3A *xcam3a)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->get_ae_max_analog_gain ();
 }
 gboolean gst_xcamsrc_set_exposure_time_range (GstXCam3A *xcam3a, gint64 min_time_in_us, gint64 max_time_in_us)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_ae_exposure_time_range (min_time_in_us, max_time_in_us);
 }
 gboolean gst_xcamsrc_get_exposure_time_range (GstXCam3A *xcam3a, gint64 *min_time_in_us, gint64 *max_time_in_us)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->get_ae_exposure_time_range (min_time_in_us, max_time_in_us);
 }
 gboolean gst_xcamsrc_set_noise_reduction_level (GstXCam3A *xcam3a, guint8 level)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_noise_reduction_level (level);
 }
 gboolean gst_xcamsrc_set_temporal_noise_reduction_level (GstXCam3A *xcam3a, guint8 level)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_temporal_noise_reduction_level (level);
 }
 gboolean gst_xcamsrc_set_gamma_table (GstXCam3A *xcam3a, double *r_table, double *g_table, double *b_table)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_gamma_table (r_table, g_table, b_table);
 }
 gboolean gst_xcamsrc_set_gbce (GstXCam3A *xcam3a, gboolean enable)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_gbce (enable);
 }
 gboolean gst_xcamsrc_set_manual_brightness (GstXCam3A *xcam3a, guint8 value)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_manual_brightness (value);
 }
 gboolean gst_xcamsrc_set_manual_contrast (GstXCam3A *xcam3a, guint8 value)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_manual_contrast (value);
 }
 gboolean gst_xcamsrc_set_manual_hue (GstXCam3A *xcam3a, guint8 value)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_manual_hue (value);
 }
 gboolean gst_xcamsrc_set_manual_saturation (GstXCam3A *xcam3a, guint8 value)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_manual_saturation (value);
 }
 gboolean gst_xcamsrc_set_manual_sharpness (GstXCam3A *xcam3a, guint8 value)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_manual_sharpness (value);
 }
 gboolean gst_xcamsrc_set_dvs (GstXCam3A *xcam3a, gboolean enable)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_dvs (enable);
 }
 gboolean gst_xcamsrc_set_night_mode (GstXCam3A *xcam3a, gboolean enable)
 {
+    XCAM_UNUSED (xcam3a);
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
     SmartPtr<X3aAnalyzer> analyzer = device_manager->get_analyzer ();
     return analyzer->set_night_mode (enable);
 }
 
+gboolean gst_xcamsrc_set_hdr_mode (GstXCam3A *xcam3a, guint8 mode)
+{
+    XCAM_UNUSED (xcam3a);
+#if HAVE_LIBCL
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<CL3aImageProcessor> cl_image_processor = device_manager->get_cl_image_processor ();
+    if (cl_image_processor.ptr ())
+        return cl_image_processor->set_hdr (mode);
+    else
+#endif
+        return false;
+}
+
+gboolean gst_xcamsrc_set_denoise_mode (GstXCam3A *xcam3a, guint8 mode)
+{
+    XCAM_UNUSED (xcam3a);
+#if HAVE_LIBCL
+    gboolean ret;
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<CL3aImageProcessor> cl_image_processor = device_manager->get_cl_image_processor ();
+    if (cl_image_processor.ptr ()) {
+        ret = cl_image_processor->set_denoise (mode) &&
+              cl_image_processor->set_snr (mode);
+        return ret;
+    }
+    else
+#endif
+        return false;
+}
+
+gboolean gst_xcamsrc_set_gamma_mode (GstXCam3A *xcam3a, gboolean enable)
+{
+    XCAM_UNUSED (xcam3a);
+#if HAVE_LIBCL
+    SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
+    SmartPtr<CL3aImageProcessor> cl_image_processor = device_manager->get_cl_image_processor ();
+    if (cl_image_processor.ptr ())
+        return cl_image_processor->set_gamma (enable);
+    else
+#endif
+        return false;
+}

--- a/wrapper/gstreamer/stub.h
+++ b/wrapper/gstreamer/stub.h
@@ -76,6 +76,9 @@ gboolean gst_xcamsrc_set_manual_saturation (GstXCam3A *xcam3a, guint8 value);
 gboolean gst_xcamsrc_set_manual_sharpness (GstXCam3A *xcam3a, guint8 value);
 gboolean gst_xcamsrc_set_dvs (GstXCam3A *xcam3a, gboolean enable);
 gboolean gst_xcamsrc_set_night_mode (GstXCam3A *xcam3a, gboolean enable);
+gboolean gst_xcamsrc_set_hdr_mode (GstXCam3A *xcam3a, guint8 mode);
+gboolean gst_xcamsrc_set_denoise_mode (GstXCam3A *xcam3a, guint8 mode);
+gboolean gst_xcamsrc_set_gamma_mode (GstXCam3A *xcam3a, gboolean enable);
 
 XCAM_END_DECLARE
 

--- a/wrapper/gstreamer/v4l2dev.h
+++ b/wrapper/gstreamer/v4l2dev.h
@@ -93,6 +93,20 @@ public:
     pthread_cond_t          bufs_cond;
     std::queue< SmartPtr<VideoBuffer> > release_bufs;
     pthread_mutex_t         release_mutex;
+
+#if HAVE_LIBCL
+public:
+    void set_cl_image_processor (SmartPtr<CL3aImageProcessor> &processor) {
+        _cl_image_processor = processor;
+    }
+
+    SmartPtr<CL3aImageProcessor> &get_cl_image_processor () {
+        return _cl_image_processor;
+    }
+
+private:
+    SmartPtr<CL3aImageProcessor> _cl_image_processor;
+#endif
 };
 
 };

--- a/xcore/cl_3a_image_processor.cpp
+++ b/xcore/cl_3a_image_processor.cpp
@@ -35,12 +35,7 @@ namespace XCam {
 CL3aImageProcessor::CL3aImageProcessor ()
     : CLImageProcessor ("CL3aImageProcessor")
     , _output_fourcc (V4L2_PIX_FMT_NV12)
-    , _enable_hdr (false)
-    , _enable_denoise (false)
-    , _enable_gamma (false)
-    , _enable_macc (false)
     , _out_smaple_type (OutSampleYuv)
-    , _enable_snr (false)
 {
     XCAM_LOG_DEBUG ("CL3aImageProcessor constructed");
 }
@@ -171,16 +166,14 @@ CL3aImageProcessor::create_handlers ()
     add_handler (image_handler);
 
     /* denoise */
-    if (_enable_denoise) {
-        image_handler = create_cl_denoise_image_handler (context);
-        _denoise = image_handler;
-        XCAM_FAIL_RETURN (
-            WARNING,
-            _denoise.ptr (),
-            XCAM_RETURN_ERROR_CL,
-            "CL3aImageProcessor create denoise handler failed");
-        add_handler (image_handler);
-    }
+    image_handler = create_cl_denoise_image_handler (context);
+    _denoise = image_handler.dynamic_cast_ptr<CLDenoiseImageHandler> ();
+    XCAM_FAIL_RETURN (
+        WARNING,
+        _denoise.ptr (),
+        XCAM_RETURN_ERROR_CL,
+        "CL3aImageProcessor create denoise handler failed");
+    add_handler (image_handler);
 
     image_handler = create_cl_3a_stats_image_handler (context);
     _x3a_stats_calculator = image_handler.dynamic_cast_ptr<CL3AStatsCalculator> ();
@@ -202,28 +195,24 @@ CL3aImageProcessor::create_handlers ()
     add_handler (image_handler);
 
     /* gamma */
-    if(_enable_gamma) {
-        image_handler = create_cl_gamma_image_handler (context);
-        _gamma = image_handler.dynamic_cast_ptr<CLGammaImageHandler> ();
-        XCAM_FAIL_RETURN (
-            WARNING,
-            _gamma.ptr (),
-            XCAM_RETURN_ERROR_CL,
-            "CL3aImageProcessor create gamma handler failed");
-        add_handler (image_handler);
-    }
+    image_handler = create_cl_gamma_image_handler (context);
+    _gamma = image_handler.dynamic_cast_ptr<CLGammaImageHandler> ();
+    XCAM_FAIL_RETURN (
+        WARNING,
+        _gamma.ptr (),
+        XCAM_RETURN_ERROR_CL,
+        "CL3aImageProcessor create gamma handler failed");
+    add_handler (image_handler);
 
     /* hdr */
-    if (_enable_hdr) {
-        image_handler = create_cl_hdr_image_handler (context, CL_HDR_TYPE_RGB);
-        _hdr = image_handler;
-        XCAM_FAIL_RETURN (
-            WARNING,
-            _hdr.ptr (),
-            XCAM_RETURN_ERROR_CL,
-            "CL3aImageProcessor create hdr handler failed");
-        add_handler (image_handler);
-    }
+    image_handler = create_cl_hdr_image_handler (context, CL_HDR_DISABLE);
+    _hdr = image_handler.dynamic_cast_ptr<CLHdrImageHandler> ();
+    XCAM_FAIL_RETURN (
+        WARNING,
+        _hdr.ptr (),
+        XCAM_RETURN_ERROR_CL,
+        "CL3aImageProcessor create hdr handler failed");
+    add_handler (image_handler);
 
     /* demosaic */
     image_handler = create_cl_demosaic_image_handler (context);
@@ -236,28 +225,24 @@ CL3aImageProcessor::create_handlers ()
     add_handler (image_handler);
 
     /* simple noise reduction */
-    if (_enable_snr) {
-        image_handler = create_cl_snr_image_handler (context);
-        _snr = image_handler;
-        XCAM_FAIL_RETURN (
-            WARNING,
-            _snr.ptr (),
-            XCAM_RETURN_ERROR_CL,
-            "CL3aImageProcessor create snr handler failed");
-        add_handler (image_handler);
-    }
+    image_handler = create_cl_snr_image_handler (context);
+    _snr = image_handler.dynamic_cast_ptr<CLSnrImageHandler> ();
+    XCAM_FAIL_RETURN (
+        WARNING,
+        _snr.ptr (),
+        XCAM_RETURN_ERROR_CL,
+        "CL3aImageProcessor create snr handler failed");
+    add_handler (image_handler);
 
     /* macc */
-    if (_enable_macc) {
-        image_handler = create_cl_macc_image_handler (context);
-        _macc = image_handler.dynamic_cast_ptr<CLMaccImageHandler> ();
-        XCAM_FAIL_RETURN (
-            WARNING,
-            _macc.ptr (),
-            XCAM_RETURN_ERROR_CL,
-            "CL3aImageProcessor create macc handler failed");
-        add_handler (image_handler);
-    }
+    image_handler = create_cl_macc_image_handler (context);
+    _macc = image_handler.dynamic_cast_ptr<CLMaccImageHandler> ();
+    XCAM_FAIL_RETURN (
+        WARNING,
+        _macc.ptr (),
+        XCAM_RETURN_ERROR_CL,
+        "CL3aImageProcessor create macc handler failed");
+    add_handler (image_handler);
 
     /* color space conversion */
     if (_out_smaple_type == OutSampleYuv) {
@@ -274,6 +259,61 @@ CL3aImageProcessor::create_handlers ()
     }
 
     return XCAM_RETURN_NO_ERROR;
+}
+
+bool
+CL3aImageProcessor::set_hdr (uint32_t mode)
+{
+    STREAM_LOCK;
+
+    if (!_hdr.ptr ())
+        return false;
+    else
+        return _hdr->set_mode (mode);
+}
+
+bool
+CL3aImageProcessor::set_denoise (uint32_t mode)
+{
+    STREAM_LOCK;
+
+    if (!_denoise.ptr ())
+        return false;
+    else
+        return _denoise->set_mode (mode);
+}
+
+bool
+CL3aImageProcessor::set_gamma (bool enable)
+{
+    STREAM_LOCK;
+
+    if (!_gamma.ptr ())
+        return false;
+    else
+        return _gamma->set_enable (enable);
+}
+
+bool
+CL3aImageProcessor::set_snr (uint32_t mode)
+{
+    STREAM_LOCK;
+
+    if (!_snr.ptr ())
+        return false;
+    else
+        return _snr->set_mode (mode);
+}
+
+bool
+CL3aImageProcessor::set_macc (bool enable)
+{
+    STREAM_LOCK;
+
+    if (!_macc.ptr ())
+        return false;
+    else
+        return _macc->set_enable (enable);
 }
 
 };

--- a/xcore/cl_3a_image_processor.h
+++ b/xcore/cl_3a_image_processor.h
@@ -33,6 +33,9 @@ class CLGammaImageHandler;
 class CL3AStatsCalculator;
 class CLWbImageHandler;
 class CLMaccImageHandler;
+class CLHdrImageHandler;
+class CLDenoiseImageHandler;
+class CLSnrImageHandler;
 
 class CL3aImageProcessor
     : public CLImageProcessor
@@ -50,21 +53,12 @@ public:
     void set_stats_callback (const SmartPtr<StatsCallback> &callback);
 
     bool set_output_format (uint32_t fourcc);
-    void set_hdr (bool enable) {
-        _enable_hdr = enable;
-    }
-    void set_denoise (bool enable) {
-        _enable_denoise = enable;
-    }
-    void set_gamma (bool enable) {
-        _enable_gamma = enable;
-    }
-    void set_snr (bool enable) {
-        _enable_snr = enable;
-    }
-    void set_macc (bool enable) {
-        _enable_macc = enable;
-    }
+
+    virtual bool set_hdr (uint32_t mode);
+    virtual bool set_denoise (uint32_t mode);
+    virtual bool set_gamma (bool enable);
+    virtual bool set_snr (uint32_t mode);
+    virtual bool set_macc (bool enable);
 
 protected:
 
@@ -79,25 +73,20 @@ private:
 
 private:
     uint32_t                           _output_fourcc;
-    bool                               _enable_hdr;
-    bool                               _enable_denoise;
-    bool                               _enable_gamma;
-    bool                               _enable_macc;
     OutSampleType                      _out_smaple_type;
-    bool                               _enable_snr;
 
     SmartPtr<StatsCallback>            _stats_callback;
 
     SmartPtr<CLImageHandler>           _black_level;
     SmartPtr<CLBayer2RGBImageHandler>  _demosaic;
-    SmartPtr<CLImageHandler>           _hdr;
+    SmartPtr<CLHdrImageHandler>        _hdr;
     SmartPtr<CLCscImageHandler>        _csc;
-    SmartPtr<CLImageHandler>           _denoise;
+    SmartPtr<CLDenoiseImageHandler>    _denoise;
     SmartPtr<CLGammaImageHandler>      _gamma;
     SmartPtr<CL3AStatsCalculator>      _x3a_stats_calculator;
     SmartPtr<CLWbImageHandler>         _wb;
-    SmartPtr<CLImageHandler>           _snr;
-    SmartPtr<CLMaccImageHandler>     _macc;
+    SmartPtr<CLSnrImageHandler>        _snr;
+    SmartPtr<CLMaccImageHandler>       _macc;
 };
 
 };

--- a/xcore/cl_denoise_handler.h
+++ b/xcore/cl_denoise_handler.h
@@ -25,11 +25,18 @@
 
 namespace XCam {
 
+enum CLDenoiseType {
+    CL_DENOISE_DISABLE = 0,
+    CL_DENOISE_TYPE_SIMPLE,
+    CL_DENOISE_TYPE_BILATERIAL,
+};
+
 class CLDenoiseImageKernel
     : public CLImageKernel
 {
 public:
-    explicit CLDenoiseImageKernel (SmartPtr<CLContext> &context);
+    explicit CLDenoiseImageKernel (SmartPtr<CLContext> &context,
+                                   const char *name);
 
 protected:
     virtual XCamReturn prepare_arguments (
@@ -42,6 +49,17 @@ private:
     float    _sigma_r;
     uint32_t _imw;
     uint32_t _imh;
+};
+
+class CLDenoiseImageHandler
+    : public CLImageHandler
+{
+public:
+    explicit CLDenoiseImageHandler (const char *name);
+    bool set_mode (uint32_t mode);
+
+private:
+    XCAM_DEAD_COPY (CLDenoiseImageHandler);
 };
 
 SmartPtr<CLImageHandler>

--- a/xcore/cl_gamma_handler.cpp
+++ b/xcore/cl_gamma_handler.cpp
@@ -58,7 +58,7 @@ float default_gamma_table[XCAM_GAMMA_TABLE_SIZE] = {
 namespace XCam {
 
 CLGammaImageKernel::CLGammaImageKernel (SmartPtr<CLContext> &context)
-    : CLImageKernel (context, "kernel_gamma")
+    : CLImageKernel (context, "kernel_gamma", false)
 {
     set_gamma(default_gamma_table);
 }
@@ -111,9 +111,21 @@ CLGammaImageKernel::set_gamma (float *gamma)
     memcpy(_gamma_table, gamma, sizeof(float)*XCAM_GAMMA_TABLE_SIZE);
     return true;
 }
+
 CLGammaImageHandler::CLGammaImageHandler (const char *name)
     : CLImageHandler (name)
 {
+}
+
+bool
+CLGammaImageHandler::set_enable (bool enable)
+{
+    for (KernelList::iterator i_kernel = _kernels.begin ();
+            i_kernel != _kernels.end (); ++i_kernel) {
+        (*i_kernel)->set_enable (enable);
+    }
+
+    return true;
 }
 
 bool

--- a/xcore/cl_gamma_handler.h
+++ b/xcore/cl_gamma_handler.h
@@ -54,6 +54,7 @@ public:
     explicit CLGammaImageHandler (const char *name);
     bool set_gamma_table (XCam3aResultGammaTable gamma);
     bool set_gamma_kernel(SmartPtr<CLGammaImageKernel> &kernel);
+    bool set_enable (bool enable);
 
 private:
     XCAM_DEAD_COPY (CLGammaImageHandler);

--- a/xcore/cl_hdr_handler.cpp
+++ b/xcore/cl_hdr_handler.cpp
@@ -22,12 +22,42 @@
 
 namespace XCam {
 
+CLHdrImageKernel::CLHdrImageKernel (SmartPtr<CLContext> &context,
+                                    const char *name,
+                                    CLHdrType type)
+    : CLImageKernel (context, name, false)
+    , _type (type)
+{
+}
+
+CLHdrImageHandler::CLHdrImageHandler (const char *name)
+    : CLImageHandler (name)
+{
+}
+
+bool
+CLHdrImageHandler::set_mode (uint32_t mode)
+{
+    SmartPtr<CLHdrImageKernel> hdr_kernel;
+
+    for (KernelList::iterator i_kernel = _kernels.begin ();
+            i_kernel != _kernels.end (); ++i_kernel) {
+        hdr_kernel = (*i_kernel).dynamic_cast_ptr<CLHdrImageKernel> ();
+        XCAM_ASSERT (hdr_kernel.ptr ());
+        hdr_kernel->set_enable (mode == hdr_kernel->get_type ());
+    }
+
+    return true;
+}
+
 SmartPtr<CLImageHandler>
 create_cl_hdr_image_handler (SmartPtr<CLContext> &context, CLHdrType type)
 {
-    SmartPtr<CLImageHandler> hdr_handler;
+    SmartPtr<CLHdrImageHandler> hdr_handler;
     SmartPtr<CLImageKernel> hdr_kernel;
     XCamReturn ret = XCAM_RETURN_NO_ERROR;
+
+    hdr_handler = new CLHdrImageHandler ("cl_handler_hdr");
 
     XCAM_CL_KERNEL_FUNC_SOURCE_BEGIN(kernel_hdr_rgb)
 #include "kernel_hdr_rgb.cl"
@@ -36,14 +66,8 @@ create_cl_hdr_image_handler (SmartPtr<CLContext> &context, CLHdrType type)
 #include "kernel_hdr_lab.cl"
     XCAM_CL_KERNEL_FUNC_END;
 
-    if (type == CL_HDR_TYPE_RGB) {
-        hdr_kernel = new CLImageKernel (context, "kernel_hdr_rgb");
-        ret = hdr_kernel->load_from_source (kernel_hdr_rgb_body, strlen (kernel_hdr_rgb_body));
-    }
-    else if (type == CL_HDR_TYPE_LAB) {
-        hdr_kernel = new CLImageKernel (context, "kernel_hdr_lab");
-        ret = hdr_kernel->load_from_source (kernel_hdr_lab_body, strlen (kernel_hdr_lab_body));
-    }
+    hdr_kernel = new CLHdrImageKernel (context, "kernel_hdr_rgb", CL_HDR_TYPE_RGB);
+    ret = hdr_kernel->load_from_source (kernel_hdr_rgb_body, strlen (kernel_hdr_rgb_body));
     XCAM_FAIL_RETURN (
         WARNING,
         ret == XCAM_RETURN_NO_ERROR,
@@ -51,9 +75,20 @@ create_cl_hdr_image_handler (SmartPtr<CLContext> &context, CLHdrType type)
         "CL image handler(%s) load source failed", hdr_kernel->get_kernel_name());
 
     XCAM_ASSERT (hdr_kernel->is_valid ());
-    hdr_handler = new CLImageHandler ("cl_handler_hdr");
-    hdr_handler->add_kernel  (hdr_kernel);
+    hdr_handler->add_kernel (hdr_kernel);
 
+    hdr_kernel = new CLHdrImageKernel (context, "kernel_hdr_lab", CL_HDR_TYPE_LAB);
+    ret = hdr_kernel->load_from_source (kernel_hdr_lab_body, strlen (kernel_hdr_lab_body));
+    XCAM_FAIL_RETURN (
+        WARNING,
+        ret == XCAM_RETURN_NO_ERROR,
+        NULL,
+        "CL image handler(%s) load source failed", hdr_kernel->get_kernel_name());
+
+    XCAM_ASSERT (hdr_kernel->is_valid ());
+    hdr_handler->add_kernel (hdr_kernel);
+
+    hdr_handler->set_mode (type);
     return hdr_handler;
 }
 

--- a/xcore/cl_hdr_handler.h
+++ b/xcore/cl_hdr_handler.h
@@ -27,8 +27,35 @@
 namespace XCam {
 
 enum CLHdrType {
+    CL_HDR_DISABLE = 0,
     CL_HDR_TYPE_RGB,
     CL_HDR_TYPE_LAB,
+};
+
+class CLHdrImageKernel
+    : public CLImageKernel
+{
+public:
+    explicit CLHdrImageKernel (SmartPtr<CLContext> &context,
+                               const char *name,
+                               CLHdrType type);
+    CLHdrType get_type () {
+        return _type;
+    }
+
+private:
+    CLHdrType _type;
+};
+
+class CLHdrImageHandler
+    : public CLImageHandler
+{
+public:
+    explicit CLHdrImageHandler (const char *name);
+    bool set_mode (uint32_t mode);
+
+private:
+    XCAM_DEAD_COPY (CLHdrImageHandler);
 };
 
 SmartPtr<CLImageHandler>

--- a/xcore/cl_image_handler.h
+++ b/xcore/cl_image_handler.h
@@ -49,11 +49,19 @@ class CLImageKernel
     : public CLKernel
 {
 public:
-    explicit CLImageKernel (SmartPtr<CLContext> &context, const char *name);
+    explicit CLImageKernel (SmartPtr<CLContext> &context, const char *name, bool enable = true);
     virtual ~CLImageKernel ();
 
     XCamReturn pre_execute (SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output);
     virtual XCamReturn post_execute ();
+
+    void set_enable (bool enable) {
+        _enable = enable;
+    }
+
+    bool is_enable () {
+        return _enable;
+    }
 
 protected:
     virtual XCamReturn prepare_arguments (
@@ -63,6 +71,7 @@ protected:
 
 private:
     XCAM_DEAD_COPY (CLImageKernel);
+    bool _enable;
 
 protected:
     SmartPtr<CLImage>   _image_in;
@@ -71,7 +80,6 @@ protected:
 
 class CLImageHandler
 {
-    typedef std::list<SmartPtr<CLImageKernel>> KernelList;
 public:
     explicit CLImageHandler (const char *name);
     virtual ~CLImageHandler ();
@@ -95,12 +103,15 @@ protected:
         return _buf_pool;
     }
 
+protected:
+    typedef std::list<SmartPtr<CLImageKernel>> KernelList;
+    KernelList                 _kernels;
+
 private:
     XCAM_DEAD_COPY (CLImageHandler);
 
 private:
     char                      *_name;
-    KernelList                 _kernels;
     SmartPtr<BufferPool>       _buf_pool;
 };
 

--- a/xcore/cl_macc_handler.cpp
+++ b/xcore/cl_macc_handler.cpp
@@ -20,7 +20,7 @@
 #include "xcam_utils.h"
 #include "cl_macc_handler.h"
 
-float default_macc_table[XCAM_CHROMA_AXIS_SIZE*XCAM_CHROMA_MATRIX_SIZE] = {
+float default_macc_table[XCAM_CHROMA_AXIS_SIZE * XCAM_CHROMA_MATRIX_SIZE] = {
     1.000000, 0.000000, 0.000000, 1.000000, 1.000000, 0.000000, 0.000000, 1.000000,
     1.000000, 0.000000, 0.000000, 1.000000, 1.000000, 0.000000, 0.000000, 1.000000,
     1.000000, 0.000000, 0.000000, 1.000000, 1.000000, 0.000000, 0.000000, 1.000000,
@@ -34,7 +34,7 @@ float default_macc_table[XCAM_CHROMA_AXIS_SIZE*XCAM_CHROMA_MATRIX_SIZE] = {
 namespace XCam {
 
 CLMaccImageKernel::CLMaccImageKernel (SmartPtr<CLContext> &context)
-    : CLImageKernel (context, "kernel_macc")
+    : CLImageKernel (context, "kernel_macc", false)
 {
     set_macc (default_macc_table);
 }
@@ -86,9 +86,21 @@ CLMaccImageKernel::set_macc (float *macc)
     memcpy(_macc_table, macc, sizeof(float)*XCAM_CHROMA_AXIS_SIZE * XCAM_CHROMA_MATRIX_SIZE);
     return true;
 }
+
 CLMaccImageHandler::CLMaccImageHandler (const char *name)
     : CLImageHandler (name)
 {
+}
+
+bool
+CLMaccImageHandler::set_enable (bool enable)
+{
+    for (KernelList::iterator i_kernel = _kernels.begin ();
+            i_kernel != _kernels.end (); ++i_kernel) {
+        (*i_kernel)->set_enable (enable);
+    }
+
+    return true;
 }
 
 bool

--- a/xcore/cl_macc_handler.h
+++ b/xcore/cl_macc_handler.h
@@ -54,6 +54,7 @@ public:
     explicit CLMaccImageHandler (const char *name);
     bool set_macc_table (XCam3aResultMaccMatrix macc);
     bool set_macc_kernel(SmartPtr<CLMaccImageKernel> &kernel);
+    bool set_enable (bool enable);
 
 private:
     XCAM_DEAD_COPY (CLMaccImageHandler);

--- a/xcore/cl_snr_handler.h
+++ b/xcore/cl_snr_handler.h
@@ -23,6 +23,7 @@
 
 #include "xcam_utils.h"
 #include "cl_image_handler.h"
+#include "cl_denoise_handler.h"
 
 namespace XCam {
 
@@ -30,7 +31,8 @@ class CLSnrImageKernel
     : public CLImageKernel
 {
 public:
-    explicit CLSnrImageKernel (SmartPtr<CLContext> &context);
+    explicit CLSnrImageKernel (SmartPtr<CLContext> &context,
+                               const char *name);
 
 protected:
     virtual XCamReturn prepare_arguments (
@@ -40,6 +42,17 @@ protected:
 
 private:
     XCAM_DEAD_COPY (CLSnrImageKernel);
+};
+
+class CLSnrImageHandler
+    : public CLImageHandler
+{
+public:
+    explicit CLSnrImageHandler (const char *name);
+    bool set_mode (uint32_t mode);
+
+private:
+    XCAM_DEAD_COPY (CLSnrImageHandler);
 };
 
 SmartPtr<CLImageHandler>

--- a/xcore/device_manager.h
+++ b/xcore/device_manager.h
@@ -26,6 +26,7 @@
 #include "v4l2_device.h"
 #include "v4l2_buffer_proxy.h"
 #include "x3a_analyzer.h"
+#include "x3a_image_process_center.h"
 #include "image_processor.h"
 #include "x3a_statistics_queue.h"
 #include "poll_thread.h"
@@ -55,7 +56,6 @@ struct XCamMessage {
 };
 
 class MessageThread;
-class X3aImageProcessCenter;
 
 class DeviceManager
     : public PollCallback


### PR DESCRIPTION
Due to performance constraints, HDR/denoise/gamma need to
switch on/off or among different modes at run time.

 * extend gst plugin and xcam interface to set these modes
 * all CL image handlers are created at the beginning
 * CLImageProcessor will save CL mode settings in the calling
   context of upper layer, and configure CLImageHandler when
   ImageProcessorThread process buffers
 * CLImageHandler determins if a specific CLKernel needs to
   run via the new virtual fuction isEnable of CLKernel