### PR TITLE
avoid use the wrong header

### DIFF
--- a/wrapper/gstreamer/interface/gstxcaminterface.h
+++ b/wrapper/gstreamer/interface/gstxcaminterface.h
@@ -27,7 +27,7 @@
 
 #include <gst/gst.h>
 #include <linux/videodev2.h>
-#include <xcam_3a_types.h>
+#include <base/xcam_3a_types.h>
 
 
 G_BEGIN_DECLS


### PR DESCRIPTION
When previous libxcam was installed, it will install xcam_3a_types.h
 in /usr/include/xcam.
Our new libxcam will install this file to /usr/include/xcam/base.
So use the correct header to avoid build failure.