### PR TITLE
add double quotation in cl file, but need to call the shell script in makefile

### DIFF
--- a/tools/cl_double_quotation.sh
+++ b/tools/cl_double_quotation.sh
@@ -1,0 +1,44 @@
+#! /bin/sh
+
+OLD_CL_FILE=$1
+NEW_CL_FILE=$2
+
+awk '
+    BEGIN {FS=""}
+    {
+        if ($0~/^[\t " "]*[\/]+/ || $0~/^[\t " "]*[\*]/)
+            printf("%s\n", $0);
+        else
+        {
+            gsub(/^\"[\\]?n?/, "");
+            gsub(/[\\]?n?\"[ ]*$/, "");
+
+            if ($0~/^[ ]*$/)
+                printf("\n");
+            else
+            {
+                gsub(/\\\"/, "\"");
+                gsub(/\\%/, "%");
+                gsub(/\\\\n/, "\\n");
+
+                gsub(/\"/, "\\\"");
+                gsub(/%/, "\\%");
+                gsub(/\\n/, "\\\\n");
+
+                gsub(/^#/, "\\n#");
+
+                printf("\"%s\\n\"\n", $0);
+            }
+        }
+    }
+    ' $OLD_CL_FILE > $OLD_CL_FILE.tmp
+
+ret=$?
+if [ $ret != 0 ] ; then
+    rm -rf $OLD_CL_FILE.tmp
+    echo "add double quotation on $OLD_CL_FILE failed"
+else
+    mv $OLD_CL_FILE.tmp $NEW_CL_FILE
+    echo "add double quotation on $OLD_CL_FILE done"
+fi
+


### PR DESCRIPTION
    * the usage of the script:
      cl_double_quotation.sh <input.cl> <output.cl>

      this script for rupypark, if use in linux PC, please change the eighth gsub() as:
      gsub(/\\n/, "\\\\n");   --->  gsub(/\\n/, "\\\\\\n");