### PR TITLE
plugin: init and destroy mutex and cond properly

### DIFF
--- a/wrapper/gstreamer/v4l2dev.cpp
+++ b/wrapper/gstreamer/v4l2dev.cpp
@@ -52,11 +52,11 @@ MainDeviceManager::handle_message (SmartPtr<XCamMessage> &msg)
 void
 MainDeviceManager::handle_buffer (SmartPtr<VideoBuffer> &buf)
 {
-    pthread_mutex_lock (&bufs_mutex);
+    bufs_mutex.lock ();
     bufs.push (buf);
     if (bufs.size() == 1)
-        pthread_cond_signal (&bufs_cond);
-    pthread_mutex_unlock (&bufs_mutex);
+        bufs_cond.signal ();
+    bufs_mutex.unlock ();
 }
 
 };

--- a/wrapper/gstreamer/v4l2dev.h
+++ b/wrapper/gstreamer/v4l2dev.h
@@ -89,10 +89,10 @@ protected:
 
 public:
     std::queue< SmartPtr<VideoBuffer> > bufs;
-    pthread_mutex_t         bufs_mutex;
-    pthread_cond_t          bufs_cond;
+    Mutex                   bufs_mutex;
+    Cond                    bufs_cond;
     std::queue< SmartPtr<VideoBuffer> > release_bufs;
-    pthread_mutex_t         release_mutex;
+    Mutex                   release_mutex;
 
 #if HAVE_LIBCL
 public:


### PR DESCRIPTION
pthread mutex and cond wasn't init nor destroy in plugin, which
caused random assert failure; use xcam mutex and cond to ensure
init and destroy properly.

btw, this can't fix the flicker issue. still working on that one.