### PR TITLE
video flicker fix & aiq maunal 3a implementation

### DIFF
--- a/wrapper/gstreamer/bufmap.h
+++ b/wrapper/gstreamer/bufmap.h
@@ -36,20 +36,22 @@ public:
     static SmartPtr<BufMap> instance();
 
     GstBuffer* gbuf(SmartPtr<VideoBuffer> &buf) {
-        if (_v2g.find (buf.ptr ()) == _v2g.end ()) { //non-existing
+        XCAM_ASSERT (buf.ptr ());
+        if (_v2g.find (buf->get_fd ()) == _v2g.end ()) { //non-existing
             return NULL;
         }
-        return _v2g[buf.ptr ()];
+        return _v2g[buf->get_fd ()];
     }
-    SmartPtr<VideoBuffer> vbuf(GstBuffer* gbuf) {
+    int vbuf(GstBuffer* gbuf) {
         if (_g2v.find (gbuf) == _g2v.end ()) { //non-existing
             return NULL;
         }
         return _g2v[gbuf];
     }
     void setmap(GstBuffer* gbuf, SmartPtr<VideoBuffer>& buf) {
-        _g2v[gbuf] = buf.ptr ();
-        _v2g[buf.ptr ()] = gbuf;
+        XCAM_ASSERT (buf.ptr ());
+        _g2v[gbuf] = buf->get_fd ();
+        _v2g[buf->get_fd ()] = gbuf;
     }
 
 private:
@@ -61,8 +63,8 @@ private:
     static SmartPtr<BufMap> _instance;
     static Mutex        _mutex;
 
-    std::map <GstBuffer*, VideoBuffer*> _g2v;
-    std::map <VideoBuffer*, GstBuffer*> _v2g;
+    std::map <GstBuffer*, int> _g2v;
+    std::map <int, GstBuffer*> _v2g;
 };
 
 } //namespace

--- a/xcore/aiq_handler.cpp
+++ b/xcore/aiq_handler.cpp
@@ -1352,6 +1352,27 @@ AiqCompositor::apply_gamma_table (struct atomisp_parameters *isp_param)
     return XCAM_RETURN_NO_ERROR;
 }
 
+XCamReturn
+AiqCompositor::apply_night_mode (struct atomisp_parameters *isp_param)
+{
+    static const struct atomisp_cc_config night_yuv2rgb_cc_config = {
+        10,
+        { 1 << 10, 0, 0,  /* 1.0, 0, 0 */
+          1 << 10, 0, 0,  /* 1.0, 0, 0 */
+          1 << 10, 0, 0} }; /* 1.0, 0, 0 */
+    static const struct atomisp_wb_config night_wb_config = {
+        1,
+        1 << 15, 1 << 15, 1 << 15, 1 << 15 }; /* 1.0, 1.0, 1.0, 1.0*/
+
+    if (isp_param->ctc_config)
+        isp_param->ctc_config = NULL;
+
+    *isp_param->wb_config = night_wb_config;
+    *isp_param->yuv2rgb_cc_config = night_yuv2rgb_cc_config;
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
 XCamReturn AiqCompositor::integrate (X3aResultList &results)
 {
     IspInputParameters isp_params;
@@ -1374,11 +1395,18 @@ XCamReturn AiqCompositor::integrate (X3aResultList &results)
 
     xcam_mem_clear (pa_input);
     pa_input.frame_use = _frame_use;
-    pa_input.awb_results = aiq_awb->get_result ();
     if (aiq_ae->is_started())
         pa_input.exposure_params = (aiq_ae->get_result ())->exposures[0].exposure;
     pa_input.sensor_frame_params = &_frame_params;
     pa_input.color_gains = NULL;
+
+    if (aiq_common->_params.enable_night_mode) {
+        pa_input.awb_results = NULL;
+        isp_params.effects = ia_isp_effect_grayscale;
+    }
+    else {
+        pa_input.awb_results = aiq_awb->get_result ();
+    }
 
     ia_error = ia_aiq_pa_run (_ia_handle, &pa_input, &pa_result);
     if (ia_error != ia_err_none) {
@@ -1423,6 +1451,10 @@ XCamReturn AiqCompositor::integrate (X3aResultList &results)
     }
     isp_3a_result = ((struct atomisp_parameters *)output.data);
     apply_gamma_table (isp_3a_result);
+    if (aiq_common->_params.enable_night_mode)
+    {
+        apply_night_mode (isp_3a_result);
+    }
 
     isp_results = generate_3a_configs (isp_3a_result);
     results.push_back (isp_results);

--- a/xcore/aiq_handler.cpp
+++ b/xcore/aiq_handler.cpp
@@ -1345,6 +1345,19 @@ XCamReturn AiqCompositor::integrate (X3aResultList &results)
         XCAM_LOG_WARNING ("AIQ pa run failed"); // but not return error
     }
     _pa_result = pa_result;
+    
+    if (XCAM_DOUBLE_EQUAL_AROUND (aiq_awb->_params.gr_gain, 0.0) ||
+        XCAM_DOUBLE_EQUAL_AROUND (aiq_awb->_params.r_gain, 0.0)  ||
+        XCAM_DOUBLE_EQUAL_AROUND (aiq_awb->_params.b_gain, 0.0)  ||
+        XCAM_DOUBLE_EQUAL_AROUND (aiq_awb->_params.gb_gain, 0.0)) {
+        XCAM_LOG_DEBUG ("Zero gain would cause ISP division fatal error");
+    }
+    else {
+        _pa_result->color_gains[0] = aiq_awb->_params.gr_gain;
+        _pa_result->color_gains[1] = aiq_awb->_params.r_gain;
+        _pa_result->color_gains[2] = aiq_awb->_params.b_gain;
+        _pa_result->color_gains[3] = aiq_awb->_params.gb_gain;
+    }
 
     isp_params.frame_use = _frame_use;
     isp_params.awb_results = aiq_awb->get_result ();

--- a/xcore/aiq_handler.cpp
+++ b/xcore/aiq_handler.cpp
@@ -1312,6 +1312,46 @@ XCamReturn AiqCompositor::convert_color_effect (IspInputParameters &isp_input)
     return XCAM_RETURN_NO_ERROR;
 }
 
+XCamReturn
+AiqCompositor::apply_gamma_table (struct atomisp_parameters *isp_param)
+{
+    if (_common_handler->_params.is_manual_gamma) {
+        int i;
+
+        if (isp_param->r_gamma_table) {
+            isp_param->r_gamma_table->vamem_type = 1; //IA_CSS_VAMEM_TYPE_2 = 1;
+            for (i = 0; i < XCAM_GAMMA_TABLE_SIZE; ++i) {
+                // change from double to u0.12
+                isp_param->r_gamma_table->data.vamem_2[i] =
+                    (uint32_t) (_common_handler->_params.r_gamma[i] * 4096.0);
+            }
+            isp_param->r_gamma_table->data.vamem_2[256] = 4091;
+        }
+
+        if (isp_param->g_gamma_table) {
+            isp_param->g_gamma_table->vamem_type = 1; //IA_CSS_VAMEM_TYPE_2 = 1;
+            for (i = 0; i < XCAM_GAMMA_TABLE_SIZE; ++i) {
+                // change from double to u0.12
+                isp_param->g_gamma_table->data.vamem_2[i] =
+                    (uint32_t) (_common_handler->_params.g_gamma[i] * 4096.0);
+            }
+            isp_param->g_gamma_table->data.vamem_2[256] = 4091;
+        }
+
+        if (isp_param->b_gamma_table) {
+            isp_param->b_gamma_table->vamem_type = 1; //IA_CSS_VAMEM_TYPE_2 = 1;
+            for (i = 0; i < XCAM_GAMMA_TABLE_SIZE; ++i) {
+                // change from double to u0.12
+                isp_param->b_gamma_table->data.vamem_2[i] =
+                    (uint32_t) (_common_handler->_params.b_gamma[i] * 4096.0);
+            }
+            isp_param->b_gamma_table->data.vamem_2[256] = 4091;
+        }
+    }
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
 XCamReturn AiqCompositor::integrate (X3aResultList &results)
 {
     IspInputParameters isp_params;
@@ -1382,6 +1422,8 @@ XCamReturn AiqCompositor::integrate (X3aResultList &results)
         return XCAM_RETURN_ERROR_ISP;
     }
     isp_3a_result = ((struct atomisp_parameters *)output.data);
+    apply_gamma_table (isp_3a_result);
+
     isp_results = generate_3a_configs (isp_3a_result);
     results.push_back (isp_results);
     return XCAM_RETURN_NO_ERROR;

--- a/xcore/aiq_handler.h
+++ b/xcore/aiq_handler.h
@@ -276,6 +276,8 @@ public:
 private:
     XCamReturn apply_gamma_table (struct atomisp_parameters *isp_param);
     XCamReturn apply_night_mode (struct atomisp_parameters *isp_param);
+    XCamReturn limit_nr_levels (struct atomisp_parameters *isp_param);
+    double calculate_value_by_factor (double factor, double min, double mid, double max);
 
     XCAM_DEAD_COPY (AiqCompositor);
 

--- a/xcore/aiq_handler.h
+++ b/xcore/aiq_handler.h
@@ -275,6 +275,7 @@ public:
 
 private:
     XCamReturn apply_gamma_table (struct atomisp_parameters *isp_param);
+    XCamReturn apply_night_mode (struct atomisp_parameters *isp_param);
 
     XCAM_DEAD_COPY (AiqCompositor);
 

--- a/xcore/aiq_handler.h
+++ b/xcore/aiq_handler.h
@@ -274,6 +274,7 @@ public:
     }
 
 private:
+    XCamReturn apply_gamma_table (struct atomisp_parameters *isp_param);
 
     XCAM_DEAD_COPY (AiqCompositor);
 

--- a/xcore/aiq_handler.h
+++ b/xcore/aiq_handler.h
@@ -155,6 +155,7 @@ protected:
 class AiqAwbHandler
     : public AwbHandler
 {
+    friend class AiqCompositor;
 public:
     explicit AiqAwbHandler (SmartPtr<AiqCompositor> &aiq_compositor);
     ~AiqAwbHandler () {}


### PR DESCRIPTION
This is to fix the video flicker issue with both ISP and CL pipelines.

Previously pointer to video buffers were used in bufmap, but it would
cause video flicker issue, as video buffers are created and destroyed
dynamically.