### PR TITLE
refine local preview:

### DIFF
--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -386,8 +386,11 @@ int main (int argc, char *argv[])
     device->set_capture_mode (capture_mode);
     //device->set_mem_type (V4L2_MEMORY_DMABUF);
     device->set_mem_type (v4l2_mem_type);
-    device->set_buffer_count (8);
     device->set_framerate (25, 1);
+    if (need_display)
+        device->set_buffer_count (1);
+    else
+        device->set_buffer_count (8);
     ret = device->open ();
     CHECK (ret, "device(%s) open failed", device->get_device_name());
     ret = device->set_format (1920, 1080, pixel_format, V4L2_FIELD_NONE, 1920 * 2);

--- a/xcore/poll_thread.cpp
+++ b/xcore/poll_thread.cpp
@@ -294,7 +294,7 @@ PollThread::poll_buffer_loop ()
     poll_ret = _capture_dev->poll_event (PollThread::default_capture_event_timeout);
 
     if (poll_ret < 0) {
-        XCAM_LOG_DEBUG ("poll buffer event got error but continue");
+        XCAM_LOG_WARNING ("poll buffer event got error but continue");
         ::usleep (100000); // 100ms
         return XCAM_RETURN_ERROR_TIMEOUT;
     }
@@ -314,6 +314,12 @@ PollThread::poll_buffer_loop ()
     XCAM_ASSERT (_poll_callback);
 
     SmartPtr<V4l2BufferProxy> buf_proxy = new V4l2BufferProxy (buf, _capture_dev);
+
+    ret = _capture_dev->queue_buffer (buf);
+    if (ret != XCAM_RETURN_NO_ERROR) {
+        XCAM_LOG_WARNING ("queue buffer failed");
+        return ret;
+    }
 
     if (_poll_callback)
         return _poll_callback->poll_buffer_ready (buf_proxy);

--- a/xcore/v4l2_buffer_proxy.cpp
+++ b/xcore/v4l2_buffer_proxy.cpp
@@ -66,11 +66,6 @@ V4l2BufferProxy::V4l2BufferProxy (SmartPtr<V4l2Buffer> &buf, SmartPtr<V4l2Device
 
 V4l2BufferProxy::~V4l2BufferProxy ()
 {
-    SmartPtr<BufferData> data = get_buffer_data ();
-    SmartPtr<V4l2Buffer> v4l2_data = data.dynamic_cast_ptr<V4l2Buffer> ();
-    if (_device.ptr () && v4l2_data.ptr ())
-        _device->queue_buffer (v4l2_data);
-    XCAM_LOG_DEBUG ("v4l2 buffer released");
 }
 
 void


### PR DESCRIPTION
* change v4l2 poll buffer fail message back to level warning.
* fix v4l2 warning:"poll buffer event got error but continue".
* set buffer count as 1 to avoid picture shake when use
  teset-device-manager local preview.