### PR TITLE
Temporal Noise Reduction on RGB & YUV domain

### DIFF
--- a/xcore/Makefile.am
+++ b/xcore/Makefile.am
@@ -116,6 +116,7 @@ xcam_sources +=              \
 	cl_gamma_handler.cpp	 \
         cl_snr_handler.cpp       \
 	cl_macc_handler.cpp	 \
+	cl_tnr_handler.cpp	\
 	$(NULL)
 endif
 

--- a/xcore/cl_tnr_handler.h
+++ b/xcore/cl_tnr_handler.h
@@ -45,12 +45,7 @@ public:
                                CLTnrType type);
 
     virtual ~CLTnrImageKernel () {
-        while (_image_in_list.size ()) {
-            XCAM_LOG_DEBUG("~CLTnrImageKernel while loop\n");
-            (_image_in_list.begin ())->release ();
-        }
-
-        _image_out_prev.release ();
+        _image_in_list.clear ();
     }
 
     CLTnrType get_type () {


### PR DESCRIPTION
-> In RGB domain apply order statistics based average filter on sequential frames (3 frames as default)
-> In YUV domain apply IIR filter on currently frame
   f^(i, j, k) = |1- a(i, j, k)| * f^(i, j, k-1) + a(j, j, k) * g(i, j, k) 