### PR TITLE
plugin: add caps filter support

### DIFF
--- a/wrapper/gstreamer/gstxcamsrc.cpp
+++ b/wrapper/gstreamer/gstxcamsrc.cpp
@@ -286,9 +286,7 @@ gst_xcamsrc_start (GstBaseSrc *src)
     capture_device->set_capture_mode (xcamsrc->capture_mode);
     capture_device->set_mem_type (xcamsrc->mem_type);
     capture_device->set_buffer_count (xcamsrc->buf_count);
-    capture_device->set_framerate (xcamsrc->_fps_n, xcamsrc->_fps_d);
     capture_device->open ();
-    capture_device->set_format (xcamsrc->width, xcamsrc->height, xcamsrc->pixelformat, xcamsrc->field, xcamsrc->bytes_perline);
 
     SmartPtr<V4l2SubDevice> event_device = new V4l2SubDevice (DEFAULT_EVENT_DEVICE);
     device_manager->set_event_device (event_device);
@@ -343,8 +341,6 @@ gst_xcamsrc_start (GstBaseSrc *src)
     }
     device_manager->set_analyzer (analyzer);
 
-    device_manager->start ();
-
     return TRUE;
 }
 
@@ -373,18 +369,38 @@ gst_xcambufferpool_new (Gstxcamsrc *xcamsrc, GstCaps *caps);
 static gboolean
 gst_xcamsrc_set_caps (GstBaseSrc *src, GstCaps *caps)
 {
+    GstVideoInfo info;
+    gst_video_info_from_caps (&info, caps);
+
     Gstxcamsrc *xcamsrc = GST_XCAMSRC (src);
 
-    guint32 block_size = DEFAULT_BLOCKSIZE;
     SmartPtr<MainDeviceManager> device_manager = DeviceManagerInstance::device_manager_instance();
-    SmartPtr<V4l2Device> device = device_manager->get_capture_device();
+    SmartPtr<V4l2Device> capture_device = device_manager->get_capture_device ();
+    capture_device->set_framerate (info.fps_n, info.fps_d);
+    capture_device->set_format (info.width, info.height, xcamsrc->pixelformat, xcamsrc->field,  info.stride[0]);
 
+    if (device_manager->start () != XCAM_RETURN_NO_ERROR)
+        return FALSE;
 
+    guint32 block_size = DEFAULT_BLOCKSIZE;
     struct v4l2_format format;
-    device->get_format (format);
+    capture_device->get_format (format);
     block_size = format.fmt.pix.sizeimage;
 
     gst_base_src_set_blocksize (GST_BASE_SRC (xcamsrc), block_size);
+
+    xcamsrc->_video_info = info;
+    gsize offset = 0;
+    for (int n = 0; n < GST_VIDEO_INFO_N_PLANES (&xcamsrc->_video_info); n++) {
+        GST_VIDEO_INFO_PLANE_OFFSET (&xcamsrc->_video_info, n) = offset;
+        if (format.fmt.pix.pixelformat == V4L2_PIX_FMT_NV12) {
+            GST_VIDEO_INFO_PLANE_STRIDE (&xcamsrc->_video_info, n) = format.fmt.pix.bytesperline * 2 / 3;
+        }
+        else {
+            GST_VIDEO_INFO_PLANE_STRIDE (&xcamsrc->_video_info, n) = format.fmt.pix.bytesperline / 2;
+        }
+        offset += GST_VIDEO_INFO_PLANE_STRIDE (&xcamsrc->_video_info, n) * format.fmt.pix.height;
+    }
 
     xcamsrc->duration = gst_util_uint64_scale_int (GST_SECOND, xcamsrc->_fps_d, xcamsrc->_fps_n);
     xcamsrc->pool = gst_xcambufferpool_new ((Gstxcamsrc*)src, caps);

--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -25,6 +25,7 @@
 #include <gst/base/gstpushsrc.h>
 #include <linux/videodev2.h>
 #include <xcam_defs.h>
+#include <gst/video/video.h>
 
 #define DEFAULT_BLOCKSIZE   1843200
 #define CAPTURE_DEVICE_STILL  "/dev/video0"
@@ -106,6 +107,7 @@ struct _Gstxcamsrc
 
     guint64 offset;
 
+    GstVideoInfo _video_info;
 };
 
 struct _GstxcamsrcClass

--- a/xcore/device_manager.cpp
+++ b/xcore/device_manager.cpp
@@ -130,6 +130,11 @@ DeviceManager::set_analyzer (SmartPtr<X3aAnalyzer> analyzer)
 
     XCAM_ASSERT (analyzer.ptr () && !_3a_analyzer.ptr ());
     _3a_analyzer = analyzer;
+    if (_3a_analyzer->create_handlers () != XCAM_RETURN_NO_ERROR) {
+        XCAM_LOG_ERROR ("Failed to create 3a handlers");
+        return false;
+    }
+
     return true;
 }
 
@@ -175,9 +180,13 @@ DeviceManager::start ()
 
         if (!_3a_analyzer.ptr()) {
             _3a_analyzer = X3aAnalyzerManager::instance()->create_analyzer();
-        }
-        if (!_3a_analyzer.ptr()) {
-            XCAM_FAILED_STOP (ret = XCAM_RETURN_ERROR_PARAM, "create analyzer failed");
+            if (!_3a_analyzer.ptr()) {
+                XCAM_FAILED_STOP (ret = XCAM_RETURN_ERROR_PARAM, "create analyzer failed");
+            }
+
+            if (_3a_analyzer->create_handlers () != XCAM_RETURN_NO_ERROR) {
+                XCAM_FAILED_STOP (ret = XCAM_RETURN_ERROR_PARAM, "create handler failed");
+            }
         }
         _3a_analyzer->set_results_callback (this);
 

--- a/xcore/v4l2_buffer_proxy.cpp
+++ b/xcore/v4l2_buffer_proxy.cpp
@@ -49,6 +49,8 @@ V4l2Buffer::unmap ()
 int
 V4l2Buffer::get_fd ()
 {
+    if (_buf.memory == V4L2_MEMORY_MMAP)
+        return NULL;
     return _buf.m.fd;
 }
 

--- a/xcore/x3a_analyzer.cpp
+++ b/xcore/x3a_analyzer.cpp
@@ -161,19 +161,12 @@ X3aAnalyzer::set_results_callback (AnalyzerCallback *callback)
 }
 
 XCamReturn
-X3aAnalyzer::init (uint32_t width, uint32_t height, double framerate)
+X3aAnalyzer::create_handlers ()
 {
-    XCamReturn ret = XCAM_RETURN_NO_ERROR;
     SmartPtr<AeHandler> ae_handler;
     SmartPtr<AwbHandler> awb_handler;
     SmartPtr<AfHandler> af_handler;
     SmartPtr<CommonHandler> common_handler;
-
-
-    XCAM_ASSERT (!_width && !_height);
-    _width = width;
-    _height = height;
-    _framerate = framerate;
 
     XCAM_ASSERT (!_ae_handler.ptr() || !_awb_handler.ptr() ||
                  !_af_handler.ptr() || !_common_handler.ptr());
@@ -185,13 +178,26 @@ X3aAnalyzer::init (uint32_t width, uint32_t height, double framerate)
 
     if (!ae_handler.ptr() || !awb_handler.ptr() || !af_handler.ptr() || !common_handler.ptr()) {
         XCAM_LOG_WARNING ("create handlers failed");
-        deinit ();
         return XCAM_RETURN_ERROR_MEM;
     }
+
     _ae_handler = ae_handler;
     _awb_handler = awb_handler;
     _af_handler = af_handler;
     _common_handler = common_handler;
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+XCamReturn
+X3aAnalyzer::init (uint32_t width, uint32_t height, double framerate)
+{
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+
+    XCAM_ASSERT (!_width && !_height);
+    _width = width;
+    _height = height;
+    _framerate = framerate;
 
     ret = internal_init (width, height, _framerate);
     if (ret != XCAM_RETURN_NO_ERROR) {

--- a/xcore/x3a_analyzer.h
+++ b/xcore/x3a_analyzer.h
@@ -50,6 +50,7 @@ public:
 
     bool set_results_callback (AnalyzerCallback *callback);
 
+    XCamReturn create_handlers ();
     XCamReturn init (uint32_t width, uint32_t height, double framerate);
     XCamReturn deinit ();
     XCamReturn start ();


### PR DESCRIPTION
 * use fd and v4l2 index to track dma and v4l2 buffer respectively
 * set v4l2 format and start device manager in set_caps
 * attach video meta info to gst output buffer
 * enhance X3aAnalyzer to set 3a settings before device manager starts