### PR TITLE
xcamsrc: remove duration since fps not stable

### DIFF
--- a/wrapper/gstreamer/gstxcamsrc.cpp
+++ b/wrapper/gstreamer/gstxcamsrc.cpp
@@ -818,7 +818,7 @@ gst_xcam_src_fill (GstPushSrc *basesrc, GstBuffer *buf)
     }
 
     GST_BUFFER_TIMESTAMP (buf) += src->time_offset;
-    GST_BUFFER_DURATION (buf) = src->duration;
+    //GST_BUFFER_DURATION (buf) = src->duration;
 
     return GST_FLOW_OK;
 }


### PR DESCRIPTION
 * fixed duration may cause issue on muxer if fps not stable