### PR TITLE
denoise: use bitmask to toggle denoise features

### DIFF
--- a/wrapper/gstreamer/gstxcamsrc.cpp
+++ b/wrapper/gstreamer/gstxcamsrc.cpp
@@ -240,7 +240,7 @@ static gboolean gst_xcam_src_set_manual_sharpness (GstXCam3A *xcam3a, guint8 val
 static gboolean gst_xcam_src_set_dvs (GstXCam3A *xcam3a, gboolean enable);
 static gboolean gst_xcam_src_set_night_mode (GstXCam3A *xcam3a, gboolean enable);
 static gboolean gst_xcam_src_set_hdr_mode (GstXCam3A *xcam3a, guint8 mode);
-static gboolean gst_xcam_src_set_denoise_mode (GstXCam3A *xcam3a, guint8 mode);
+static gboolean gst_xcam_src_set_denoise_mode (GstXCam3A *xcam3a, guint32 mode);
 static gboolean gst_xcam_src_set_gamma_mode (GstXCam3A *xcam3a, gboolean enable);
 
 static gboolean gst_xcam_src_plugin_init (GstPlugin * xcamsrc);
@@ -1098,7 +1098,7 @@ gst_xcam_src_set_hdr_mode (GstXCam3A *xcam3a, guint8 mode)
 }
 
 static gboolean
-gst_xcam_src_set_denoise_mode (GstXCam3A *xcam3a, guint8 mode)
+gst_xcam_src_set_denoise_mode (GstXCam3A *xcam3a, guint32 mode)
 {
     GST_XCAM_INTERFACE_HEADER (xcam3a, src, device_manager, analyzer);
     XCAM_UNUSED (analyzer);
@@ -1107,8 +1107,7 @@ gst_xcam_src_set_denoise_mode (GstXCam3A *xcam3a, guint8 mode)
     gboolean ret;
     SmartPtr<CL3aImageProcessor> cl_image_processor = device_manager->get_cl_image_processor ();
     if (cl_image_processor.ptr ()) {
-        ret = cl_image_processor->set_denoise (mode) &&
-              cl_image_processor->set_snr (mode);
+        ret = cl_image_processor->set_denoise (mode);
         return ret;
     }
     else

--- a/wrapper/gstreamer/interface/gstxcaminterface.h
+++ b/wrapper/gstreamer/interface/gstxcaminterface.h
@@ -416,10 +416,16 @@ struct _GstXCam3AInterface {
      * \brief set denoise mode.
      *
      * \param[in,out]    xcam          XCam3A handle
-     * \param[in]        mode          0: disable, 1: simple, 2: bilinear
+     * \param[in]        mode          bit mask to enable/disable denoise functions
+     *                                 each bit controls a specific denoise function, 0: disable, 1: enable
+     *                                   bit 0: simple noise reduction
+     *                                   bit 1: bilateral noise reduction
+     *                                   bit 2: luminance noise reduction and edge enhancement
+     *                                   bit 3: bayer noise reduction
+     *                                   bit 4: advanced bayer noise reduction
      * \return           bool          0 on success
      */
-    gboolean (* set_denoise_mode)               (GstXCam3A *xcam, guint8 mode);
+    gboolean (* set_denoise_mode)               (GstXCam3A *xcam, guint32 mode);
 
     /*!
      * \brief set gamma mode.

--- a/xcore/base/xcam_3a_types.h
+++ b/xcore/base/xcam_3a_types.h
@@ -145,6 +145,14 @@ typedef enum {
     XCAM_COLOR_EFFECT_GRAYSCALE,
 } XCamColorEffect;
 
+typedef enum {
+    XCAM_DENOISE_TYPE_SIMPLE    = (1UL << 0), // simple noise reduction
+    XCAM_DENOISE_TYPE_BILATERAL = (1UL << 1), // bilateral noise reduction
+    XCAM_DENOISE_TYPE_EE        = (1UL << 2), // luminance noise reduction and edge enhancement
+    XCAM_DENOISE_TYPE_BNR       = (1UL << 3), // bayer noise reduction
+    XCAM_DENOISE_TYPE_ANR       = (1UL << 4), // advanced bayer noise reduction
+} XCamDenoiseType;
+
 XCAM_END_DECLARE
 
 #endif //__XCAM_3A_TYPES_H

--- a/xcore/cl_3a_image_processor.h
+++ b/xcore/cl_3a_image_processor.h
@@ -22,6 +22,7 @@
 #define XCAM_CL_3A_IMAGE_PROCESSOR_H
 
 #include "xcam_utils.h"
+#include <base/xcam_3a_types.h>
 #include "cl_image_processor.h"
 #include "stats_callback_interface.h"
 
@@ -60,10 +61,8 @@ public:
     virtual bool set_hdr (uint32_t mode);
     virtual bool set_denoise (uint32_t mode);
     virtual bool set_gamma (bool enable);
-    virtual bool set_snr (uint32_t mode);
     virtual bool set_macc (bool enable);
     virtual bool set_tnr (uint32_t mode, uint8_t level);
-    virtual bool set_ee (bool enable);
 
 protected:
 
@@ -86,24 +85,21 @@ private:
     SmartPtr<CLBayer2RGBImageHandler>  _demosaic;
     SmartPtr<CLHdrImageHandler>        _hdr;
     SmartPtr<CLCscImageHandler>        _csc;
-    SmartPtr<CLDenoiseImageHandler>    _denoise;
     SmartPtr<CLGammaImageHandler>      _gamma;
     SmartPtr<CL3AStatsCalculator>      _x3a_stats_calculator;
     SmartPtr<CLWbImageHandler>         _wb;
-    SmartPtr<CLSnrImageHandler>        _snr;
     SmartPtr<CLMaccImageHandler>       _macc;
     SmartPtr<CLTnrImageHandler>        _tnr_rgb;
     SmartPtr<CLTnrImageHandler>        _tnr_yuv;
-    SmartPtr<CLEeImageHandler>        _ee;
+    SmartPtr<CLSnrImageHandler>        _snr;
+    SmartPtr<CLDenoiseImageHandler>    _binr;
+    SmartPtr<CLEeImageHandler>         _ee;
 
     uint32_t                           _enable_hdr;
-    uint32_t                           _enable_denoise;
-    uint32_t                           _enable_snr;
     uint32_t                           _tnr_mode;
     bool                               _enable_gamma;
     bool                               _enable_macc;
-    bool                               _enable_ee;
-
+    uint32_t                           _snr_mode; // spatial nr mode
 };
 
 };

--- a/xcore/cl_denoise_handler.cpp
+++ b/xcore/cl_denoise_handler.cpp
@@ -83,14 +83,6 @@ CLDenoiseImageHandler::CLDenoiseImageHandler (const char *name)
 }
 
 bool
-CLDenoiseImageHandler::set_mode (uint32_t mode)
-{
-    _bilateral_kernel->set_enable (mode == CL_DENOISE_TYPE_BILATERIAL);
-
-    return true;
-}
-
-bool
 CLDenoiseImageHandler::set_bi_kernel (SmartPtr<CLDenoiseImageKernel> &kernel)
 {
     SmartPtr<CLImageKernel> image_kernel = kernel;

--- a/xcore/cl_denoise_handler.h
+++ b/xcore/cl_denoise_handler.h
@@ -25,12 +25,6 @@
 
 namespace XCam {
 
-enum CLDenoiseType {
-    CL_DENOISE_DISABLE = 0,
-    CL_DENOISE_TYPE_SIMPLE,
-    CL_DENOISE_TYPE_BILATERIAL,
-};
-
 class CLDenoiseImageKernel
     : public CLImageKernel
 {
@@ -56,7 +50,7 @@ class CLDenoiseImageHandler
 {
 public:
     explicit CLDenoiseImageHandler (const char *name);
-    bool set_mode (uint32_t mode);
+    bool set_enable (bool enable);
 
     bool set_bi_kernel (SmartPtr<CLDenoiseImageKernel> &kernel);
 

--- a/xcore/cl_snr_handler.cpp
+++ b/xcore/cl_snr_handler.cpp
@@ -79,14 +79,6 @@ CLSnrImageHandler::set_simple_kernel(SmartPtr<CLSnrImageKernel> &kernel)
     return true;
 }
 
-bool
-CLSnrImageHandler::set_mode (uint32_t mode)
-{
-    _simple_kernel->set_enable (mode == CL_DENOISE_TYPE_SIMPLE);
-
-    return true;
-}
-
 SmartPtr<CLImageHandler>
 create_cl_snr_image_handler (SmartPtr<CLContext> &context)
 {

--- a/xcore/cl_snr_handler.h
+++ b/xcore/cl_snr_handler.h
@@ -50,7 +50,6 @@ class CLSnrImageHandler
 public:
     explicit CLSnrImageHandler (const char *name);
     bool set_simple_kernel(SmartPtr<CLSnrImageKernel> &kernel);
-    bool set_mode (uint32_t mode);
 
 private:
     XCAM_DEAD_COPY (CLSnrImageHandler);


### PR DESCRIPTION
 * use bitmask to set combined denoise modes via 3A interface
 * snr/bilateral's set_enable() is removed; set_kernels_enable
   can be used instead to enable/disable them