### PR TITLE
cl: enable Defect Pixel Correction for CL path

### DIFF
--- a/3alib/aiq3a_utils.cpp
+++ b/3alib/aiq3a_utils.cpp
@@ -172,6 +172,21 @@ translate_atomisp_parameters (
         results[result_count++] = (XCam3aResultHead*)macc;
     }
 
+    /* Translation for defect pixel correction */
+    XCAM_ASSERT (result_count < max_count);
+    if (atomisp_params.dp_config) {
+        XCam3aResultDefectPixel *dpc = xcam_malloc0_type (XCam3aResultDefectPixel);
+        dpc->head.type = XCAM_3A_RESULT_DEFECT_PIXEL_CORRECTION;
+        dpc->head.process_type = XCAM_IMAGE_PROCESS_ALWAYS;
+        dpc->head.version = XCAM_VERSION;
+        coefficient = pow (2, 16);
+        dpc->gr_threshold = atomisp_params.dp_config->threshold / coefficient;
+        dpc->r_threshold = atomisp_params.dp_config->threshold / coefficient;
+        dpc->b_threshold = atomisp_params.dp_config->threshold / coefficient;
+        dpc->gb_threshold = atomisp_params.dp_config->threshold / coefficient;
+        results[result_count++] = (XCam3aResultHead*)dpc;
+    }
+
     return result_count;
 }
 

--- a/cl_kernel/kernel_dpc.cl
+++ b/cl_kernel/kernel_dpc.cl
@@ -1,0 +1,85 @@
+/*
+ * function: kernel_dpc
+ *     defect pixel correction on bayer data input
+ * input:    image2d_t as read only
+ * output:   image2d_t as write only
+ * gr_threshold:   GR threshold of defect pixel correction
+ * r_threshold:    R threshold of defect pixel correction
+ * b_threshold:    B threshold of defect pixel correction
+ * gb_threshold:   GB threshold of defect pixel correction
+ * param:
+ */
+
+__kernel void kernel_dpc (__read_only image2d_t input,
+                          __write_only image2d_t output,
+                          float gr_threshold, float r_threshold,
+                          float b_threshold, float gb_threshold)
+{
+    int x = get_global_id (0);
+    int y = get_global_id (1);
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+    float4 p[9];
+    p[0] = read_imagef(input, sampler, (int2)(x - 2, y - 2));
+    p[1] = read_imagef(input, sampler, (int2)(x, y - 2));
+    p[2] = read_imagef(input, sampler, (int2)(x + 2, y - 2));
+    p[3] = read_imagef(input, sampler, (int2)(x - 2, y));
+    p[4] = read_imagef(input, sampler, (int2)(x, y));
+    p[5] = read_imagef(input, sampler, (int2)(x + 2, y));
+    p[6] = read_imagef(input, sampler, (int2)(x - 2, y + 2));
+    p[7] = read_imagef(input, sampler, (int2)(x, y + 2));
+    p[8] = read_imagef(input, sampler, (int2)(x + 2, y + 2));
+
+    float aveVer = (p[1].x + p[7].x) / 2;
+    float aveHor = (p[3].x + p[5].x) / 2;
+    float avePosDia = (p[0].x + p[8].x) / 2;
+    float aveNegDia = (p[2].x + p[6].x) / 2;
+
+    float aveMin, aveMax;
+    if (aveVer > aveHor)  {
+        aveMin = aveHor;
+        aveMax = aveVer;
+    }
+    else {
+        aveMin = aveVer;
+        aveMax = aveHor;
+    }
+
+    if (avePosDia < aveMin)
+        aveMin = avePosDia;
+    else if (avePosDia > aveMax)
+        aveMax = avePosDia;
+
+    if (aveNegDia < aveMin)
+        aveMin = aveNegDia;
+    else if (aveNegDia > aveMax)
+        aveMax = aveNegDia;
+
+    float edgeVer = p[4].x - aveVer;
+    float edgeHor = p[4].x - aveHor;
+    float edgeNeighbourVer = (p[3].x + p[5].x - (p[0].x + p[2].x + p[6].x + p[8].x) / 2) / 2;
+    float edgeNeighbourHor = (p[1].x + p[7].x - (p[0].x + p[2].x + p[6].x + p[8].x) / 2) / 2;
+
+    float threshold;
+    if (x % 2 == 0)
+        threshold = (y % 2 == 0) ? gr_threshold : b_threshold;
+    else
+        threshold = (y % 2 == 0) ? r_threshold : gb_threshold;
+
+    float4 pixelOut;
+    pixelOut.x = p[4].x;
+    pixelOut.y = p[4].y;
+    pixelOut.z = p[4].z;
+    pixelOut.w = p[4].w;
+    if ((edgeVer > edgeNeighbourVer) && (edgeHor > edgeNeighbourHor))  {
+        if ((p[4].x - aveMax) > threshold)  {
+            pixelOut.x = aveMax;
+        }
+    }
+    if ((edgeVer < edgeNeighbourVer) && (edgeHor < edgeNeighbourHor))  {
+        if ((aveMin - p[4].x) > threshold)  {
+            pixelOut.x = aveMin;
+        }
+    }
+
+    write_imagef (output, (int2)(x, y), pixelOut);
+}

--- a/clx_kernel/Makefile.am
+++ b/clx_kernel/Makefile.am
@@ -18,6 +18,7 @@ clx_kernel_sources = \
 	kernel_tnr_yuv.clx            \
 	kernel_wb.clx                 \
 	kernel_ee.clx              \
+        kernel_dpc.clx              \
 	$(NULL)
 
 cl_quote_sh = \

--- a/tests/test-cl-image.cpp
+++ b/tests/test-cl-image.cpp
@@ -33,6 +33,7 @@
 #include "cl_snr_handler.h"
 #include "cl_macc_handler.h"
 #include "cl_ee_handler.h"
+#include "cl_dpc_handler.h"
 
 using namespace XCam;
 
@@ -286,8 +287,20 @@ int main (int argc, char *argv[])
         blc_handler->set_blc_config (blc);
         break;
     }
-    case TestHandlerDefect:
+    case TestHandlerDefect:  {
+        XCam3aResultDefectPixel dpc;
+        dpc.r_threshold = 0.125;
+        dpc.gr_threshold = 0.125;
+        dpc.gb_threshold = 0.125;
+        dpc.b_threshold = 0.125;
+        image_handler = create_cl_dpc_image_handler (context);
+        SmartPtr<CLDpcImageHandler> dpc_handler;
+        dpc_handler = image_handler.dynamic_cast_ptr<CLDpcImageHandler> ();
+        XCAM_ASSERT (dpc_handler.ptr ());
+        dpc_handler->set_dpc_config (dpc);
         break;
+    }
+    break;
     case TestHandlerDemosaic: {
         SmartPtr<CLBayer2RGBImageHandler> ba2rgb_handler;
         image_handler = create_cl_demosaic_image_handler (context);

--- a/xcore/Makefile.am
+++ b/xcore/Makefile.am
@@ -119,6 +119,7 @@ xcam_sources +=              \
 	cl_macc_handler.cpp	 \
 	cl_tnr_handler.cpp	\
 	cl_ee_handler.cpp	 \
+        cl_dpc_handler.cpp       \
 	$(NULL)
 endif
 

--- a/xcore/base/xcam_3a_result.h
+++ b/xcore/base/xcam_3a_result.h
@@ -148,7 +148,10 @@ typedef struct _XCam3aResultDefectPixel {
 
     /* data */
     double           gain;
-    double           threshold;
+    double           gr_threshold;
+    double           r_threshold;
+    double           b_threshold;
+    double           gb_threshold;
 } XCam3aResultDefectPixel;
 
 typedef struct _XCam3aResultNoiseReduction {

--- a/xcore/cl_3a_image_processor.cpp
+++ b/xcore/cl_3a_image_processor.cpp
@@ -31,6 +31,7 @@
 #include "cl_macc_handler.h"
 #include "cl_tnr_handler.h"
 #include "cl_ee_handler.h"
+#include "cl_dpc_handler.h"
 
 namespace XCam {
 
@@ -156,7 +157,10 @@ CL3aImageProcessor::apply_3a_result (SmartPtr<X3aResult> &result)
 
     case XCAM_3A_RESULT_DEFECT_PIXEL_CORRECTION: {
         SmartPtr<X3aDefectPixelResult> def_res = result.dynamic_cast_ptr<X3aDefectPixelResult> ();
-        //XCAM_ASSERT (def_res.ptr ());
+        XCAM_ASSERT (def_res.ptr ());
+        if (!_dpc.ptr())
+            break;
+        _dpc->set_dpc_config (def_res->get_standard_result ());
         break;
     }
 
@@ -242,6 +246,15 @@ CL3aImageProcessor::create_handlers ()
         image_handler.ptr (),
         XCAM_RETURN_ERROR_CL,
         "CL3aImageProcessor create blc handler failed");
+    add_handler (image_handler);
+
+    image_handler = create_cl_dpc_image_handler (context);
+    _dpc = image_handler.dynamic_cast_ptr<CLDpcImageHandler> ();;
+    XCAM_FAIL_RETURN (
+        WARNING,
+        image_handler.ptr (),
+        XCAM_RETURN_ERROR_CL,
+        "CL3aImageProcessor create dpc handler failed");
     add_handler (image_handler);
 
     image_handler = create_cl_3a_stats_image_handler (context);

--- a/xcore/cl_3a_image_processor.h
+++ b/xcore/cl_3a_image_processor.h
@@ -40,6 +40,7 @@ class CLSnrImageHandler;
 class CLBlcImageHandler;
 class CLTnrImageHandler;
 class CLEeImageHandler;
+class CLDpcImageHandler;
 
 class CL3aImageProcessor
     : public CLImageProcessor
@@ -94,6 +95,7 @@ private:
     SmartPtr<CLSnrImageHandler>        _snr;
     SmartPtr<CLDenoiseImageHandler>    _binr;
     SmartPtr<CLEeImageHandler>         _ee;
+    SmartPtr<CLDpcImageHandler>        _dpc;
 
     uint32_t                           _enable_hdr;
     uint32_t                           _tnr_mode;

--- a/xcore/cl_dpc_handler.cpp
+++ b/xcore/cl_dpc_handler.cpp
@@ -1,0 +1,136 @@
+/*
+ * cl_dpc_handler.cpp - CL defect pixel correction handler
+ *
+ *  Copyright (c) 2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Shincy Tu <shincy.tu@intel.com>
+ */
+#include "xcam_utils.h"
+#include "cl_dpc_handler.h"
+
+namespace XCam {
+
+CLDpcImageKernel::CLDpcImageKernel (SmartPtr<CLContext> &context)
+    : CLImageKernel (context, "kernel_dpc")
+{
+    _dpc_config.gain = XCAM_CL_DPC_DEFAULT_GAIN;
+    _dpc_config.r_threshold = XCAM_CL_DPC_DEFAULT_THRESHOLD;
+    _dpc_config.gr_threshold = XCAM_CL_DPC_DEFAULT_THRESHOLD;
+    _dpc_config.gb_threshold = XCAM_CL_DPC_DEFAULT_THRESHOLD;
+    _dpc_config.b_threshold = XCAM_CL_DPC_DEFAULT_THRESHOLD;
+}
+
+XCamReturn
+CLDpcImageKernel::prepare_arguments (
+    SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
+    CLArgument args[], uint32_t &arg_count,
+    CLWorkSize &work_size)
+{
+    SmartPtr<CLContext> context = get_context ();
+
+    _image_in = new CLVaImage (context, input);
+    _image_out = new CLVaImage (context, output);
+
+    XCAM_ASSERT (_image_in->is_valid () && _image_out->is_valid ());
+    XCAM_FAIL_RETURN (
+        WARNING,
+        _image_in->is_valid () && _image_out->is_valid (),
+        XCAM_RETURN_ERROR_MEM,
+        "cl image kernel(%s) in/out memory not available", get_kernel_name ());
+
+    //set args;
+    args[0].arg_adress = &_image_in->get_mem_id ();
+    args[0].arg_size = sizeof (cl_mem);
+    args[1].arg_adress = &_image_out->get_mem_id ();
+    args[1].arg_size = sizeof (cl_mem);
+    args[2].arg_adress = &_dpc_config.gr_threshold;
+    args[2].arg_size = sizeof (cl_float);
+    args[3].arg_adress = &_dpc_config.r_threshold;
+    args[3].arg_size = sizeof (cl_float);
+    args[4].arg_adress = &_dpc_config.b_threshold;
+    args[4].arg_size = sizeof (cl_float);
+    args[5].arg_adress = &_dpc_config.gb_threshold;
+    args[5].arg_size = sizeof (cl_float);
+    arg_count = 6;
+
+    const CLImageDesc out_info = _image_out->get_image_desc ();
+    work_size.dim = XCAM_DEFAULT_IMAGE_DIM;
+    work_size.global[0] = out_info.width;
+    work_size.global[1] = out_info.height;
+    work_size.local[0] = 8;
+    work_size.local[1] = 4;
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+bool
+CLDpcImageKernel::set_dpc (CLDPCConfig dpc)
+{
+    _dpc_config = dpc;
+    return true;
+}
+CLDpcImageHandler::CLDpcImageHandler (const char *name)
+    : CLImageHandler (name)
+{
+}
+
+bool
+CLDpcImageHandler::set_dpc_config (XCam3aResultDefectPixel dpc)
+{
+    CLDPCConfig _dpc_config;
+    _dpc_config.gr_threshold = (float)dpc.gr_threshold;
+    _dpc_config.r_threshold = (float)dpc.r_threshold;
+    _dpc_config.b_threshold = (float)dpc.b_threshold;
+    _dpc_config.gb_threshold = (float)dpc.gb_threshold;
+    _dpc_kernel->set_dpc(_dpc_config);
+    return true;
+}
+
+bool
+CLDpcImageHandler::set_dpc_kernel(SmartPtr<CLDpcImageKernel> &kernel)
+{
+    SmartPtr<CLImageKernel> image_kernel = kernel;
+    add_kernel (image_kernel);
+    _dpc_kernel = kernel;
+    return true;
+}
+
+SmartPtr<CLImageHandler>
+create_cl_dpc_image_handler (SmartPtr<CLContext> &context)
+{
+    SmartPtr<CLDpcImageHandler> dpc_handler;
+    SmartPtr<CLDpcImageKernel> dpc_kernel;
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+
+    dpc_kernel = new CLDpcImageKernel (context);
+    {
+        XCAM_CL_KERNEL_FUNC_SOURCE_BEGIN(kernel_dpc)
+#include "kernel_dpc.clx"
+        XCAM_CL_KERNEL_FUNC_END;
+        ret = dpc_kernel->load_from_source (kernel_dpc_body, strlen (kernel_dpc_body));
+        XCAM_FAIL_RETURN (
+            WARNING,
+            ret == XCAM_RETURN_NO_ERROR,
+            NULL,
+            "CL image handler(%s) load source failed", dpc_kernel->get_kernel_name());
+    }
+    XCAM_ASSERT (dpc_kernel->is_valid ());
+    dpc_handler = new CLDpcImageHandler ("cl_handler_dpc");
+    dpc_handler->set_dpc_kernel (dpc_kernel);
+
+    return dpc_handler;
+}
+
+};

--- a/xcore/cl_dpc_handler.h
+++ b/xcore/cl_dpc_handler.h
@@ -1,0 +1,77 @@
+/*
+ * cl_dpc_handler.h - CL defect pixel correction handler
+ *
+ *  Copyright (c) 2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Shincy Tu <shincy.tu@intel.com>
+ */
+
+#ifndef XCAM_CL_DPC_HANLDER_H
+#define XCAM_CL_DPC_HANLDER_H
+
+#include "xcam_utils.h"
+#include "cl_image_handler.h"
+#include "base/xcam_3a_result.h"
+
+namespace XCam {
+
+#define XCAM_CL_DPC_DEFAULT_GAIN 1.0
+#define XCAM_CL_DPC_DEFAULT_THRESHOLD 0.125
+
+typedef struct {
+    cl_float gain;   /* The sensitivity of mis-correction.     */
+    cl_float  gr_threshold;  /* GR threshold of defect pixel correction */
+    cl_float  r_threshold;   /* R threshold of defect pixel correction */
+    cl_float  b_threshold;   /* B threshold of defect pixel correction */
+    cl_float  gb_threshold;   /* GB  threshold of defect pixel correction */
+} CLDPCConfig;
+
+class CLDpcImageKernel
+    : public CLImageKernel
+{
+public:
+    explicit CLDpcImageKernel (SmartPtr<CLContext> &context);
+    bool set_dpc (CLDPCConfig dpc);
+
+protected:
+    virtual XCamReturn prepare_arguments (
+        SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
+        CLArgument args[], uint32_t &arg_count,
+        CLWorkSize &work_size);
+
+private:
+    XCAM_DEAD_COPY (CLDpcImageKernel);
+    CLDPCConfig _dpc_config;
+};
+
+class CLDpcImageHandler
+    : public CLImageHandler
+{
+public:
+    explicit CLDpcImageHandler (const char *name);
+    bool set_dpc_config (XCam3aResultDefectPixel dpc);
+    bool set_dpc_kernel(SmartPtr<CLDpcImageKernel> &kernel);
+
+private:
+    XCAM_DEAD_COPY (CLDpcImageHandler);
+    SmartPtr<CLDpcImageKernel> _dpc_kernel;
+};
+
+SmartPtr<CLImageHandler>
+create_cl_dpc_image_handler (SmartPtr<CLContext> &context);
+
+};
+
+#endif //XCAM_CL_DPC_HANLDER_H


### PR DESCRIPTION
command is:
 ./test-cl-image -t defect -f ba10 -i capture_buffer.raw -o dpc.raw