### PR TITLE
bilateral performance tuning: SLM method

### DIFF
--- a/cl_kernel/kernel_denoise.cl
+++ b/cl_kernel/kernel_denoise.cl
@@ -8,727 +8,139 @@
  * imh:      image height, used for edge detect
  */
 
+__constant float gausssingle[25]={0.6411,0.7574,0.8007,0.7574,0.6411,0.7574,0.8948,0.9459,0.8948,0.7574,0.8007,0.94595945,1,0.9459,0.8007,0.7574,0.8948,0.9459,0.8948,0.7574,0.6411,0.7574,0.8007,0.7574,0.6411};
+
+#define LOCAL_SIZE_X 16
+#define LOCAL_SIZE_Y 15
 
 __kernel void kernel_denoise(__read_only image2d_t srcRGB, __write_only image2d_t dstRGB, float sigma_r, unsigned int imw, unsigned int imh)
 {
-    int x = 4 * get_global_id(1);
-    int y = get_global_id(0);
-    float normF;
-    float normF1;
-    float normF2;
-    float normF3;
-    float H;
-    float delta;
-    int i = 0;
-    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE | CLK_FILTER_NEAREST;
-    sigma_r = 2 * pown(sigma_r, 2);
+    int x = get_global_id(1);    //[0,imw-1]
+    int y = get_global_id(0);    //[0,imh-1]
+    int localX = get_local_id(1);    //[0,imw/120-1]
+    int localY = get_local_id(0);    //[0,imh/72-1]
+    //printf("localX=%d,localY=%d\n",localX,localY);
 
-    float4 line, line1;
-    float4 line2, line3;
-    float4 line4, line5;
-    float4 line6, line7;
-    float4 tmp[2];
+    float normF=0;
+    float H=0;
+    float delta=0;
+    int i=0,j=0;
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE |CLK_FILTER_NEAREST;
+    sigma_r = 2*pown(sigma_r,2);
 
-    line = read_imagef(srcRGB, sampler, (int2)(x, y));
-    line2 = read_imagef(srcRGB, sampler, (int2)(x + 1, y));
-    line4 = read_imagef(srcRGB, sampler, (int2)(x + 2, y));
-    line6 = read_imagef(srcRGB, sampler, (int2)(x + 3, y));
+    //coord in srcY
+    float4 line;
+    line.x=0;
+    line.y=0;
+    line.z=0;
+    line.w=1.0;
 
-    if (x > 2 &&
-            x < (imw - 6) &&
-            y > 2 &&
-            y < (imh - 3))
+    __local float4 pixel[LOCAL_SIZE_X+4][LOCAL_SIZE_Y+4];
+    bool interior = x > 1 && x <(imw-3)
+    && y>1 && y< (imh-3);
+    if(interior)
     {
+        pixel[localX+2][localY+2]=read_imagef(srcRGB, sampler,(int2)(x,y));
 
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x - 2, y - 2));
-        delta = pown(tmp[0].x - line.x, 2) + pown(tmp[0].y - line.y, 2) + pown(tmp[0].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line1.x = tmp[0].x * H;
-        line1.y = tmp[0].y * H;
-        line1.z = tmp[0].z * H;
-        normF = H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x - 2, y - 1));
-        delta = pown(tmp[1].x - line.x, 2) + pown(tmp[1].y - line.y, 2) + pown(tmp[1].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line1.x += tmp[1].x * H;
-        line1.y += tmp[1].y * H;
-        line1.z += tmp[1].z * H;
-        normF += H;
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x - 2, y));
-        delta = pown(tmp[0].x - line.x, 2) + pown(tmp[0].y - line.y, 2) + pown(tmp[0].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.8077;
-        line1.x += tmp[0].x * H;
-        line1.y += tmp[0].y * H;
-        line1.z += tmp[0].z * H;
-        normF += H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x - 2, y + 1));
-        delta = pown(tmp[1].x - line.x, 2) + pown(tmp[1].y - line.y, 2) + pown(tmp[1].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line1.x += tmp[1].x * H;
-        line1.y += tmp[1].y * H;
-        line1.z += tmp[1].z * H;
-        normF += H;
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x - 2, y + 2));
-        delta = pown(tmp[0].x - line.x, 2) + pown(tmp[0].y - line.y, 2) + pown(tmp[0].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line1.x += tmp[0].x * H;
-        line1.y += tmp[0].y * H;
-        line1.z += tmp[0].z * H;
-        normF += H;
-
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x - 1, y - 2));
-        delta = pown(tmp[1].x - line.x, 2) + pown(tmp[1].y - line.y, 2) + pown(tmp[1].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line1.x += tmp[1].x * H;
-        line1.y += tmp[1].y * H;
-        line1.z += tmp[1].z * H;
-        normF += H;
-        delta = pown(tmp[1].x - line2.x, 2) + pown(tmp[1].y - line2.y, 2) + pown(tmp[1].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line3.x = tmp[1].x * H;
-        line3.y = tmp[1].y * H;
-        line3.z = tmp[1].z * H;
-        normF1 = H;
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x - 1, y - 1));
-        delta = pown(tmp[0].x - line.x, 2) + pown(tmp[0].y - line.y, 2) + pown(tmp[0].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line1.x += tmp[0].x * H;
-        line1.y += tmp[0].y * H;
-        line1.z += tmp[0].z * H;
-        normF += H;
-        delta = pown(tmp[0].x - line2.x, 2) + pown(tmp[0].y - line2.y, 2) + pown(tmp[0].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line3.x += tmp[0].x * H;
-        line3.y += tmp[0].y * H;
-        line3.z += tmp[0].z * H;
-        normF1 += H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x - 1, y));
-        delta = pown(tmp[1].x - line.x, 2) + pown(tmp[1].y - line.y, 2) + pown(tmp[1].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.9459;
-        line1.x += tmp[1].x * H;
-        line1.y += tmp[1].y * H;
-        line1.z += tmp[1].z * H;
-        normF += H;
-        delta = pown(tmp[1].x - line2.x, 2) + pown(tmp[1].y - line2.y, 2) + pown(tmp[1].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line3.x += tmp[1].x * H;
-        line3.y += tmp[1].y * H;
-        line3.z += tmp[1].z * H;
-        normF1 += H;
-
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x - 1, y + 1));
-        delta = pown(tmp[0].x - line.x, 2) + pown(tmp[0].y - line.y, 2) + pown(tmp[0].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line1.x += tmp[0].x * H;
-        line1.y += tmp[0].y * H;
-        line1.z += tmp[0].z * H;
-        normF += H;
-        delta = pown(tmp[0].x - line2.x, 2) + pown(tmp[0].y - line2.y, 2) + pown(tmp[0].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line3.x += tmp[0].x * H;
-        line3.y += tmp[0].y * H;
-        line3.z += tmp[0].z * H;
-        normF1 += H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x - 1, y + 2));
-        delta = pown(tmp[1].x - line.x, 2) + pown(tmp[1].y - line.y, 2) + pown(tmp[1].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line1.x += tmp[1].x * H;
-        line1.y += tmp[1].y * H;
-        line1.z += tmp[1].z * H;
-        normF += H;
-        delta = pown(tmp[1].x - line2.x, 2) + pown(tmp[1].y - line2.y, 2) + pown(tmp[1].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line3.x += tmp[1].x * H;
-        line3.y += tmp[1].y * H;
-        line3.z += tmp[1].z * H;
-        normF1 += H;
-
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x, y - 2));
-        delta = pown(tmp[0].x - line.x, 2) + pown(tmp[0].y - line.y, 2) + pown(tmp[0].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line1.x += tmp[0].x * H;
-        line1.y += tmp[0].y * H;
-        line1.z += tmp[0].z * H;
-        normF += H;
-        delta = pown(tmp[0].x - line2.x, 2) + pown(tmp[0].y - line2.y, 2) + pown(tmp[0].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line3.x += tmp[0].x * H;
-        line3.y += tmp[0].y * H;
-        line3.z += tmp[0].z * H;
-        normF1 += H;
-        delta = pown(tmp[0].x - line4.x, 2) + pown(tmp[0].y - line4.y, 2) + pown(tmp[0].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line5.x = tmp[0].x * H;
-        line5.y = tmp[0].y * H;
-        line5.z = tmp[0].z * H;
-        normF2 = H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x, y - 1));
-        delta = pown(tmp[1].x - line.x, 2) + pown(tmp[1].y - line.y, 2) + pown(tmp[1].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.94595945;
-        line1.x += tmp[1].x * H;
-        line1.y += tmp[1].y * H;
-        line1.z += tmp[1].z * H;
-        normF += H;
-        delta = pown(tmp[1].x - line2.x, 2) + pown(tmp[1].y - line2.y, 2) + pown(tmp[1].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line3.x += tmp[1].x * H;
-        line3.y += tmp[1].y * H;
-        line3.z += tmp[1].z * H;
-        normF1 += H;
-        delta = pown(tmp[1].x - line4.x, 2) + pown(tmp[1].y - line4.y, 2) + pown(tmp[1].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line5.x += tmp[1].x * H;
-        line5.y += tmp[1].y * H;
-        line5.z += tmp[1].z * H;
-        normF2 += H;
-
-        line1.x += line.x;
-        line1.y += line.y;
-        line1.z += line.z;
-        normF += 1;
-        delta = pown(line.x - line2.x, 2) + pown(line.y - line2.y, 2) + pown(line.z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.9459;
-        line3.x += line.x * H;
-        line3.y += line.y * H;
-        line3.z += line.z * H;
-        normF1 += H;
-        delta = pown(line.x - line4.x, 2) + pown(line.y - line4.y, 2) + pown(line.z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line5.x += line.x * H;
-        line5.y += line.y * H;
-        line5.z += line.z * H;
-        normF2 += H;
-
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x, y + 1));
-        delta = pown(tmp[0].x - line.x, 2) + pown(tmp[0].y - line.y, 2) + pown(tmp[0].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.94595945;
-        line1.x += tmp[0].x * H;
-        line1.y += tmp[0].y * H;
-        line1.z += tmp[0].z * H;
-        normF += H;
-        delta = pown(tmp[0].x - line2.x, 2) + pown(tmp[0].y - line2.y, 2) + pown(tmp[0].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line3.x += tmp[0].x * H;
-        line3.y += tmp[0].y * H;
-        line3.z += tmp[0].z * H;
-        normF1 += H;
-        delta = pown(tmp[0].x - line4.x, 2) + pown(tmp[0].y - line4.y, 2) + pown(tmp[0].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line5.x += tmp[0].x * H;
-        line5.y += tmp[0].y * H;
-        line5.z += tmp[0].z * H;
-        normF2 += H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x, y + 2));
-        delta = pown(tmp[1].x - line.x, 2) + pown(tmp[1].y - line.y, 2) + pown(tmp[1].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line1.x += tmp[1].x * H;
-        line1.y += tmp[1].y * H;
-        line1.z += tmp[1].z * H;
-        normF += H;
-        delta = pown(tmp[1].x - line2.x, 2) + pown(tmp[1].y - line2.y, 2) + pown(tmp[1].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line3.x += tmp[1].x * H;
-        line3.y += tmp[1].y * H;
-        line3.z += tmp[1].z * H;
-        normF1 += H;
-        delta = pown(tmp[1].x - line4.x, 2) + pown(tmp[1].y - line4.y, 2) + pown(tmp[1].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line5.x += tmp[1].x * H;
-        line5.y += tmp[1].y * H;
-        line5.z += tmp[1].z * H;
-        normF2 += H;
-
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x + 1, y - 2));
-        delta = pown(tmp[0].x - line.x, 2) + pown(tmp[0].y - line.y, 2) + pown(tmp[0].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line1.x += tmp[0].x * H;
-        line1.y += tmp[0].y * H;
-        line1.z += tmp[0].z * H;
-        normF += H;
-        delta = pown(tmp[0].x - line2.x, 2) + pown(tmp[0].y - line2.y, 2) + pown(tmp[0].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line3.x += tmp[0].x * H;
-        line3.y += tmp[0].y * H;
-        line3.z += tmp[0].z * H;
-        normF1 += H;
-        delta = pown(tmp[0].x - line4.x, 2) + pown(tmp[0].y - line4.y, 2) + pown(tmp[0].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line5.x += tmp[0].x * H;
-        line5.y += tmp[0].y * H;
-        line5.z += tmp[0].z * H;
-        normF2 += H;
-        delta = pown(tmp[0].x - line6.x, 2) + pown(tmp[0].y - line6.y, 2) + pown(tmp[0].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line7.x += tmp[0].x * H;
-        line7.y += tmp[0].y * H;
-        line7.z += tmp[0].z * H;
-        normF3 += H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x + 1, y - 1));
-        delta = pown(tmp[1].x - line.x, 2) + pown(tmp[1].y - line.y, 2) + pown(tmp[1].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line1.x += tmp[1].x * H;
-        line1.y += tmp[1].y * H;
-        line1.z += tmp[1].z * H;
-        normF += H;
-        delta = pown(tmp[1].x - line4.x, 2) + pown(tmp[1].y - line4.y, 2) + pown(tmp[1].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line5.x += tmp[1].x * H;
-        line5.y += tmp[1].y * H;
-        line5.z += tmp[1].z * H;
-        normF2 += H;
-        delta = pown(tmp[1].x - line6.x, 2) + pown(tmp[1].y - line6.y, 2) + pown(tmp[1].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line7.x += tmp[1].x * H;
-        line7.y += tmp[1].y * H;
-        line7.z += tmp[1].z * H;
-        normF3 += H;
-
-
-        delta = pown(line2.x - line.x, 2) + pown(line2.y - line.y, 2) + pown(line2.z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.9459;
-        line1.x += tmp[0].x * H;
-        line1.y += tmp[0].y * H;
-        line1.z += tmp[0].z * H;
-        normF += H;
-        line3.x += line2.x;
-        line3.y += line2.y;
-        line3.z += line2.z;
-        normF1 += 1;
-        delta = pown(line2.x - line4.x, 2) + pown(line2.y - line4.y, 2) + pown(line2.z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.9459;
-        line5.x += tmp[0].x * H;
-        line5.y += tmp[0].y * H;
-        line5.z += tmp[0].z * H;
-        normF2 += H;
-        delta = pown(line2.x - line6.x, 2) + pown(line2.y - line6.y, 2) + pown(line2.z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line7.x += tmp[0].x * H;
-        line7.y += tmp[0].y * H;
-        line7.z += tmp[0].z * H;
-        normF3 += H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x + 1, y + 1));
-        delta = pown(tmp[1].x - line.x, 2) + pown(tmp[1].y - line.y, 2) + pown(tmp[1].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line1.x += tmp[1].x * H;
-        line1.y += tmp[1].y * H;
-        line1.z += tmp[1].z * H;
-        normF += H;
-        delta = pown(tmp[1].x - line2.x, 2) + pown(tmp[1].y - line2.y, 2) + pown(tmp[1].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.94595945;
-        line3.x += tmp[1].x * H;
-        line3.y += tmp[1].y * H;
-        line3.z += tmp[1].z * H;
-        normF1 += H;
-        delta = pown(tmp[1].x - line4.x, 2) + pown(tmp[1].y - line4.y, 2) + pown(tmp[1].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line5.x += tmp[1].x * H;
-        line5.y += tmp[1].y * H;
-        line5.z += tmp[1].z * H;
-        normF2 += H;
-        delta = pown(tmp[1].x - line6.x, 2) + pown(tmp[1].y - line6.y, 2) + pown(tmp[1].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line7.x += tmp[1].x * H;
-        line7.y += tmp[1].y * H;
-        line7.z += tmp[1].z * H;
-        normF3 += H;
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x + 1, y + 2));
-        delta = pown(tmp[0].x - line.x, 2) + pown(tmp[0].y - line.y, 2) + pown(tmp[0].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line1.x += tmp[0].x * H;
-        line1.y += tmp[0].y * H;
-        line1.z += tmp[0].z * H;
-        normF += H;
-        delta = pown(tmp[0].x - line2.x, 2) + pown(tmp[0].y - line2.y, 2) + pown(tmp[0].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line3.x += tmp[0].x * H;
-        line3.y += tmp[0].y * H;
-        line3.z += tmp[0].z * H;
-        normF1 += H;
-        delta = pown(tmp[0].x - line4.x, 2) + pown(tmp[0].y - line4.y, 2) + pown(tmp[0].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line5.x += tmp[0].x * H;
-        line5.y += tmp[0].y * H;
-        line5.z += tmp[0].z * H;
-        normF2 += H;
-        delta = pown(tmp[0].x - line6.x, 2) + pown(tmp[0].y - line6.y, 2) + pown(tmp[0].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line7.x += tmp[0].x * H;
-        line7.y += tmp[0].y * H;
-        line7.z += tmp[0].z * H;
-        normF3 += H;
-
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x + 2, y - 2));
-        delta = pown(tmp[1].x - line.x, 2) + pown(tmp[1].y - line.y, 2) + pown(tmp[1].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line1.x += tmp[1].x * H;
-        line1.y += tmp[1].y * H;
-        line1.z += tmp[1].z * H;
-        normF += H;
-        delta = pown(tmp[1].x - line2.x, 2) + pown(tmp[1].y - line2.y, 2) + pown(tmp[1].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line3.x += tmp[1].x * H;
-        line3.y += tmp[1].y * H;
-        line3.z += tmp[1].z * H;
-        normF1 += H;
-        delta = pown(tmp[1].x - line4.x, 2) + pown(tmp[1].y - line4.y, 2) + pown(tmp[1].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line5.x += tmp[1].x * H;
-        line5.y += tmp[1].y * H;
-        line5.z += tmp[1].z * H;
-        normF2 += H;
-        delta = pown(tmp[1].x - line6.x, 2) + pown(tmp[1].y - line6.y, 2) + pown(tmp[1].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line7.x += tmp[1].x * H;
-        line7.y += tmp[1].y * H;
-        line7.z += tmp[1].z * H;
-        normF3 += H;
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x + 2, y - 1));
-        delta = pown(tmp[0].x - line.x, 2) + pown(tmp[0].y - line.y, 2) + pown(tmp[0].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line1.x += tmp[0].x * H;
-        line1.y += tmp[0].y * H;
-        line1.z += tmp[0].z * H;
-        normF += H;
-        delta = pown(tmp[0].x - line2.x, 2) + pown(tmp[0].y - line2.y, 2) + pown(tmp[0].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line3.x += tmp[0].x * H;
-        line3.y += tmp[0].y * H;
-        line3.z += tmp[0].z * H;
-        normF1 += H;
-        delta = pown(tmp[0].x - line4.x, 2) + pown(tmp[0].y - line4.y, 2) + pown(tmp[0].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.94595945;
-        line5.x += tmp[0].x * H;
-        line5.y += tmp[0].y * H;
-        line5.z += tmp[0].z * H;
-        normF2 += H;
-        delta = pown(tmp[0].x - line6.x, 2) + pown(tmp[0].y - line6.y, 2) + pown(tmp[0].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line7.x += tmp[0].x * H;
-        line7.y += tmp[0].y * H;
-        line7.z += tmp[0].z * H;
-        normF3 += H;
-
-        delta = pown(line4.x - line.x, 2) + pown(line4.y - line.y, 2) + pown(line4.z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line1.x += line4.x * H;
-        line1.y += line4.y * H;
-        line1.z += line4.z * H;
-        normF += H;
-        delta = pown(line4.x - line2.x, 2) + pown(line4.y - line2.y, 2) + pown(line4.z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.9459;
-        line3.x += line4.x * H;
-        line3.y += line4.y * H;
-        line3.z += line4.z * H;
-        normF1 += H;
-        line5.x += line4.x;
-        line5.y += line4.y;
-        line5.z += line4.z;
-        normF2 += 1;
-        delta = pown(line4.x - line6.x, 2) + pown(line4.y - line6.y, 2) + pown(line4.z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.9459;
-        line7.x += line4.x * H;
-        line7.y += line4.y * H;
-        line7.z += line4.z * H;
-        normF3 += H;
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x + 2, y + 1));
-        delta = pown(tmp[0].x - line.x, 2) + pown(tmp[0].y - line.y, 2) + pown(tmp[0].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line1.x += tmp[0].x * H;
-        line1.y += tmp[0].y * H;
-        line1.z += tmp[0].z * H;
-        normF += H;
-        delta = pown(tmp[0].x - line2.x, 2) + pown(tmp[0].y - line2.y, 2) + pown(tmp[0].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line3.x += tmp[0].x * H;
-        line3.y += tmp[0].y * H;
-        line3.z += tmp[0].z * H;
-        normF1 += H;
-        delta = pown(tmp[0].x - line4.x, 2) + pown(tmp[0].y - line4.y, 2) + pown(tmp[0].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.94595945;
-        line5.x += tmp[0].x * H;
-        line5.y += tmp[0].y * H;
-        line5.z += tmp[0].z * H;
-        normF2 += H;
-        delta = pown(tmp[0].x - line6.x, 2) + pown(tmp[0].y - line6.y, 2) + pown(tmp[0].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line7.x += tmp[0].x * H;
-        line7.y += tmp[0].y * H;
-        line7.z += tmp[0].z * H;
-        normF3 += H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x + 2, y + 2));
-        delta = pown(tmp[1].x - line.x, 2) + pown(tmp[1].y - line.y, 2) + pown(tmp[1].z - line.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line1.x += tmp[1].x * H;
-        line1.y += tmp[1].y * H;
-        line1.z += tmp[1].z * H;
-        normF += H;
-        delta = pown(tmp[1].x - line2.x, 2) + pown(tmp[1].y - line2.y, 2) + pown(tmp[1].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line3.x += tmp[1].x * H;
-        line3.y += tmp[1].y * H;
-        line3.z += tmp[1].z * H;
-        normF1 += H;
-        delta = pown(tmp[1].x - line4.x, 2) + pown(tmp[1].y - line4.y, 2) + pown(tmp[1].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line5.x += tmp[1].x * H;
-        line5.y += tmp[1].y * H;
-        line5.z += tmp[1].z * H;
-        normF2 += H;
-        delta = pown(tmp[1].x - line6.x, 2) + pown(tmp[1].y - line6.y, 2) + pown(tmp[1].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line7.x += tmp[1].x * H;
-        line7.y += tmp[1].y * H;
-        line7.z += tmp[1].z * H;
-        normF3 += H;
-
-        line.x = line1.x / normF;
-        line.y = line1.y / normF;
-        line.z = line1.z / normF;
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x + 3, y - 2));
-        delta = pown(tmp[0].x - line2.x, 2) + pown(tmp[0].y - line2.y, 2) + pown(tmp[0].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line3.x += tmp[0].x * H;
-        line3.y += tmp[0].y * H;
-        line3.z += tmp[0].z * H;
-        normF1 += H;
-        delta = pown(tmp[0].x - line4.x, 2) + pown(tmp[0].y - line4.y, 2) + pown(tmp[0].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.7454;
-        line5.x += tmp[0].x * H;
-        line5.y += tmp[0].y * H;
-        line5.z += tmp[0].z * H;
-        normF2 += H;
-        delta = pown(tmp[0].x - line6.x, 2) + pown(tmp[0].y - line6.y, 2) + pown(tmp[0].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line7.x += tmp[0].x * H;
-        line7.y += tmp[0].y * H;
-        line7.z += tmp[0].z * H;
-        normF3 += H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x + 3, y - 1));
-        delta = pown(tmp[1].x - line2.x, 2) + pown(tmp[1].y - line2.y, 2) + pown(tmp[1].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line3.x += tmp[1].x * H;
-        line3.y += tmp[1].y * H;
-        line3.z += tmp[1].z * H;
-        normF1 += H;
-        delta = pown(tmp[1].x - line4.x, 2) + pown(tmp[1].y - line4.y, 2) + pown(tmp[1].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line5.x += tmp[1].x * H;
-        line5.y += tmp[1].y * H;
-        line5.z += tmp[1].z * H;
-        normF2 += H;
-        delta = pown(tmp[1].x - line6.x, 2) + pown(tmp[1].y - line6.y, 2) + pown(tmp[1].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.94595945;
-        line7.x += tmp[1].x * H;
-        line7.y += tmp[1].y * H;
-        line7.z += tmp[1].z * H;
-        normF3 += H;
-
-        delta = pown(line6.x - line2.x, 2) + pown(line6.y - line2.y, 2) + pown(line6.z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line3.x += line6.x * H;
-        line3.y += line6.y * H;
-        line3.z += line6.z * H;
-        normF1 += H;
-        delta = pown(line6.x - line4.x, 2) + pown(line6.y - line4.y, 2) + pown(line6.z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.9459;
-        line5.x += line6.x * H;
-        line5.y += line6.y * H;
-        line5.z += line6.z * H;
-        normF2 += H;
-        line7.x += line6.x;
-        line7.y += line6.y;
-        line7.z += line6.z;
-        normF3 += 1;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x + 3, y + 1));
-        delta = pown(tmp[1].x - line2.x, 2) + pown(tmp[1].y - line2.y, 2) + pown(tmp[1].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line3.x += tmp[1].x * H;
-        line3.y += tmp[1].y * H;
-        line3.z += tmp[1].z * H;
-        normF1 += H;
-        delta = pown(tmp[1].x - line4.x, 2) + pown(tmp[1].y - line4.y, 2) + pown(tmp[1].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line5.x += tmp[1].x * H;
-        line5.y += tmp[1].y * H;
-        line5.z += tmp[1].z * H;
-        normF2 += H;
-        delta = pown(tmp[1].x - line6.x, 2) + pown(tmp[1].y - line6.y, 2) + pown(tmp[1].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.94595945;
-        line7.x += tmp[1].x * H;
-        line7.y += tmp[1].y * H;
-        line7.z += tmp[1].z * H;
-        normF3 += H;
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x + 3, y + 2));
-        delta = pown(tmp[0].x - line2.x, 2) + pown(tmp[0].y - line2.y, 2) + pown(tmp[0].z - line2.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line3.x += tmp[0].x * H;
-        line3.y += tmp[0].y * H;
-        line3.z += tmp[0].z * H;
-        normF1 += H;
-        delta = pown(tmp[0].x - line4.x, 2) + pown(tmp[0].y - line4.y, 2) + pown(tmp[0].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line5.x += tmp[0].x * H;
-        line5.y += tmp[0].y * H;
-        line5.z += tmp[0].z * H;
-        normF2 += H;
-        delta = pown(tmp[0].x - line6.x, 2) + pown(tmp[0].y - line6.y, 2) + pown(tmp[0].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line7.x += tmp[0].x * H;
-        line7.y += tmp[0].y * H;
-        line7.z += tmp[0].z * H;
-        normF3 += H;
-
-        line2.x = line3.x / normF1;
-        line2.y = line3.y / normF1;
-        line2.z = line3.z / normF1;
-
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x + 4, y - 2));
-        delta = pown(tmp[1].x - line4.x, 2) + pown(tmp[1].y - line4.y, 2) + pown(tmp[1].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line5.x += tmp[1].x * H;
-        line5.y += tmp[1].y * H;
-        line5.z += tmp[1].z * H;
-        normF2 += H;
-        delta = pown(tmp[1].x - line6.x, 2) + pown(tmp[1].y - line6.y, 2) + pown(tmp[1].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.7454;
-        line7.x += tmp[1].x * H;
-        line7.y += tmp[1].y * H;
-        line7.z += tmp[1].z * H;
-        normF3 += H;
-
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x + 4, y - 1));
-        delta = pown(tmp[0].x - line4.x, 2) + pown(tmp[0].y - line4.y, 2) + pown(tmp[0].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line5.x += tmp[0].x * H;
-        line5.y += tmp[0].y * H;
-        line5.z += tmp[0].z * H;
-        normF2 += H;
-        delta = pown(tmp[0].x - line6.x, 2) + pown(tmp[0].y - line6.y, 2) + pown(tmp[0].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line7.x += tmp[0].x * H;
-        line7.y += tmp[0].y * H;
-        line7.z += tmp[0].z * H;
-        normF3 += H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x + 4, y  ));
-        delta = pown(tmp[1].x - line4.x, 2) + pown(tmp[1].y - line4.y, 2) + pown(tmp[1].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line5.x += tmp[1].x * H;
-        line5.y += tmp[1].y * H;
-        line5.z += tmp[1].z * H;
-        normF2 += H;
-        delta = pown(tmp[1].x - line6.x, 2) + pown(tmp[1].y - line6.y, 2) + pown(tmp[1].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.9459;
-        line7.x += tmp[1].x * H;
-        line7.y += tmp[1].y * H;
-        line7.z += tmp[1].z * H;
-        normF3 += H;
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x + 4, y + 1));
-        delta = pown(tmp[0].x - line4.x, 2) + pown(tmp[0].y - line4.y, 2) + pown(tmp[0].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line5.x += tmp[0].x * H;
-        line5.y += tmp[0].y * H;
-        line5.z += tmp[0].z * H;
-        normF2 += H;
-        delta = pown(tmp[0].x - line6.x, 2) + pown(tmp[0].y - line6.y, 2) + pown(tmp[0].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.8948;
-        line7.x += tmp[0].x * H;
-        line7.y += tmp[0].y * H;
-        line7.z += tmp[0].z * H;
-        normF3 += H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x + 4, y + 2));
-        delta = pown(tmp[1].x - line4.x, 2) + pown(tmp[1].y - line4.y, 2) + pown(tmp[1].z - line4.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line5.x += tmp[1].x * H;
-        line5.y += tmp[1].y * H;
-        line5.z += tmp[1].z * H;
-        normF2 += H;
-        delta = pown(tmp[1].x - line6.x, 2) + pown(tmp[1].y - line6.y, 2) + pown(tmp[1].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line7.x += tmp[1].x * H;
-        line7.y += tmp[1].y * H;
-        line7.z += tmp[1].z * H;
-        normF3 += H;
-
-        line4.x = line5.x / normF2;
-        line4.y = line5.y / normF2;
-        line4.z = line5.z / normF2;
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x + 5, y - 2));
-        delta = pown(tmp[0].x - line6.x, 2) + pown(tmp[0].y - line6.y, 2) + pown(tmp[0].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line7.x += tmp[0].x * H;
-        line7.y += tmp[0].y * H;
-        line7.z += tmp[0].z * H;
-        normF3 += H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x + 5, y - 1));
-        delta = pown(tmp[1].x - line6.x, 2) + pown(tmp[1].y - line6.y, 2) + pown(tmp[1].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line7.x += tmp[1].x * H;
-        line7.y += tmp[1].y * H;
-        line7.z += tmp[1].z * H;
-        normF3 += H;
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x + 5, y  ));
-        delta = pown(tmp[0].x - line6.x, 2) + pown(tmp[0].y - line6.y, 2) + pown(tmp[0].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.8007;
-        line7.x += tmp[0].x * H;
-        line7.y += tmp[0].y * H;
-        line7.z += tmp[0].z * H;
-        normF3 += H;
-
-        tmp[1] = read_imagef(srcRGB, sampler, (int2)(x + 5, y + 1));
-        delta = pown(tmp[1].x - line6.x, 2) + pown(tmp[1].y - line6.y, 2) + pown(tmp[1].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.7574;
-        line7.x += tmp[1].x * H;
-        line7.y += tmp[1].y * H;
-        line7.z += tmp[1].z * H;
-        normF3 += H;
-
-        tmp[0] = read_imagef(srcRGB, sampler, (int2)(x + 5, y + 2));
-        delta = pown(tmp[0].x - line6.x, 2) + pown(tmp[0].y - line6.y, 2) + pown(tmp[0].z - line6.z, 2);
-        H = exp(-delta / sigma_r) * 0.6411;
-        line7.x += tmp[0].x * H;
-        line7.y += tmp[0].y * H;
-        line7.z += tmp[0].z * H;
-        normF3 += H;
-
-        line6.x = line7.x / normF3;
-        line6.y = line7.y / normF3;
-        line6.z = line7.z / normF3;
+        if(localX==0)
+        {
+            if(localY==0)
+            {
+                pixel[0][0]=read_imagef(srcRGB, sampler,(int2)(x-2,y-2));
+                pixel[0][1]=read_imagef(srcRGB, sampler,(int2)(x-2,y-1));
+                pixel[0][2]=read_imagef(srcRGB, sampler,(int2)(x-2,y  ));
+                pixel[1][0]=read_imagef(srcRGB, sampler,(int2)(x-1,y-2));
+                pixel[1][1]=read_imagef(srcRGB, sampler,(int2)(x-1,y-1));
+                pixel[1][2]=read_imagef(srcRGB, sampler,(int2)(x-1,y  ));
+                pixel[2][0]=read_imagef(srcRGB, sampler,(int2)(x  ,y-2));
+                pixel[2][1]=read_imagef(srcRGB, sampler,(int2)(x  ,y-1));
+            }
+            else if(localY==LOCAL_SIZE_Y-1)
+            {
+                pixel[0][LOCAL_SIZE_Y-1+2]=read_imagef(srcRGB, sampler,(int2)(x-2,y  ));
+                pixel[0][LOCAL_SIZE_Y  +2]=read_imagef(srcRGB, sampler,(int2)(x-2,y+1));
+                pixel[0][LOCAL_SIZE_Y+1+2]=read_imagef(srcRGB, sampler,(int2)(x-2,y+2));
+                pixel[1][LOCAL_SIZE_Y-1+2]=read_imagef(srcRGB, sampler,(int2)(x-1,y  ));
+                pixel[1][LOCAL_SIZE_Y  +2]=read_imagef(srcRGB, sampler,(int2)(x-1,y+1));
+                pixel[1][LOCAL_SIZE_Y+1+2]=read_imagef(srcRGB, sampler,(int2)(x-1,y+2));
+                pixel[2][LOCAL_SIZE_Y  +2]=read_imagef(srcRGB, sampler,(int2)(x  ,y+1));
+                pixel[2][LOCAL_SIZE_Y+1+2]=read_imagef(srcRGB, sampler,(int2)(x  ,y+2));
+            }
+            else
+            {
+                pixel[0][localY+2]=read_imagef(srcRGB, sampler,(int2)(x-2,y));
+                pixel[1][localY+2]=read_imagef(srcRGB, sampler,(int2)(x-1,y));
+            }
+        }
+        else if(localX==LOCAL_SIZE_X-1)
+        {
+            if(localY==0)
+            {
+                pixel[LOCAL_SIZE_X-1+2+0][0]=read_imagef(srcRGB, sampler,(int2)(x  ,y-2));
+                pixel[LOCAL_SIZE_X-1+2+0][1]=read_imagef(srcRGB, sampler,(int2)(x  ,y-1));
+                //pixel[LOCAL_SIZE_X-1+2+0][2]=read_imagef(srcRGB, sampler,(int2)(x  ,y));
+                pixel[LOCAL_SIZE_X-1+2+1][0]=read_imagef(srcRGB, sampler,(int2)(x+1,y-2));
+                pixel[LOCAL_SIZE_X-1+2+1][1]=read_imagef(srcRGB, sampler,(int2)(x+1,y-1));
+                pixel[LOCAL_SIZE_X-1+2+1][2]=read_imagef(srcRGB, sampler,(int2)(x+1,y  ));
+                pixel[LOCAL_SIZE_X-1+2+2][0]=read_imagef(srcRGB, sampler,(int2)(x+2,y-2));
+                pixel[LOCAL_SIZE_X-1+2+2][1]=read_imagef(srcRGB, sampler,(int2)(x+2,y-1));
+                pixel[LOCAL_SIZE_X-1+2+2][2]=read_imagef(srcRGB, sampler,(int2)(x+2,y  ));
+            }
+            else if(localY==LOCAL_SIZE_Y-1)
+            {
+                //	pixel[LOCAL_SIZE_X-1+2+0][LOCAL_SIZE_Y-1+2+0]=read_imagef(srcRGB, sampler,(int2)(x  ,y  ));
+                pixel[LOCAL_SIZE_X-1+2+0][LOCAL_SIZE_Y-1+2+1]=read_imagef(srcRGB, sampler,(int2)(x  ,y+1));
+                pixel[LOCAL_SIZE_X-1+2+0][LOCAL_SIZE_Y-1+2+2]=read_imagef(srcRGB, sampler,(int2)(x  ,y+2));
+                pixel[LOCAL_SIZE_X-1+2+1][LOCAL_SIZE_Y-1+2+0]=read_imagef(srcRGB, sampler,(int2)(x+1,y  ));
+                pixel[LOCAL_SIZE_X-1+2+1][LOCAL_SIZE_Y-1+2+1]=read_imagef(srcRGB, sampler,(int2)(x+1,y+1));
+                pixel[LOCAL_SIZE_X-1+2+1][LOCAL_SIZE_Y-1+2+2]=read_imagef(srcRGB, sampler,(int2)(x+1,y+2));
+                pixel[LOCAL_SIZE_X-1+2+2][LOCAL_SIZE_Y-1+2+0]=read_imagef(srcRGB, sampler,(int2)(x+2,y  ));
+                pixel[LOCAL_SIZE_X-1+2+2][LOCAL_SIZE_Y-1+2+1]=read_imagef(srcRGB, sampler,(int2)(x+2,y+1));
+                pixel[LOCAL_SIZE_X-1+2+2][LOCAL_SIZE_Y-1+2+2]=read_imagef(srcRGB, sampler,(int2)(x+2,y+2));
+            }
+            else
+            {
+                pixel[LOCAL_SIZE_X-1+2+1][localY+2]=read_imagef(srcRGB, sampler,(int2)(x+1,y  ));
+                pixel[LOCAL_SIZE_X-1+2+2][localY+2]=read_imagef(srcRGB, sampler,(int2)(x+2,y  ));
+            }
+        }
+        else if(localY==0)
+        {
+            pixel[localX+2][0]=read_imagef(srcRGB,sampler,(int2)(x,y-2));
+            pixel[localX+2][1]=read_imagef(srcRGB,sampler,(int2)(x,y-1));
+        }
+        else if(localY==LOCAL_SIZE_Y-1)
+        {
+        pixel[localX+2][LOCAL_SIZE_Y-1+2+1]=read_imagef(srcRGB,sampler,(int2)(x,y+1));
+        pixel[localX+2][LOCAL_SIZE_Y-1+2+2]=read_imagef(srcRGB,sampler,(int2)(x,y+2));
     }
-    write_imagef(dstRGB, (int2)(x, y), line);
-    write_imagef(dstRGB, (int2)(x + 1, y), line2);
-    write_imagef(dstRGB, (int2)(x + 2, y), line4);
-    write_imagef(dstRGB, (int2)(x + 3, y), line6);
+    }else{
+        line=read_imagef(srcRGB, sampler,(int2)(x,y));
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (interior) {
+#pragma unroll
+        for(i=0;i<5;i++)
+        {
+#pragma unroll
+             for(j=0;j<5;j++)
+             {
+                  delta=pown(pixel[localX+i][localY+j].x-pixel[localX+2][localY+2].x,2) +
+                  pown(pixel[localX+i][localY+j].y-pixel[localX+2][localY+2].y,2) +
+                  pown(pixel[localX+i][localY+j].z-pixel[localX+2][localY+2].z,2);
+                  H = (exp(-(delta/sigma_r)))*gausssingle[i*5+j];
+                  normF+=H;
+                  line.x+=pixel[localX+i][localY+j].x*H;
+                  line.y+=pixel[localX+i][localY+j].y*H;
+                  line.z+=pixel[localX+i][localY+j].z*H;
+             }
+        }
+
+        line.x=line.x/normF;
+        line.y=line.y/normF;
+        line.z=line.z/normF;
+    }
+
+    write_imagef(dstRGB,(int2)(x,y),line);
 }

--- a/xcore/cl_denoise_handler.cpp
+++ b/xcore/cl_denoise_handler.cpp
@@ -72,7 +72,10 @@ CLDenoiseImageKernel::prepare_arguments (
 
     work_size.dim = XCAM_DEFAULT_IMAGE_DIM;
     work_size.global[0] = _imh;
-    work_size.global[1] = _imw / 4;
+    work_size.global[1] = _imw;
+    work_size.local[0] = _imh/72;
+    work_size.local[1] = _imw/120;
+
 
     return XCAM_RETURN_NO_ERROR;
 }


### PR DESCRIPTION
Use SLM, we will load the shared local memory and add a barrier to share the reading bandwidth.
And also use pragma unroll to avoid manually open the loop.

Now the performance can reach 68fps in ivybridge GT2 which have 24 EUs, and keep 13fps in baytraili.

Signed-off-by: Juan Zhao <juan.j.zhao@intel.com>