### PR TITLE
cl: add brightness functionality for both web side test and test-device-manager

### DIFF
--- a/3alib/aiq3a_utils.cpp
+++ b/3alib/aiq3a_utils.cpp
@@ -232,9 +232,19 @@ translate_3a_results_to_xcam (X3aResultList &list,
             result_count += translate_atomisp_parameters (atomisp_params, &results[result_count], max_count - result_count);
             break;
         }
-        default:
+        case XCAM_3A_RESULT_BRIGHTNESS: {
+            SmartPtr<X3aBrightnessResult> xcam_brightness =
+                isp_result.dynamic_cast_ptr<X3aBrightnessResult>();
+            const XCam3aResultBrightness &brightness = xcam_brightness->get_standard_result();
+            XCam3aResultBrightness *new_brightness = xcam_malloc0_type(XCam3aResultBrightness);
+            *new_brightness = brightness;
+            results[result_count++] = (XCam3aResultHead*)new_brightness;
+            break;
+        }
+        default: {
             XCAM_LOG_WARNING ("unknow type(%d) in translation", isp_result->get_type());
             break;
+        }
         }
     }
     return result_count;

--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -266,6 +266,8 @@ void print_help (const char *bin_name)
             "\t               pixel_fmt select from [NV12, YUYV, BA10, RG12], default is [NV12]\n"
             "\t -d cap_mode   specify capture mode\n"
             "\t               cap_mode select from [video, still], default is [video]\n"
+            "\t -b brightness specify brightness level\n"
+            "\t               brightness level select from [0, 256], default is [128]\n"
             "\t -i frame_save specify the frame count to save, default is 0 which means endless\n"
             "\t -p preview on local display\n"
             "\t -e display_mode    preview mode\n"
@@ -318,8 +320,9 @@ int main (int argc, char *argv[])
     uint32_t denoise_type = 0;
     uint8_t tnr_level = 0;
     bool dpc_type = false;
+    int32_t brightness_level = 128;
 
-    const char *short_opts = "sca:n:m:f:d:pi:e:h";
+    const char *short_opts = "sca:n:m:f:d:b:pi:e:h";
     const struct option long_opts[] = {
         {"hdr", required_argument, NULL, 'H'},
         {"tnr", required_argument, NULL, 'T'},
@@ -382,6 +385,13 @@ int main (int argc, char *argv[])
             else if (!strcmp (optarg, "video"))
                 capture_mode = V4L2_CAPTURE_MODE_VIDEO;
             else  {
+                print_help (bin_name);
+                return -1;
+            }
+            break;
+        case 'b':
+            brightness_level = atoi(optarg);
+            if(brightness_level < 0 || brightness_level > 256) {
                 print_help (bin_name);
                 return -1;
             }
@@ -555,6 +565,7 @@ int main (int argc, char *argv[])
 
 #if HAVE_LIBCL
     if (have_cl_processor) {
+
         cl_processor = new CL3aImageProcessor ();
         cl_processor->set_stats_callback(device_manager);
         cl_processor->set_dpc(dpc_type);
@@ -564,6 +575,7 @@ int main (int argc, char *argv[])
             cl_processor->set_output_format (V4L2_PIX_FMT_XBGR32);
         }
         cl_processor->set_tnr (tnr_type, tnr_level);
+        analyzer->set_parameter_brightness((brightness_level - 128) / 128.0);
         device_manager->add_image_processor (cl_processor);
     }
 #endif

--- a/xcore/analyzer_loader.cpp
+++ b/xcore/analyzer_loader.cpp
@@ -258,6 +258,7 @@ DynamicAnalyzer::configure_3a ()
                       ret == XCAM_RETURN_NO_ERROR,
                       ret,
                       "dynamic analyzer configure 3a failed");
+    set_manual_brightness(_brightness_level_param);
 
     return XCAM_RETURN_NO_ERROR;
 }

--- a/xcore/base/xcam_3a_result.h
+++ b/xcore/base/xcam_3a_result.h
@@ -72,6 +72,7 @@ typedef enum _XCam3aResultType {
     XCAM_3A_RESULT_R_GAMMA,
     XCAM_3A_RESULT_G_GAMMA,
     XCAM_3A_RESULT_B_GAMMA,
+    XCAM_3A_RESULT_BRIGHTNESS,
     //XCAM_3A_RESULT_SHADING_TABLE,
     XCAM_3A_RESULT_USER_DEFINED_TYPE = 0x8000,
 } XCam3aResultType;
@@ -201,6 +202,12 @@ typedef struct _XCam3aResultChromaToneControl {
     double           uv_gain [XCAM_GAMMA_TABLE_SIZE]; // according to Y
 } XCam3aResultChromaToneControl;
 
+typedef struct _XCam3aResultBrightness {
+    XCam3aResultHead head;
+
+    /* data */
+    double           brightness_level; // range [-1,1], -1 is full dark , 0 is normal val, 1 is full bright
+} XCam3aResultBrightness;
 
 XCAM_END_DECLARE
 

--- a/xcore/cl_3a_image_processor.cpp
+++ b/xcore/cl_3a_image_processor.cpp
@@ -96,7 +96,6 @@ CL3aImageProcessor::can_process_result (SmartPtr<X3aResult> &result)
 {
     if (result.ptr() == NULL)
         return false;
-
     switch (result->get_type ()) {
     case XCAM_3A_RESULT_WHITE_BALANCE:
     case XCAM_3A_RESULT_BLACK_LEVEL:
@@ -107,6 +106,7 @@ CL3aImageProcessor::can_process_result (SmartPtr<X3aResult> &result)
     case XCAM_3A_RESULT_DEFECT_PIXEL_CORRECTION:
     case XCAM_3A_RESULT_MACC:
     case XCAM_3A_RESULT_BAYER_NOISE_REDUCTION:
+    case XCAM_3A_RESULT_BRIGHTNESS:
         return true;
 
     default:
@@ -236,6 +236,15 @@ CL3aImageProcessor::apply_3a_result (SmartPtr<X3aResult> &result)
         break;
     }
 
+    case XCAM_3A_RESULT_BRIGHTNESS: {
+        SmartPtr<X3aBrightnessResult> brightness_res = result.dynamic_cast_ptr<X3aBrightnessResult> ();
+        XCAM_ASSERT (brightness_res.ptr ());
+        if (!_gamma.ptr())
+            break;
+        float brightness_level = ((XCam3aResultBrightness)brightness_res->get_standard_result()).brightness_level;
+        _gamma->set_manual_brightness(brightness_level);
+        break;
+    }
     default:
         XCAM_LOG_WARNING ("CL3aImageProcessor unknow 3a result:%d", res_type);
         break;
@@ -530,4 +539,5 @@ CL3aImageProcessor::set_tnr (uint32_t mode, uint8_t level)
 
     return ret;
 }
+
 };

--- a/xcore/cl_gamma_handler.h
+++ b/xcore/cl_gamma_handler.h
@@ -34,6 +34,7 @@ public:
     explicit CLGammaImageKernel (SmartPtr<CLContext> &context);
     bool set_gamma (float *gamma);
 
+
 protected:
     virtual XCamReturn prepare_arguments (
         SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
@@ -54,11 +55,13 @@ public:
     explicit CLGammaImageHandler (const char *name);
     bool set_gamma_table (const XCam3aResultGammaTable &gamma);
     bool set_gamma_kernel(SmartPtr<CLGammaImageKernel> &kernel);
+    bool set_manual_brightness (float level);
 
 private:
     XCAM_DEAD_COPY (CLGammaImageHandler);
 
     SmartPtr<CLGammaImageKernel> _gamma_kernel;
+    float _brightness_impact;
 };
 
 SmartPtr<CLImageHandler>

--- a/xcore/x3a_analyzer.cpp
+++ b/xcore/x3a_analyzer.cpp
@@ -582,6 +582,12 @@ X3aAnalyzer::set_gamma_table (double *r_table, double *g_table, double *b_table)
 }
 
 bool
+X3aAnalyzer::set_parameter_brightness(double level)
+{
+    _brightness_level_param = level;
+}
+
+bool
 X3aAnalyzer::update_awb_parameters (const XCamAwbParam &params)
 {
     XCAM_ASSERT (_awb_handler.ptr());

--- a/xcore/x3a_analyzer.h
+++ b/xcore/x3a_analyzer.h
@@ -101,6 +101,7 @@ public:
     bool set_manual_sharpness (double level);
     bool set_gamma_table (double *r_table, double *g_table, double *b_table);
     bool set_color_effect(XCamColorEffect effect);
+    bool set_parameter_brightness (double level);
 
     // whole update of parameters
     bool update_awb_parameters (const XCamAwbParam &params);
@@ -159,6 +160,9 @@ private:
     XCamReturn analyze_3a_statistics (SmartPtr<X3aStats> &stats);
 
     XCAM_DEAD_COPY (X3aAnalyzer);
+
+protected:
+    double                   _brightness_level_param;
 
 private:
     char                    *_name;

--- a/xcore/x3a_result.h
+++ b/xcore/x3a_result.h
@@ -138,8 +138,7 @@ typedef X3aStandardResultT<XCam3aResultGammaTable>     X3aGammaTableResult;
 typedef X3aStandardResultT<XCam3aResultMaccMatrix>     X3aMaccMatrixResult;
 typedef X3aStandardResultT<XCam3aResultChromaToneControl> X3aChromaToneControlResult;
 typedef X3aStandardResultT<XCam3aResultBayerNoiseReduction> X3aBayerNoiseReduction;
-
-
+typedef X3aStandardResultT<XCam3aResultBrightness>      X3aBrightnessResult;
 };
 
 #endif //XCAM_3A_RESULT_H

--- a/xcore/x3a_result_factory.cpp
+++ b/xcore/x3a_result_factory.cpp
@@ -124,6 +124,9 @@ X3aResultFactory::create_3a_result (XCam3aResultHead *from)
     case XCAM_3A_RESULT_BAYER_NOISE_REDUCTION:
         result = create_bayer_noise_reduction ((XCam3aResultBayerNoiseReduction*)from);
         break;
+    case XCAM_3A_RESULT_BRIGHTNESS:
+        result = create_brightness ((XCam3aResultBrightness*)from);
+        break;
     default:
         XCAM_LOG_WARNING ("create 3a result with unknow result type:%d", type);
         break;
@@ -240,5 +243,10 @@ X3aResultFactory::create_bayer_noise_reduction (XCam3aResultBayerNoiseReduction 
     XCAM_3A_RESULT_FACTORY (X3aBayerNoiseReduction, XCAM_3A_RESULT_BAYER_NOISE_REDUCTION, from);
 }
 
+SmartPtr<X3aBrightnessResult>
+X3aResultFactory::create_brightness (XCam3aResultBrightness *from)
+{
+    XCAM_3A_RESULT_FACTORY (X3aBrightnessResult, XCAM_3A_RESULT_BRIGHTNESS, from);
+}
 };
 

--- a/xcore/x3a_result_factory.h
+++ b/xcore/x3a_result_factory.h
@@ -54,7 +54,7 @@ public:
     SmartPtr<X3aMaccMatrixResult> create_macc (XCam3aResultMaccMatrix *from = NULL);
     SmartPtr<X3aChromaToneControlResult> create_chroma_tone_control (XCam3aResultChromaToneControl *from = NULL);
     SmartPtr<X3aBayerNoiseReduction> create_bayer_noise_reduction (XCam3aResultBayerNoiseReduction *from = NULL);
-
+    SmartPtr<X3aBrightnessResult> create_brightness (XCam3aResultBrightness *from = NULL);
 protected:
     explicit X3aResultFactory ();
 


### PR DESCRIPTION
1. web test
2. test-device-manager

command example: test-device-manager -a dynamic -m dma -c -f BA10 -d still -b 50 -p