### PR TITLE
v4l2device: Fix endless while loop in set_format()

### DIFF
--- a/xcore/v4l2_device.cpp
+++ b/xcore/v4l2_device.cpp
@@ -266,6 +266,9 @@ V4l2Device::set_format (struct v4l2_format &format)
         _fps_n = param.parm.capture.timeperframe.denominator;
         _fps_d = param.parm.capture.timeperframe.numerator;
         XCAM_LOG_INFO ("device(%s) set framerate(%d/%d)", XCAM_STR (_name), _fps_n, _fps_d);
+
+        // exit here, otherwise it is an infinite loop
+        break;
     }
 
     ret = post_set_format (format);


### PR DESCRIPTION
The while loop in V4l2Device::set_format was
missing a break. It will keep looping forever.
This issue was found when enabling USB camera
with Libxcam.

Signed-off-by: Sameer Kibey <sameer.kibey@intel.com>