### PR TITLE
xcamsrc: add property of cpf and dynamic 3a lib paths

### DIFF
--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -71,6 +71,8 @@ struct _GstXCamSrc
     uint32_t                     sensor_id;
     uint32_t                     capture_mode;
     char                        *device;
+    char                        *path_to_cpf;
+    char                        *path_to_3alib;
     gboolean                     enable_3a;
 
     gboolean                     time_offset_ready;


### PR DESCRIPTION
 * paths cpf and dynamic 3a lib can be configured by
   setting path-cpf and path-3alib.