### PR TITLE
usbcam: Added support for USB camera

### DIFF
--- a/xcore/Makefile.am
+++ b/xcore/Makefile.am
@@ -59,6 +59,7 @@ xcam_sources =               \
 	isp_config_translator.cpp \
 	poll_thread.cpp          \
 	sensor_descriptor.cpp    \
+	uvc_device.cpp           \
 	v4l2_buffer_proxy.cpp    \
 	v4l2_device.cpp          \
 	video_buffer.cpp         \

--- a/xcore/uvc_device.cpp
+++ b/xcore/uvc_device.cpp
@@ -1,0 +1,60 @@
+/*
+ * uvc_device.cpp - uvc device
+ *
+ *  Copyright (c) 2014-2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Sameer Kibey <sameer.kibey@intel.com>
+ */
+
+#include "uvc_device.h"
+#include "v4l2_buffer_proxy.h"
+#include <linux/v4l2-subdev.h>
+
+namespace XCam {
+
+UVCDevice::UVCDevice (const char *name)
+    : V4l2Device (name)
+{
+}
+
+UVCDevice::~UVCDevice ()
+{
+}
+
+XCamReturn
+UVCDevice::allocate_buffer (
+    SmartPtr<V4l2Buffer> &buf,
+    const struct v4l2_format &format,
+    const uint32_t index)
+{
+#if HAVE_LIBDRM
+    if (!_drm_disp.ptr()) {
+        _drm_disp = DrmDisplay::instance ();
+    }
+
+    if (get_mem_type () == V4L2_MEMORY_DMABUF && _drm_disp.ptr () != NULL) {
+        buf = _drm_disp->create_drm_buf (format, index, get_capture_buf_type ());
+        if (!buf.ptr()) {
+            XCAM_LOG_WARNING ("uvc device(%s) allocate buffer failed", XCAM_STR (get_device_name()));
+            return XCAM_RETURN_ERROR_MEM;
+        }
+        return XCAM_RETURN_NO_ERROR;
+    }
+#endif
+
+    return V4l2Device::allocate_buffer (buf, format, index);
+}
+
+};

--- a/xcore/uvc_device.h
+++ b/xcore/uvc_device.h
@@ -1,0 +1,68 @@
+/*
+ * uvc_device.h - uvc device
+ *
+ *  Copyright (c) 2014-2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Sameer Kibey <sameer.kibey@intel.com>
+ */
+
+#ifndef XCAM_UVC_DEVICE_H
+#define XCAM_UVC_DEVICE_H
+
+#include "xcam_utils.h"
+#include "v4l2_device.h"
+#if HAVE_LIBDRM
+#include "drm_display.h"
+#endif
+
+namespace XCam {
+
+#if HAVE_LIBDRM
+class DrmDisplay;
+#endif
+
+class UVCDevice
+    : public V4l2Device
+{
+    friend class DrmV4l2Buffer;
+
+public:
+    explicit UVCDevice (const char *name = NULL);
+    ~UVCDevice ();
+
+#if HAVE_LIBDRM
+    void set_drm_display(SmartPtr<DrmDisplay> &drm_disp) {
+        _drm_disp = drm_disp;
+    };
+#endif
+
+protected:
+    virtual XCamReturn allocate_buffer (
+        SmartPtr<V4l2Buffer> &buf,
+        const struct v4l2_format &format,
+        const uint32_t index);
+
+private:
+    XCAM_DEAD_COPY (UVCDevice);
+
+#if HAVE_LIBDRM
+private:
+    SmartPtr<DrmDisplay> _drm_disp;
+#endif
+};
+
+};
+
+#endif //XCAM_UVC_DEVICE_H


### PR DESCRIPTION
Added support to Libxcam for USB cameras. Verified
with 1080p Logitech C920 camera and test-device-manager
app.

Test command line:
test-device-manager -f YUYV -m dma -d video -p --usb /dev/videoX
test-device-manager -m mmap -s -f BA10 -d still --usb /dev/videoX -i 1

Signed-off-by: Sameer Kibey <sameer.kibey@intel.com>