### PR TITLE
analyzer: add sync mode to X3aAnalyzer

### DIFF
--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -275,6 +275,7 @@ void print_help (const char *bin_name)
             "\t               specify [/dev/video4, /dev/video5] depending on which node USB camera is attached\n"
             "\t -e display_mode    preview mode\n"
             "\t                select from [primary, overlay], default is [primary]\n"
+            "\t --sync        set analyzer in sync mode\n"
             "\t -h            help\n"
             "CL features:\n"
             "\t --hdr         specify hdr type, default is hdr off\n"
@@ -326,6 +327,7 @@ int main (int argc, char *argv[])
     int32_t brightness_level = 128;
     bool    have_usbcam = 0;
     char*   usb_device_name = NULL;
+    bool sync_mode = false;
 
     const char *short_opts = "sca:n:m:f:d:b:pi:e:h";
     const struct option long_opts[] = {
@@ -338,6 +340,7 @@ int main (int argc, char *argv[])
         {"enable-bnr", no_argument, NULL, 'B'},
         {"enable-dpc", no_argument, NULL, 'D'},
         {"usb", required_argument, NULL, 'U'},
+        {"sync", no_argument, NULL, 'Y'},
         {0, 0, 0, 0},
     };
 
@@ -423,6 +426,9 @@ int main (int argc, char *argv[])
         }
         case 'i':
             device_manager->set_frame_save(atoi(optarg));
+            break;
+        case 'Y':
+            sync_mode = true;
             break;
         case 'H': {
             if (!strcasecmp (optarg, "rgb"))
@@ -527,6 +533,8 @@ int main (int argc, char *argv[])
         print_help (bin_name);
         return -1;
     }
+    XCAM_ASSERT (analyzer.ptr ());
+    analyzer->set_sync_mode (sync_mode);
 
     signal(SIGINT, dev_stop_handler);
 

--- a/xcore/x3a_analyzer.h
+++ b/xcore/x3a_analyzer.h
@@ -54,6 +54,8 @@ public:
     // prepare_handlers must called before init
     XCamReturn init (uint32_t width, uint32_t height, double framerate);
     XCamReturn deinit ();
+    // set_sync_mode must be called before start
+    XCamReturn set_sync_mode (bool sync);
     XCamReturn start ();
     XCamReturn stop ();
 
@@ -166,6 +168,8 @@ protected:
 
 private:
     char                    *_name;
+    bool                     _sync;
+    bool                     _started;
     uint32_t                 _width;
     uint32_t                 _height;
     double                   _framerate;


### PR DESCRIPTION
 * in async mode, 3a analysis is driven by AnalyzerThread.
 * in sync mode, 3a analysis is drivern directly by the caller,
   i.e. analysis is done synchronously when push_3a_stats is called
 * test: test-device-manager -f YUYV -m dma -d video -p -a aiq --sync