### PR TITLE
analyzer: enable hybrid analyzer

### DIFF
--- a/wrapper/gstreamer/gstxcamsrc.cpp
+++ b/wrapper/gstreamer/gstxcamsrc.cpp
@@ -162,6 +162,7 @@ gst_xcam_src_analyzer_get_type (void)
         {SIMPLE_ANALYZER, "simple 3A analyzer", "simple"},
         {AIQ_ANALYZER, "aiq 3A analyzer", "aiq"},
         {DYNAMIC_ANALYZER, "dynamic load 3A analyzer", "dynamic"},
+        {HYBRID_ANALYZER, "hybrid 3A analyzer", "hybrid"},
         {0, NULL, NULL},
     };
 
@@ -624,9 +625,19 @@ gst_xcam_src_start (GstBaseSrc *src)
     case DYNAMIC_ANALYZER: {
         XCAM_LOG_INFO ("dynamic 3a library: %s", xcamsrc->path_to_3alib);
         SmartPtr<AnalyzerLoader> loader = new AnalyzerLoader (xcamsrc->path_to_3alib);
-        analyzer = loader->load_analyzer (loader);
+        analyzer = loader->load_dynamic_analyzer (loader);
         if (!analyzer.ptr ()) {
-            XCAM_LOG_ERROR ("load analyzer(%s) failed, please check.", xcamsrc->path_to_3alib);
+            XCAM_LOG_ERROR ("load dynamic analyzer(%s) failed, please check.", xcamsrc->path_to_3alib);
+            return FALSE;
+        }
+        break;
+    }
+    case HYBRID_ANALYZER: {
+        XCAM_LOG_INFO ("hybrid 3a library: %s", xcamsrc->path_to_3alib);
+        SmartPtr<AnalyzerLoader> loader = new AnalyzerLoader (xcamsrc->path_to_3alib);
+        analyzer = loader->load_hybrid_analyzer (loader, isp_controller, xcamsrc->path_to_cpf);
+        if (!analyzer.ptr ()) {
+            XCAM_LOG_ERROR ("load hybrid analyzer(%s) failed, please check.", xcamsrc->path_to_3alib);
             return FALSE;
         }
         break;

--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -57,6 +57,7 @@ typedef enum {
     SIMPLE_ANALYZER = 0,
     AIQ_ANALYZER,
     DYNAMIC_ANALYZER,
+    HYBRID_ANALYZER,
 } AnalyzerType;
 
 typedef struct _GstXCamSrc      GstXCamSrc;

--- a/xcore/Makefile.am
+++ b/xcore/Makefile.am
@@ -52,6 +52,7 @@ xcam_sources =               \
 	analyzer_loader.cpp      \
 	buffer_pool.cpp          \
 	device_manager.cpp       \
+        dynamic_analyzer.cpp     \
 	handler_interface.cpp    \
 	image_processor.cpp      \
 	isp_controller.cpp       \
@@ -82,6 +83,7 @@ xcam_sources +=              \
 	xcam_cpf_reader.c        \
 	aiq_handler.cpp          \
 	x3a_analyzer_aiq.cpp     \
+        hybrid_analyzer.cpp      \
 	$(NULL)
 endif
 

--- a/xcore/analyzer_loader.cpp
+++ b/xcore/analyzer_loader.cpp
@@ -19,312 +19,15 @@
  */
 
 #include "analyzer_loader.h"
+#include "dynamic_analyzer.h"
 #include "handler_interface.h"
+#include "hybrid_analyzer.h"
+#include "isp_controller.h"
 #include "x3a_result_factory.h"
 #include "x3a_statistics_queue.h"
 #include <dlfcn.h>
 
 namespace XCam {
-
-class DynamicAeHandler;
-class DynamicAwbHandler;
-class DynamicAfHandler;
-class DynamicCommonHandler;
-
-class DynamicAnalyzer
-    : public X3aAnalyzer
-{
-public:
-    DynamicAnalyzer (XCam3ADescription *desc, SmartPtr<AnalyzerLoader> &loader);
-    ~DynamicAnalyzer ();
-
-public:
-    XCamReturn analyze_ae (XCamAeParam &param);
-    XCamReturn analyze_awb (XCamAwbParam &param);
-    XCamReturn analyze_af (XCamAfParam &param);
-
-protected:
-    virtual SmartPtr<AeHandler> create_ae_handler ();
-    virtual SmartPtr<AwbHandler> create_awb_handler ();
-    virtual SmartPtr<AfHandler> create_af_handler ();
-    virtual SmartPtr<CommonHandler> create_common_handler ();
-    virtual XCamReturn internal_init (uint32_t width, uint32_t height, double framerate);
-    virtual XCamReturn internal_deinit ();
-
-    virtual XCamReturn configure_3a ();
-    virtual XCamReturn pre_3a_analyze (SmartPtr<X3aStats> &stats);
-    virtual XCamReturn post_3a_analyze (X3aResultList &results);
-
-    XCamReturn create_context ();
-    void destroy_context ();
-
-private:
-    XCamReturn convert_results (XCam3aResultHead *from[], uint32_t from_count, X3aResultList &to);
-    XCAM_DEAD_COPY (DynamicAnalyzer);
-
-private:
-    XCam3ADescription           *_desc;
-    XCam3AContext               *_context;
-    SmartPtr<X3aStats>           _cur_stats;
-    SmartPtr<DynamicCommonHandler> _common_handler;
-    SmartPtr<AnalyzerLoader>       _loader;
-};
-
-class DynamicAeHandler
-    : public AeHandler
-{
-public:
-    explicit DynamicAeHandler (DynamicAnalyzer *analyzer)
-        : _analyzer (analyzer)
-    {}
-    virtual XCamReturn analyze (X3aResultList &output) {
-        XCAM_UNUSED (output);
-        AnalyzerHandler::HandlerLock lock(this);
-        XCamAeParam param = this->get_params_unlock ();
-        return _analyzer->analyze_ae (param);
-    }
-
-private:
-    DynamicAnalyzer *_analyzer;
-};
-
-class DynamicAwbHandler
-    : public AwbHandler
-{
-public:
-    explicit DynamicAwbHandler (DynamicAnalyzer *analyzer)
-        : _analyzer (analyzer)
-    {}
-    virtual XCamReturn analyze (X3aResultList &output) {
-        XCAM_UNUSED (output);
-        AnalyzerHandler::HandlerLock lock(this);
-        XCamAwbParam param = this->get_params_unlock ();
-        return _analyzer->analyze_awb (param);
-    }
-
-private:
-    DynamicAnalyzer *_analyzer;
-};
-
-class DynamicAfHandler
-    : public AfHandler
-{
-public:
-    explicit DynamicAfHandler (DynamicAnalyzer *analyzer)
-        : _analyzer (analyzer)
-    {}
-    virtual XCamReturn analyze (X3aResultList &output) {
-        XCAM_UNUSED (output);
-        AnalyzerHandler::HandlerLock lock(this);
-        XCamAfParam param = this->get_params_unlock ();
-        return _analyzer->analyze_af (param);
-    }
-
-private:
-    DynamicAnalyzer *_analyzer;
-};
-
-class DynamicCommonHandler
-    : public CommonHandler
-{
-    friend class DynamicAnalyzer;
-public:
-    explicit DynamicCommonHandler (DynamicAnalyzer *analyzer)
-        : _analyzer (analyzer)
-    {}
-    virtual XCamReturn analyze (X3aResultList &output) {
-        XCAM_UNUSED (output);
-        AnalyzerHandler::HandlerLock lock(this);
-        return XCAM_RETURN_NO_ERROR;
-    }
-
-private:
-    DynamicAnalyzer *_analyzer;
-};
-
-DynamicAnalyzer::DynamicAnalyzer (XCam3ADescription *desc, SmartPtr<AnalyzerLoader> &loader)
-    : X3aAnalyzer ("DynamicAnalyzer")
-    , _desc (desc)
-    , _context (NULL)
-    , _loader (loader)
-{
-}
-
-DynamicAnalyzer::~DynamicAnalyzer ()
-{
-    destroy_context ();
-}
-
-XCamReturn
-DynamicAnalyzer::create_context ()
-{
-    XCam3AContext *context = NULL;
-    XCamReturn ret = XCAM_RETURN_NO_ERROR;
-    XCAM_ASSERT (!_context);
-    if ((ret = _desc->create_context (&context)) != XCAM_RETURN_NO_ERROR) {
-        XCAM_LOG_WARNING ("dynamic 3a lib create context failed");
-        return ret;
-    }
-    _context = context;
-    return XCAM_RETURN_NO_ERROR;
-}
-
-void
-DynamicAnalyzer::destroy_context ()
-{
-    if (_context && _desc && _desc->destroy_context) {
-        _desc->destroy_context (_context);
-        _context = NULL;
-    }
-}
-
-XCamReturn
-DynamicAnalyzer::analyze_ae (XCamAeParam &param)
-{
-    XCAM_ASSERT (_context);
-    return _desc->analyze_ae (_context, &param);
-}
-
-XCamReturn
-DynamicAnalyzer::analyze_awb (XCamAwbParam &param)
-{
-    XCAM_ASSERT (_context);
-    return _desc->analyze_awb (_context, &param);
-}
-
-XCamReturn
-DynamicAnalyzer::analyze_af (XCamAfParam &param)
-{
-    XCAM_ASSERT (_context);
-    return _desc->analyze_af (_context, &param);
-}
-
-SmartPtr<AeHandler>
-DynamicAnalyzer::create_ae_handler ()
-{
-    return new DynamicAeHandler (this);
-}
-
-SmartPtr<AwbHandler>
-DynamicAnalyzer::create_awb_handler ()
-{
-    return new DynamicAwbHandler (this);
-}
-
-SmartPtr<AfHandler>
-DynamicAnalyzer::create_af_handler ()
-{
-    return new DynamicAfHandler (this);
-}
-
-SmartPtr<CommonHandler>
-DynamicAnalyzer::create_common_handler ()
-{
-    if (_common_handler.ptr())
-        return _common_handler;
-
-    _common_handler = new DynamicCommonHandler (this);
-    return _common_handler;
-}
-
-XCamReturn
-DynamicAnalyzer::internal_init (uint32_t width, uint32_t height, double framerate)
-{
-    XCAM_UNUSED (width);
-    XCAM_UNUSED (height);
-    XCAM_UNUSED (framerate);
-    return create_context ();
-}
-
-XCamReturn
-DynamicAnalyzer::internal_deinit ()
-{
-    destroy_context ();
-    return XCAM_RETURN_NO_ERROR;
-}
-
-XCamReturn
-DynamicAnalyzer::configure_3a ()
-{
-    uint32_t width = get_width ();
-    uint32_t height = get_height ();
-    double framerate = get_framerate ();
-    XCamReturn ret = XCAM_RETURN_NO_ERROR;
-
-    XCAM_ASSERT (_context);
-
-    ret = _desc->configure_3a (_context, width, height, framerate);
-    XCAM_FAIL_RETURN (WARNING,
-                      ret == XCAM_RETURN_NO_ERROR,
-                      ret,
-                      "dynamic analyzer configure 3a failed");
-    set_manual_brightness(_brightness_level_param);
-
-    return XCAM_RETURN_NO_ERROR;
-}
-XCamReturn
-DynamicAnalyzer::pre_3a_analyze (SmartPtr<X3aStats> &stats)
-{
-    XCamReturn ret = XCAM_RETURN_NO_ERROR;
-    XCamCommonParam common_params = _common_handler->get_params_unlock ();
-
-    XCAM_ASSERT (_context);
-    _cur_stats = stats;
-    ret = _desc->set_3a_stats (_context, stats->get_stats (), stats->get_timestamp ());
-    XCAM_FAIL_RETURN (WARNING,
-                      ret == XCAM_RETURN_NO_ERROR,
-                      ret,
-                      "dynamic analyzer set_3a_stats failed");
-
-    ret = _desc->update_common_params (_context, &common_params);
-    XCAM_FAIL_RETURN (WARNING,
-                      ret == XCAM_RETURN_NO_ERROR,
-                      ret,
-                      "dynamic analyzer update common params failed");
-
-    return XCAM_RETURN_NO_ERROR;
-}
-
-XCamReturn
-DynamicAnalyzer::post_3a_analyze (X3aResultList &results)
-{
-    XCamReturn ret = XCAM_RETURN_NO_ERROR;
-    XCam3aResultHead *res_array[XCAM_3A_LIB_MAX_RESULT_COUNT];
-    uint32_t res_count = 0;
-
-    xcam_mem_clear (res_array);
-    XCAM_ASSERT (_context);
-    ret = _desc->combine_analyze_results (_context, res_array, &res_count);
-    XCAM_FAIL_RETURN (WARNING,
-                      ret == XCAM_RETURN_NO_ERROR,
-                      ret,
-                      "dynamic analyzer combine_analyze_results failed");
-
-    _cur_stats.release ();
-
-    if (res_count) {
-        ret = convert_results (res_array, res_count, results);
-        XCAM_FAIL_RETURN (WARNING,
-                          ret == XCAM_RETURN_NO_ERROR,
-                          ret,
-                          "dynamic analyzer convert_results failed");
-        _desc->free_results (res_array, res_count);
-    }
-
-    return XCAM_RETURN_NO_ERROR;
-}
-
-XCamReturn
-DynamicAnalyzer::convert_results (XCam3aResultHead *from[], uint32_t from_count, X3aResultList &to)
-{
-    for (uint32_t i = 0; i < from_count; ++i) {
-        SmartPtr<X3aResult> standard_res =
-            X3aResultFactory::instance ()->create_3a_result (from[i]);
-        to.push_back (standard_res);
-    }
-
-    return XCAM_RETURN_NO_ERROR;
-}
 
 AnalyzerLoader::AnalyzerLoader (const char *lib_path)
     : _path (NULL)
@@ -341,10 +44,9 @@ AnalyzerLoader::~AnalyzerLoader ()
         xcam_free (_path);
 }
 
-SmartPtr<X3aAnalyzer>
+XCam3ADescription *
 AnalyzerLoader::load_analyzer (SmartPtr<AnalyzerLoader> &self)
 {
-    SmartPtr<X3aAnalyzer> analyzer;
     XCam3ADescription *desc = NULL;
     const char *symbol = XCAM_3A_LIB_DESCRIPTION;
 
@@ -363,10 +65,37 @@ AnalyzerLoader::load_analyzer (SmartPtr<AnalyzerLoader> &self)
     }
 
     XCAM_LOG_DEBUG ("got symbols(%s) from lib(%s)", symbol, XCAM_STR (_path));
+    return desc;
+}
+
+SmartPtr<X3aAnalyzer>
+AnalyzerLoader::load_dynamic_analyzer (SmartPtr<AnalyzerLoader> &self)
+{
+    SmartPtr<X3aAnalyzer> analyzer;
+    XCam3ADescription *desc = load_analyzer (self);
 
     analyzer = new DynamicAnalyzer (desc, self);
     if (!analyzer.ptr ()) {
-        XCAM_LOG_WARNING ("get symbol(%s) from lib:%s failed", symbol, XCAM_STR (_path));
+        XCAM_LOG_WARNING ("create analyzer(%s) from lib:%s failed", XCAM_STR (analyzer->get_name()), XCAM_STR (_path));
+        close_handle ();
+        return NULL;
+    }
+
+    XCAM_LOG_INFO ("analyzer(%s) created from 3a lib(%s)", XCAM_STR (analyzer->get_name()), XCAM_STR (_path));
+    return analyzer;
+}
+
+SmartPtr<X3aAnalyzer>
+AnalyzerLoader::load_hybrid_analyzer (SmartPtr<AnalyzerLoader> &self,
+                                      SmartPtr<IspController> &isp,
+                                      const char *cpf_path)
+{
+    SmartPtr<X3aAnalyzer> analyzer;
+    XCam3ADescription *desc = load_analyzer (self);
+
+    analyzer = new HybridAnalyzer (desc, self, isp, cpf_path);
+    if (!analyzer.ptr ()) {
+        XCAM_LOG_WARNING ("create analyzer(%s) from lib:%s failed", XCAM_STR (analyzer->get_name()), XCAM_STR (_path));
         close_handle ();
         return NULL;
     }

--- a/xcore/analyzer_loader.h
+++ b/xcore/analyzer_loader.h
@@ -27,6 +27,8 @@
 #include "x3a_analyzer.h"
 
 namespace XCam {
+class IspController;
+class HybridAnalyzer;
 
 class AnalyzerLoader
 {
@@ -34,13 +36,17 @@ public:
     AnalyzerLoader (const char *lib_path);
     ~AnalyzerLoader ();
 
-    SmartPtr<X3aAnalyzer> load_analyzer (SmartPtr<AnalyzerLoader> &self);
+    SmartPtr<X3aAnalyzer> load_dynamic_analyzer (SmartPtr<AnalyzerLoader> &self);
+    SmartPtr<X3aAnalyzer> load_hybrid_analyzer (SmartPtr<AnalyzerLoader> &self,
+            SmartPtr<IspController> &isp,
+            const char *cpf_path);
 
 private:
     bool open_handle ();
     XCam3ADescription *get_symbol (const char *symbol);
     bool close_handle ();
     void convert_results (XCam3aResultHead *from, uint32_t num_of_from, X3aResultList &to);
+    XCam3ADescription *load_analyzer (SmartPtr<AnalyzerLoader> &self);
 
     XCAM_DEAD_COPY(AnalyzerLoader);
 

--- a/xcore/dynamic_analyzer.cpp
+++ b/xcore/dynamic_analyzer.cpp
@@ -1,0 +1,214 @@
+/*
+ * analyzer_loader.cpp - analyzer loader
+ *
+ *  Copyright (c) 2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Wind Yuan <feng.yuan@intel.com>
+ */
+
+#include "dynamic_analyzer.h"
+
+namespace XCam {
+
+DynamicAnalyzer::DynamicAnalyzer (XCam3ADescription *desc, SmartPtr<AnalyzerLoader> &loader, const char *name)
+    : X3aAnalyzer (name)
+    , _desc (desc)
+    , _context (NULL)
+    , _loader (loader)
+{
+}
+
+DynamicAnalyzer::~DynamicAnalyzer ()
+{
+    destroy_context ();
+}
+
+XCamReturn
+DynamicAnalyzer::create_context ()
+{
+    XCam3AContext *context = NULL;
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+    XCAM_ASSERT (!_context);
+    if ((ret = _desc->create_context (&context)) != XCAM_RETURN_NO_ERROR) {
+        XCAM_LOG_WARNING ("dynamic 3a lib create context failed");
+        return ret;
+    }
+    _context = context;
+    return XCAM_RETURN_NO_ERROR;
+}
+
+void
+DynamicAnalyzer::destroy_context ()
+{
+    if (_context && _desc && _desc->destroy_context) {
+        _desc->destroy_context (_context);
+        _context = NULL;
+    }
+}
+
+XCamReturn
+DynamicAnalyzer::analyze_ae (XCamAeParam &param)
+{
+    XCAM_ASSERT (_context);
+    return _desc->analyze_ae (_context, &param);
+}
+
+XCamReturn
+DynamicAnalyzer::analyze_awb (XCamAwbParam &param)
+{
+    XCAM_ASSERT (_context);
+    return _desc->analyze_awb (_context, &param);
+}
+
+XCamReturn
+DynamicAnalyzer::analyze_af (XCamAfParam &param)
+{
+    XCAM_ASSERT (_context);
+    return _desc->analyze_af (_context, &param);
+}
+
+SmartPtr<AeHandler>
+DynamicAnalyzer::create_ae_handler ()
+{
+    return new DynamicAeHandler (this);
+}
+
+SmartPtr<AwbHandler>
+DynamicAnalyzer::create_awb_handler ()
+{
+    return new DynamicAwbHandler (this);
+}
+
+SmartPtr<AfHandler>
+DynamicAnalyzer::create_af_handler ()
+{
+    return new DynamicAfHandler (this);
+}
+
+SmartPtr<CommonHandler>
+DynamicAnalyzer::create_common_handler ()
+{
+    if (_common_handler.ptr())
+        return _common_handler;
+
+    _common_handler = new DynamicCommonHandler (this);
+    return _common_handler;
+}
+
+XCamReturn
+DynamicAnalyzer::internal_init (uint32_t width, uint32_t height, double framerate)
+{
+    XCAM_UNUSED (width);
+    XCAM_UNUSED (height);
+    XCAM_UNUSED (framerate);
+    return create_context ();
+}
+
+XCamReturn
+DynamicAnalyzer::internal_deinit ()
+{
+    destroy_context ();
+    return XCAM_RETURN_NO_ERROR;
+}
+
+XCamReturn
+DynamicAnalyzer::configure_3a ()
+{
+    uint32_t width = get_width ();
+    uint32_t height = get_height ();
+    double framerate = get_framerate ();
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+
+    XCAM_ASSERT (_context);
+
+    ret = _desc->configure_3a (_context, width, height, framerate);
+    XCAM_FAIL_RETURN (WARNING,
+                      ret == XCAM_RETURN_NO_ERROR,
+                      ret,
+                      "dynamic analyzer configure 3a failed");
+    set_manual_brightness(_brightness_level_param);
+
+    return XCAM_RETURN_NO_ERROR;
+}
+XCamReturn
+DynamicAnalyzer::pre_3a_analyze (SmartPtr<X3aStats> &stats)
+{
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+    XCamCommonParam common_params = _common_handler->get_params_unlock ();
+
+    XCAM_ASSERT (_context);
+    _cur_stats = stats;
+    ret = _desc->set_3a_stats (_context, stats->get_stats (), stats->get_timestamp ());
+    XCAM_FAIL_RETURN (WARNING,
+                      ret == XCAM_RETURN_NO_ERROR,
+                      ret,
+                      "dynamic analyzer set_3a_stats failed");
+
+    ret = _desc->update_common_params (_context, &common_params);
+    XCAM_FAIL_RETURN (WARNING,
+                      ret == XCAM_RETURN_NO_ERROR,
+                      ret,
+                      "dynamic analyzer update common params failed");
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+XCamReturn
+DynamicAnalyzer::post_3a_analyze (X3aResultList &results)
+{
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+    XCam3aResultHead *res_array[XCAM_3A_LIB_MAX_RESULT_COUNT];
+    uint32_t res_count = 0;
+
+    xcam_mem_clear (res_array);
+    XCAM_ASSERT (_context);
+    ret = _desc->combine_analyze_results (_context, res_array, &res_count);
+    XCAM_FAIL_RETURN (WARNING,
+                      ret == XCAM_RETURN_NO_ERROR,
+                      ret,
+                      "dynamic analyzer combine_analyze_results failed");
+
+    _cur_stats.release ();
+
+    if (res_count) {
+        ret = convert_results (res_array, res_count, results);
+        XCAM_FAIL_RETURN (WARNING,
+                          ret == XCAM_RETURN_NO_ERROR,
+                          ret,
+                          "dynamic analyzer convert_results failed");
+        _desc->free_results (res_array, res_count);
+    }
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+const XCamCommonParam
+DynamicAnalyzer::get_common_params ()
+{
+    return _common_handler->get_params_unlock ();
+}
+
+XCamReturn
+DynamicAnalyzer::convert_results (XCam3aResultHead *from[], uint32_t from_count, X3aResultList &to)
+{
+    for (uint32_t i = 0; i < from_count; ++i) {
+        SmartPtr<X3aResult> standard_res =
+            X3aResultFactory::instance ()->create_3a_result (from[i]);
+        to.push_back (standard_res);
+    }
+
+    return XCAM_RETURN_NO_ERROR;
+}
+}

--- a/xcore/dynamic_analyzer.h
+++ b/xcore/dynamic_analyzer.h
@@ -1,0 +1,153 @@
+/*
+ * dynamic_analyzer.h - dynamic analyzer
+ *
+ *  Copyright (c) 2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Wind Yuan <feng.yuan@intel.com>
+ */
+#ifndef XCAM_DYNAMIC_ANALYZER_H
+#define XCAM_DYNAMIC_ANALYZER_H
+
+#include <base/xcam_3a_description.h>
+#include "analyzer_loader.h"
+#include "x3a_analyzer.h"
+#include "x3a_stats_pool.h"
+#include "handler_interface.h"
+#include "x3a_result_factory.h"
+
+namespace XCam {
+
+class DynamicAeHandler;
+class DynamicAwbHandler;
+class DynamicAfHandler;
+class DynamicCommonHandler;
+
+class DynamicAnalyzer
+    : public X3aAnalyzer
+{
+public:
+    DynamicAnalyzer (XCam3ADescription *desc, SmartPtr<AnalyzerLoader> &loader, const char *name = "DynamicAnalyzer");
+    ~DynamicAnalyzer ();
+
+    virtual XCamReturn configure_3a ();
+    virtual XCamReturn analyze_ae (XCamAeParam &param);
+    virtual XCamReturn analyze_awb (XCamAwbParam &param);
+    virtual XCamReturn analyze_af (XCamAfParam &param);
+
+protected:
+    virtual SmartPtr<AeHandler> create_ae_handler ();
+    virtual SmartPtr<AwbHandler> create_awb_handler ();
+    virtual SmartPtr<AfHandler> create_af_handler ();
+    virtual SmartPtr<CommonHandler> create_common_handler ();
+    virtual XCamReturn internal_init (uint32_t width, uint32_t height, double framerate);
+    virtual XCamReturn internal_deinit ();
+
+    virtual XCamReturn pre_3a_analyze (SmartPtr<X3aStats> &stats);
+    virtual XCamReturn post_3a_analyze (X3aResultList &results);
+
+    XCamReturn create_context ();
+    void destroy_context ();
+
+    const XCamCommonParam get_common_params ();
+    SmartPtr<X3aStats> get_cur_stats () const {
+        return _cur_stats;
+    }
+
+private:
+    XCamReturn convert_results (XCam3aResultHead *from[], uint32_t from_count, X3aResultList &to);
+    XCAM_DEAD_COPY (DynamicAnalyzer);
+
+private:
+    XCam3ADescription           *_desc;
+    XCam3AContext               *_context;
+    SmartPtr<X3aStats>           _cur_stats;
+    SmartPtr<DynamicCommonHandler> _common_handler;
+    SmartPtr<AnalyzerLoader>       _loader;
+};
+
+class DynamicAeHandler
+    : public AeHandler
+{
+public:
+    explicit DynamicAeHandler (DynamicAnalyzer *analyzer)
+        : _analyzer (analyzer)
+    {}
+    virtual XCamReturn analyze (X3aResultList &output) {
+        XCAM_UNUSED (output);
+        AnalyzerHandler::HandlerLock lock(this);
+        XCamAeParam param = this->get_params_unlock ();
+        return _analyzer->analyze_ae (param);
+    }
+
+private:
+    DynamicAnalyzer *_analyzer;
+};
+
+class DynamicAwbHandler
+    : public AwbHandler
+{
+public:
+    explicit DynamicAwbHandler (DynamicAnalyzer *analyzer)
+        : _analyzer (analyzer)
+    {}
+    virtual XCamReturn analyze (X3aResultList &output) {
+        XCAM_UNUSED (output);
+        AnalyzerHandler::HandlerLock lock(this);
+        XCamAwbParam param = this->get_params_unlock ();
+        return _analyzer->analyze_awb (param);
+    }
+
+private:
+    DynamicAnalyzer *_analyzer;
+};
+
+class DynamicAfHandler
+    : public AfHandler
+{
+public:
+    explicit DynamicAfHandler (DynamicAnalyzer *analyzer)
+        : _analyzer (analyzer)
+    {}
+    virtual XCamReturn analyze (X3aResultList &output) {
+        XCAM_UNUSED (output);
+        AnalyzerHandler::HandlerLock lock(this);
+        XCamAfParam param = this->get_params_unlock ();
+        return _analyzer->analyze_af (param);
+    }
+
+private:
+    DynamicAnalyzer *_analyzer;
+};
+
+class DynamicCommonHandler
+    : public CommonHandler
+{
+    friend class DynamicAnalyzer;
+public:
+    explicit DynamicCommonHandler (DynamicAnalyzer *analyzer)
+        : _analyzer (analyzer)
+    {}
+    virtual XCamReturn analyze (X3aResultList &output) {
+        XCAM_UNUSED (output);
+        AnalyzerHandler::HandlerLock lock(this);
+        return XCAM_RETURN_NO_ERROR;
+    }
+
+private:
+    DynamicAnalyzer *_analyzer;
+};
+}
+
+#endif //XCAM_DYNAMIC_ANALYZER_H

--- a/xcore/hybrid_analyzer.cpp
+++ b/xcore/hybrid_analyzer.cpp
@@ -1,0 +1,161 @@
+/*
+ * hybrid_analyzer.h - hybrid analyzer
+ *
+ *  Copyright (c) 2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Jia Meng <jia.meng@intel.com>
+ */
+
+#include "hybrid_analyzer.h"
+#include "isp_controller.h"
+#include "x3a_analyzer_aiq.h"
+
+namespace XCam {
+HybridAnalyzer::HybridAnalyzer (XCam3ADescription *desc,
+                                SmartPtr<AnalyzerLoader> &loader,
+                                SmartPtr<IspController> &isp,
+                                const char *cpf_path)
+    : DynamicAnalyzer (desc, loader, "HybridAnalyzer"),
+      _isp (isp),
+      _cpf_path (cpf_path)
+{
+    _analyzer_aiq = new X3aAnalyzerAiq (isp, cpf_path);
+    XCAM_ASSERT (_analyzer_aiq.ptr ());
+    _analyzer_aiq->prepare_handlers ();
+    _analyzer_aiq->set_results_callback (this);
+    _analyzer_aiq->set_sync_mode (true);
+}
+
+XCamReturn
+HybridAnalyzer::internal_init (uint32_t width, uint32_t height, double framerate)
+{
+    if (_analyzer_aiq->init (width, height, framerate) != XCAM_RETURN_NO_ERROR) {
+        return XCAM_RETURN_ERROR_AIQ;
+    }
+
+    return create_context ();
+}
+
+XCamReturn
+HybridAnalyzer::internal_deinit ()
+{
+    if (_analyzer_aiq->deinit () != XCAM_RETURN_NO_ERROR) {
+        return XCAM_RETURN_ERROR_AIQ;
+    }
+
+    return DynamicAnalyzer::internal_deinit ();
+}
+
+XCamReturn
+HybridAnalyzer::configure_3a ()
+{
+    if (_analyzer_aiq->start () != XCAM_RETURN_NO_ERROR) {
+        return XCAM_RETURN_ERROR_AIQ;
+    }
+
+    return DynamicAnalyzer::configure_3a ();
+}
+
+XCamReturn
+HybridAnalyzer::pre_3a_analyze (SmartPtr<X3aStats> &stats)
+{
+    _analyzer_aiq->update_common_parameters (get_common_params ());
+
+    return DynamicAnalyzer::pre_3a_analyze (stats);
+}
+
+XCamReturn
+HybridAnalyzer::post_3a_analyze (X3aResultList &results)
+{
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+    SmartPtr<X3aStats> stats = get_cur_stats ();
+
+    if ((ret = DynamicAnalyzer::post_3a_analyze (results)) != XCAM_RETURN_NO_ERROR) {
+        return ret;
+    }
+
+    for (X3aResultList::iterator i_res = results.begin ();
+            i_res != results.end (); ++i_res) {
+        SmartPtr<X3aResult> result = *i_res;
+
+        switch (result->get_type ()) {
+        case XCAM_3A_RESULT_EXPOSURE: {
+            XCam3aResultExposure *res = (XCam3aResultExposure *) result->get_ptr ();
+            _analyzer_aiq->set_ae_mode (XCAM_AE_MODE_MANUAL);
+            _analyzer_aiq->set_ae_manual_exposure_time (res->exposure_time);
+            _analyzer_aiq->set_ae_manual_analog_gain (res->analog_gain);
+            break;
+        }
+        case XCAM_3A_RESULT_WHITE_BALANCE: {
+            _analyzer_aiq->set_awb_mode (XCAM_AWB_MODE_MANUAL);
+            XCam3aResultWhiteBalance *res = (XCam3aResultWhiteBalance *) result->get_ptr ();
+            _analyzer_aiq->set_awb_manual_gain (res->gr_gain, res->r_gain, res->b_gain, res->gb_gain);
+            break;
+        }
+        default:
+            break;
+        }
+    }
+
+    results.clear ();
+    return _analyzer_aiq->push_3a_stats (stats);
+}
+
+XCamReturn
+HybridAnalyzer::analyze_ae (XCamAeParam &param)
+{
+    if (!_analyzer_aiq->update_ae_parameters (param))
+        return XCAM_RETURN_ERROR_AIQ;
+
+    return DynamicAnalyzer::analyze_ae (param);
+}
+
+XCamReturn
+HybridAnalyzer::analyze_awb (XCamAwbParam &param)
+{
+    if (!_analyzer_aiq->update_awb_parameters (param))
+        return XCAM_RETURN_ERROR_AIQ;
+
+    return DynamicAnalyzer::analyze_awb (param);
+}
+
+XCamReturn
+HybridAnalyzer::analyze_af (XCamAfParam &param)
+{
+    if (!_analyzer_aiq->update_af_parameters (param))
+        return XCAM_RETURN_ERROR_AIQ;
+
+    return DynamicAnalyzer::analyze_af (param);
+}
+
+void
+HybridAnalyzer::x3a_calculation_done (X3aAnalyzer *analyzer, X3aResultList &results)
+{
+    XCAM_UNUSED (analyzer);
+    notify_calculation_done (results);
+}
+
+HybridAnalyzer::~HybridAnalyzer ()
+{
+    destroy_context ();
+}
+
+void
+HybridAnalyzer::x3a_calculation_failed (X3aAnalyzer *analyzer, int64_t timestamp, const char *msg)
+{
+    XCAM_UNUSED (analyzer);
+    notify_calculation_failed (NULL, timestamp, msg);
+}
+}

--- a/xcore/hybrid_analyzer.h
+++ b/xcore/hybrid_analyzer.h
@@ -1,0 +1,66 @@
+/*
+ * hybrid_analyzer.h - hybrid analyzer
+ *
+ *  Copyright (c) 2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Jia Meng <jia.meng@intel.com>
+ */
+
+#ifndef XCAM_HYBRID_ANALYZER_H
+#define XCAM_HYBRID_ANALYZER_H
+
+#include "dynamic_analyzer.h"
+
+namespace XCam {
+class IspController;
+class X3aAnalyzerAiq;
+
+class HybridAnalyzer
+    : public DynamicAnalyzer
+    , public AnalyzerCallback
+{
+public:
+    explicit HybridAnalyzer (XCam3ADescription *desc,
+                             SmartPtr<AnalyzerLoader> &loader,
+                             SmartPtr<IspController> &isp,
+                             const char *cpf_path);
+    ~HybridAnalyzer ();
+
+    virtual XCamReturn analyze_ae (XCamAeParam &param);
+    virtual XCamReturn analyze_awb (XCamAwbParam &param);
+    virtual XCamReturn analyze_af (XCamAfParam &param);
+
+    virtual void x3a_calculation_done (X3aAnalyzer *analyzer, X3aResultList &results);
+    virtual void x3a_calculation_failed (X3aAnalyzer *analyzer, int64_t timestamp, const char *msg);
+
+protected:
+    virtual XCamReturn internal_init (uint32_t width, uint32_t height, double framerate);
+    virtual XCamReturn internal_deinit ();
+
+    virtual XCamReturn configure_3a ();
+    virtual XCamReturn pre_3a_analyze (SmartPtr<X3aStats> &stats);
+    virtual XCamReturn post_3a_analyze (X3aResultList &results);
+
+private:
+    XCAM_DEAD_COPY (HybridAnalyzer);
+
+    SmartPtr <IspController>       _isp;
+    const char                    *_cpf_path;
+    SmartPtr <X3aAnalyzerAiq>      _analyzer_aiq;
+};
+
+}
+
+#endif //XCAM_HYBRID_ANALYZER_H

--- a/xcore/x3a_analyzer_manager.cpp
+++ b/xcore/x3a_analyzer_manager.cpp
@@ -104,7 +104,7 @@ X3aAnalyzerManager::load_analyzer_from_binary (const char *path)
 
     _loader.release ();
     _loader = new AnalyzerLoader (path);
-    analyzer = _loader->load_analyzer (_loader);
+    analyzer = _loader->load_dynamic_analyzer (_loader);
 
     if (analyzer.ptr ())
         return analyzer;


### PR DESCRIPTION
 * hybrid analyzer extends dynamic analyzer and composites aiq
   analyzer
 * with analyzer, customer ae/awb 3a results will be applied to
   aiq maunal settings
 * test: put a customized 3a lib under /usr/lib/xcam/, then
   test-device-manager -f YUYV -m dma -d video -p -a hybrid

I made a dummy customized 3a lib to verify that its 3a results can impact AIQ result:
```cpp
#include <base/xcam_3a_description.h>
#include "xcam_utils.h"

using namespace XCam;

#define AIQ_CONTEXT_CAST(context)  ((XCam3ASampleContext*)(context))

class XCam3ASampleContext
{
public:
    XCam3ASampleContext ();
    ~XCam3ASampleContext ();

private:
    XCAM_DEAD_COPY (XCam3ASampleContext);

};

XCam3ASampleContext::XCam3ASampleContext ()
{
}

XCam3ASampleContext::~XCam3ASampleContext ()
{
}

static XCamReturn
xcam_create_context (XCam3AContext **context)
{
    XCAM_ASSERT (context);
    XCam3ASampleContext *ctx = new XCam3ASampleContext ();
    *context = ((XCam3AContext*)(ctx));
    return XCAM_RETURN_NO_ERROR;
}

static XCamReturn
xcam_destroy_context (XCam3AContext *context)
{
    XCam3ASampleContext *ctx = AIQ_CONTEXT_CAST (context);
    if (ctx)
        delete ctx;
    return XCAM_RETURN_NO_ERROR;
}

static XCamReturn
xcam_configure_3a (XCam3AContext *context, uint32_t width, uint32_t height, double framerate)
{
    return XCAM_RETURN_NO_ERROR;
}

static XCamReturn
xcam_set_3a_stats (XCam3AContext *context, XCam3AStats *stats, int64_t timestamp)
{
    XCam3AStatsInfo info = stats->info;
    for (uint32_t i = 0; i < info.height; ++i)
        for (uint32_t j = 0; j < info.width; ++j) {
            XCAM_LOG_DEBUG ("%d %d %d %d %d %d %d %d",
                           stats->stats[i * info.aligned_width + j].avg_y,
                           stats->stats[i * info.aligned_width + j].avg_gr,
                           stats->stats[i * info.aligned_width + j].avg_r,
                           stats->stats[i * info.aligned_width + j].avg_b, 
                           stats->stats[i * info.aligned_width + j].avg_gb,
                           stats->stats[i * info.aligned_width + j].valid_wb_count,
                           stats->stats[i * info.aligned_width + j].f_value1,
                           stats->stats[i * info.aligned_width + j].f_value2);
        }
    return XCAM_RETURN_NO_ERROR;
}

static XCamReturn
xcam_update_common_params (XCam3AContext *context, XCamCommonParam *params)
{
    return XCAM_RETURN_NO_ERROR;
}

static XCamReturn
xcam_analyze_awb (XCam3AContext *context, XCamAwbParam *params)
{
    return XCAM_RETURN_NO_ERROR;
}

static XCamReturn
xcam_analyze_ae (XCam3AContext *context, XCamAeParam *params)
{
    return XCAM_RETURN_NO_ERROR;
}

static XCamReturn
xcam_analyze_af (XCam3AContext *context, XCamAfParam *params)
{
    return XCAM_RETURN_NO_ERROR;
}

static XCamReturn
xcam_combine_analyze_results (XCam3AContext *context, XCam3aResultHead *results[], uint32_t *res_count)
{
    uint32_t result_count = 2;
    static XCam3aResultHead *res_array[XCAM_3A_LIB_MAX_RESULT_COUNT];
    xcam_mem_clear (res_array);

    for (uint32_t i = 0; i < result_count; ++i) {
        results[i] = res_array[i];
    }
    *res_count = result_count;

    XCam3aResultExposure *exposure = xcam_malloc0_type (XCam3aResultExposure);
    exposure->head.type = XCAM_3A_RESULT_EXPOSURE;
    exposure->head.process_type = XCAM_IMAGE_PROCESS_ALWAYS;
    exposure->head.version = XCAM_VERSION;
    exposure->exposure_time = 5000; //5ms
    exposure->analog_gain = 10;
    results[0] = (XCam3aResultHead *)exposure;

    XCam3aResultWhiteBalance *wb = xcam_malloc0_type (XCam3aResultWhiteBalance);
    wb->head.type = XCAM_3A_RESULT_WHITE_BALANCE;
    wb->head.process_type = XCAM_IMAGE_PROCESS_ALWAYS;
    wb->head.version = XCAM_VERSION;
    wb->gr_gain = 2;
    wb->r_gain = 2;
    wb->b_gain = 2;
    wb->gb_gain = 2;
    results[1] = (XCam3aResultHead *)wb;
    
    return XCAM_RETURN_NO_ERROR;
}

static void
xcam_free_results (XCam3aResultHead *results[], uint32_t res_count)
{
    for (uint32_t i = 0; i < res_count; ++i) {
        if (results[i])
            xcam_free (results[i]);
    }
}

XCAM_BEGIN_DECLARE

XCam3ADescription xcam_3a_desciption = {
    XCAM_VERSION,
    sizeof (XCam3ADescription),
    xcam_create_context,
    xcam_destroy_context,
    xcam_configure_3a,
    xcam_set_3a_stats,
    xcam_update_common_params,
    xcam_analyze_awb,
    xcam_analyze_ae,
    xcam_analyze_af,
    xcam_combine_analyze_results,
    xcam_free_results
};

XCAM_END_DECLARE
```