### PR TITLE
xcamsrc: support options for cl pipe profile

### DIFF
--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -89,6 +89,7 @@ struct _GstXCamSrc
     VideoBufferInfo              xcam_video_info;
     ImageProcessorType           image_processor_type;
     AnalyzerType                 analyzer_type;
+    int32_t                      cl_pipe_profile;
     SmartPtr<MainDeviceManager>  device_manager;
 };
 

--- a/xcore/cl_3a_image_processor.h
+++ b/xcore/cl_3a_image_processor.h
@@ -49,16 +49,24 @@ class CLRgbPipeImageHandler;
 class CL3aImageProcessor
     : public CLImageProcessor
 {
+public:
     enum OutSampleType {
         OutSampleYuv,
         OutSampleRGB,
         OutSampleBayer,
     };
 
+    enum PipelineProfile {
+        BasicPipelineProfile    = 0,
+        AdvancedPipelineProfile,
+        ExtremePipelineProfile,
+    };
+
 public:
     explicit CL3aImageProcessor ();
     virtual ~CL3aImageProcessor ();
 
+    bool set_profile (PipelineProfile value);
     void set_stats_callback (const SmartPtr<StatsCallback> &callback);
 
     bool set_output_format (uint32_t fourcc);
@@ -69,6 +77,10 @@ public:
     virtual bool set_macc (bool enable);
     virtual bool set_dpc (bool enable);
     virtual bool set_tnr (uint32_t mode, uint8_t level);
+
+    PipelineProfile get_profile () const {
+        return _pipeline_profile;
+    }
 
 protected:
 
@@ -84,6 +96,7 @@ private:
 private:
     uint32_t                           _output_fourcc;
     OutSampleType                      _out_smaple_type;
+    PipelineProfile                    _pipeline_profile;
 
     SmartPtr<StatsCallback>            _stats_callback;
 


### PR DESCRIPTION
 * add 'pipe-profile' options for different cl pipe profile
 * tests:
   gst-launch-1.0 xcamsrc io-mode=4 imageprocessor=1 analyzer=2 \
   pipe-profile=basic ! video/x-raw, format=NV12, width=1920, \
   height=1080, framerate=25/1 ! fakesink