### PR TITLE
Attach timestamps on the results of x3a analyzer to synchronize with …

### DIFF
--- a/xcore/cl_3a_image_processor.cpp
+++ b/xcore/cl_3a_image_processor.cpp
@@ -153,49 +153,66 @@ CL3aImageProcessor::apply_3a_result (SmartPtr<X3aResult> &result)
     case XCAM_3A_RESULT_WHITE_BALANCE: {
         SmartPtr<X3aWhiteBalanceResult> wb_res = result.dynamic_cast_ptr<X3aWhiteBalanceResult> ();
         XCAM_ASSERT (wb_res.ptr ());
-        if (_wb.ptr ())
+        if (_wb.ptr ()) {
             _wb->set_wb_config (wb_res->get_standard_result ());
-        if (_bayer_pipe.ptr ())
+            _wb->set_3a_result (result);
+        }
+        if (_bayer_pipe.ptr ()) {
             _bayer_pipe->set_wb_config (wb_res->get_standard_result ());
+            _bayer_pipe->set_3a_result (result);
+        }
         break;
     }
 
     case XCAM_3A_RESULT_BLACK_LEVEL: {
         SmartPtr<X3aBlackLevelResult> bl_res = result.dynamic_cast_ptr<X3aBlackLevelResult> ();
         XCAM_ASSERT (bl_res.ptr ());
-        if (_black_level.ptr ())
+        if (_black_level.ptr ()) {
             _black_level->set_blc_config (bl_res->get_standard_result ());
-        if (_bayer_pipe.ptr ())
+            _black_level->set_3a_result (result);
+        }
+        if (_bayer_pipe.ptr ()) {
             _bayer_pipe->set_blc_config (bl_res->get_standard_result ());
+            _bayer_pipe->set_3a_result (result);
+        }
         break;
     }
 
     case XCAM_3A_RESULT_DEFECT_PIXEL_CORRECTION: {
         SmartPtr<X3aDefectPixelResult> def_res = result.dynamic_cast_ptr<X3aDefectPixelResult> ();
         XCAM_ASSERT (def_res.ptr ());
-        if (!_dpc.ptr())
-            break;
-        _dpc->set_dpc_config (def_res->get_standard_result ());
+        if (_dpc.ptr ()) {
+            _dpc->set_dpc_config (def_res->get_standard_result ());
+            _dpc->set_3a_result (result);
+        }
         break;
     }
 
     case XCAM_3A_RESULT_RGB2YUV_MATRIX: {
         SmartPtr<X3aColorMatrixResult> csc_res = result.dynamic_cast_ptr<X3aColorMatrixResult> ();
         XCAM_ASSERT (csc_res.ptr ());
-        if (_csc.ptr())
+        if (_csc.ptr()) {
             _csc->set_rgbtoyuv_matrix (csc_res->get_standard_result ());
-        if (_yuv_pipe.ptr())
+            _csc->set_3a_result (result);
+        }
+        if (_yuv_pipe.ptr()) {
             _yuv_pipe->set_rgbtoyuv_matrix (csc_res->get_standard_result ());
+            _yuv_pipe->set_3a_result (result);
+        }
         break;
     }
 
     case XCAM_3A_RESULT_MACC: {
         SmartPtr<X3aMaccMatrixResult> macc_res = result.dynamic_cast_ptr<X3aMaccMatrixResult> ();
         XCAM_ASSERT (macc_res.ptr ());
-        if (_macc.ptr())
+        if (_macc.ptr()) {
             _macc->set_macc_table (macc_res->get_standard_result ());
-        if (_yuv_pipe.ptr())
+            _macc->set_3a_result (result);
+        }
+        if (_yuv_pipe.ptr()) {
             _yuv_pipe->set_macc_table (macc_res->get_standard_result ());
+            _yuv_pipe->set_3a_result (result);
+        }
         break;
     }
     case XCAM_3A_RESULT_R_GAMMA:
@@ -206,23 +223,27 @@ CL3aImageProcessor::apply_3a_result (SmartPtr<X3aResult> &result)
     case XCAM_3A_RESULT_Y_GAMMA: {
         SmartPtr<X3aGammaTableResult> gamma_res = result.dynamic_cast_ptr<X3aGammaTableResult> ();
         XCAM_ASSERT (gamma_res.ptr ());
-        if (_gamma.ptr())
+        if (_gamma.ptr()) {
             _gamma->set_gamma_table (gamma_res->get_standard_result ());
-        if (_bayer_pipe.ptr ())
+            _gamma->set_3a_result (result);
+        }
+        if (_bayer_pipe.ptr ()) {
             _bayer_pipe->set_gamma_table (gamma_res->get_standard_result ());
+            _bayer_pipe->set_3a_result (result);
+        }
         break;
     }
 
     case XCAM_3A_RESULT_TEMPORAL_NOISE_REDUCTION_RGB: {
         SmartPtr<X3aTemporalNoiseReduction> tnr_res = result.dynamic_cast_ptr<X3aTemporalNoiseReduction> ();
         XCAM_ASSERT (tnr_res.ptr ());
-
         if (_tnr_rgb.ptr()) {
             _tnr_rgb->set_rgb_config (tnr_res->get_standard_result ());
+            _tnr_rgb->set_3a_result (result);
         }
-
         if (_rgb_pipe.ptr ()) {
             _rgb_pipe->set_tnr_config(tnr_res->get_standard_result ());
+            _rgb_pipe->set_3a_result (result);
         }
 
         break;
@@ -233,6 +254,7 @@ CL3aImageProcessor::apply_3a_result (SmartPtr<X3aResult> &result)
         XCAM_ASSERT (tnr_res.ptr ());
         if (_tnr_yuv.ptr()) {
             _tnr_yuv->set_yuv_config (tnr_res->get_standard_result ());
+            _tnr_yuv->set_3a_result (result);
         }
         break;
     }
@@ -248,6 +270,7 @@ CL3aImageProcessor::apply_3a_result (SmartPtr<X3aResult> &result)
         if (!_ee.ptr())
             break;
         _ee->set_ee_config_nr (ee_nr_res->get_standard_result ());
+        _ee->set_3a_result (result);
         break;
     }
 
@@ -257,6 +280,7 @@ CL3aImageProcessor::apply_3a_result (SmartPtr<X3aResult> &result)
         if (!_bnr.ptr())
             break;
         _bnr->set_bnr_config (bnr_res->get_standard_result ());
+        _bnr->set_3a_result (result);
         break;
     }
 
@@ -267,6 +291,7 @@ CL3aImageProcessor::apply_3a_result (SmartPtr<X3aResult> &result)
             break;
         float brightness_level = ((XCam3aResultBrightness)brightness_res->get_standard_result()).brightness_level;
         _gamma->set_manual_brightness(brightness_level);
+        _gamma->set_3a_result (result);
         break;
     }
     default:

--- a/xcore/cl_image_handler.cpp
+++ b/xcore/cl_image_handler.cpp
@@ -140,6 +140,7 @@ CLImageHandler::CLImageHandler (const char *name)
     : _name (NULL)
     , _buf_pool_type (CLImageHandler::CLBoPoolType)
     , _buf_pool_size (XCAM_CL_IMAGE_HANDLER_DEFAULT_BUF_NUM)
+    , _result_timestamp (XCam::InvalidTimestamp)
 {
     XCAM_ASSERT (name);
     if (name)
@@ -354,6 +355,43 @@ CLImageHandler::execute (SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &ou
     XCAM_OBJ_PROFILING_END (XCAM_STR (_name), 30);
 
     return XCAM_RETURN_NO_ERROR;
+}
+
+void
+CLImageHandler::set_3a_result (SmartPtr<X3aResult> &result)
+{
+    if (!result.ptr ())
+        return;
+
+    int64_t ts = result->get_timestamp ();
+    _result_timestamp = (ts != XCam::InvalidTimestamp) ? ts : _result_timestamp;
+
+    X3aResultList::iterator i_res = _3a_results.begin ();
+    for (; i_res != _3a_results.end(); ++i_res) {
+        if (result->get_type () == (*i_res)->get_type ()) {
+            (*i_res) = result;
+            break;
+        }
+    }
+
+    if (i_res == _3a_results.end ()) {
+        _3a_results.push_back (result);
+    }
+}
+
+SmartPtr<X3aResult>
+CLImageHandler::get_3a_result (XCam3aResultType type)
+{
+    X3aResultList::iterator i_res = _3a_results.begin ();
+    SmartPtr<X3aResult> res = (*i_res);
+
+    for ( ; i_res != _3a_results.end(); ++i_res) {
+        if (type == (*i_res)->get_type ()) {
+            res = (*i_res);
+            break;
+        }
+    }
+    return res;
 }
 
 };

--- a/xcore/cl_image_handler.h
+++ b/xcore/cl_image_handler.h
@@ -25,6 +25,7 @@
 #include "cl_kernel.h"
 #include "drm_bo_buffer.h"
 #include "cl_memory.h"
+#include "x3a_result.h"
 
 namespace XCam {
 
@@ -97,6 +98,13 @@ public:
         return _name;
     }
 
+    void set_3a_result (SmartPtr<X3aResult> &result);
+    SmartPtr<X3aResult> get_3a_result (XCam3aResultType type);
+
+    int64_t get_result_timestamp () const {
+        return _result_timestamp;
+    };
+
     void set_pool_type (BufferPoolType type) {
         _buf_pool_type = type;
     }
@@ -133,6 +141,8 @@ private:
     SmartPtr<BufferPool>       _buf_pool;
     BufferPoolType             _buf_pool_type;
     uint32_t                   _buf_pool_size;
+    X3aResultList              _3a_results;
+    int64_t                    _result_timestamp;
 
     XCAM_OBJ_PROFILING_DEFINES;
 };

--- a/xcore/x3a_analyzer.cpp
+++ b/xcore/x3a_analyzer.cpp
@@ -359,11 +359,25 @@ X3aAnalyzer::analyze_3a_statistics (SmartPtr<X3aStats> &stats)
         return ret;
     }
 
-    if (!results.empty ())
+    if (!results.empty ()) {
+        set_results_timestamp(results, stats->get_timestamp ());
         notify_calculation_done (results);
+    }
 
     return ret;
+}
 
+void
+X3aAnalyzer::set_results_timestamp (X3aResultList &results, int64_t timestamp)
+{
+    if (results.empty ())
+        return;
+
+    X3aResultList::iterator i_results = results.begin ();
+    for (; i_results != results.end ();  ++i_results)
+    {
+        (*i_results)->set_timestamp(timestamp);
+    }
 }
 
 void
@@ -619,6 +633,7 @@ bool
 X3aAnalyzer::set_parameter_brightness(double level)
 {
     _brightness_level_param = level;
+    return true;
 }
 
 bool

--- a/xcore/x3a_analyzer.h
+++ b/xcore/x3a_analyzer.h
@@ -160,6 +160,7 @@ protected:
 
 private:
     XCamReturn analyze_3a_statistics (SmartPtr<X3aStats> &stats);
+    void set_results_timestamp (X3aResultList &results, int64_t timestamp);
 
     XCAM_DEAD_COPY (X3aAnalyzer);
 

--- a/xcore/x3a_analyzer_aiq.cpp
+++ b/xcore/x3a_analyzer_aiq.cpp
@@ -104,7 +104,6 @@ X3aAnalyzerAiq::~X3aAnalyzerAiq()
 SmartPtr<AeHandler>
 X3aAnalyzerAiq::create_ae_handler ()
 {
-
     SmartPtr<AiqAeHandler> ae_handler = new AiqAeHandler (_aiq_compositor);
     _aiq_compositor->set_ae_handler (ae_handler);
     return ae_handler;

--- a/xcore/x3a_result.h
+++ b/xcore/x3a_result.h
@@ -34,7 +34,7 @@ protected:
     explicit X3aResult (
         uint32_t type,
         XCamImageProcessType process_type = XCAM_IMAGE_PROCESS_ALWAYS,
-        uint64_t timestamp = XCam::InvalidTimestamp
+        int64_t timestamp = XCam::InvalidTimestamp
     )
         : _type (type)
         , _process_type (process_type)
@@ -55,7 +55,10 @@ public:
     void set_done (bool flag) {
         _processed = flag;
     }
-    uint64_t get_timestamp () const {
+    void set_timestamp (int64_t timestamp) {
+        _timestamp = timestamp;
+    }
+    int64_t get_timestamp () const {
         return _timestamp;
     }
     uint32_t get_type () const {
@@ -83,7 +86,7 @@ protected:
     //XCam3aResultType      _type;
     uint32_t              _type;  // XCam3aResultType
     XCamImageProcessType  _process_type;
-    uint64_t              _timestamp;
+    int64_t               _timestamp;
     void                 *_ptr;
     bool                  _processed;
 };

--- a/xcore/xcam_utils.h
+++ b/xcore/xcam_utils.h
@@ -33,7 +33,6 @@ extern "C" {
 namespace XCam {
 
 static const int64_t InvalidTimestamp = INT64_C(-1);
-};
 
 inline double
 linear_interpolate_p2 (double value_start, double value_end,
@@ -119,5 +118,7 @@ linear_interpolate_p4(double value_lt, double value_rt,
                             (weight_lt + weight_rt + weight_lb + weight_rb) + 0.5 );
     return value;
 }
+
+};
 
 #endif //XCAM_UTILS_H


### PR DESCRIPTION
…the processed video frame

3A analyzer runs in different thread with image processor, in order to apply the right parameters / settings on each processed video frame, use timestamp to do synchronization.
-> Attach timestamps on Analyzer result parameters
-> The timestamps come from the input statistic data of Analyzer, and these originally come from input video frames.