### PR TITLE
cl: adjust tnr frame count and bayer pipe output format to improve

### DIFF
--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -294,6 +294,8 @@ void print_help (const char *bin_name)
             "\t --enable-bnr  enable bayer noise reduction\n"
             "\t --enable-dpc  enable defect pixel correction\n"
             "\t --enable-tonemapping  enable tonemapping\n"
+            "\t --pipeline    pipe mode\n"
+            "\t               select from [basic, advance], default is [basic]\n"
             "(e.g.: xxxx --hdr=xx --tnr=xx --tnr-level=xx --bilateral --enable-snr --enable-ee --enable-bnr --enable-dpc)\n\n"
 #endif
             , bin_name
@@ -340,6 +342,7 @@ int main (int argc, char *argv[])
     bool    have_usbcam = 0;
     char*   usb_device_name = NULL;
     bool sync_mode = false;
+    CL3aImageProcessor::PipelineProfile pipeline_mode = CL3aImageProcessor::BasicPipelineProfile;
 
     const char *short_opts = "sca:n:m:f:d:b:pi:e:h";
     const struct option long_opts[] = {
@@ -354,6 +357,7 @@ int main (int argc, char *argv[])
         {"enable-tonemapping", no_argument, NULL, 'M'},
         {"usb", required_argument, NULL, 'U'},
         {"sync", no_argument, NULL, 'Y'},
+        {"pipeline", required_argument, NULL, 'P'},
         {0, 0, 0, 0},
     };
 
@@ -504,6 +508,17 @@ int main (int argc, char *argv[])
             tonemapping_type = true;
             break;
         }
+        case 'P': {
+            if (!strcasecmp (optarg, "basic"))
+                pipeline_mode = CL3aImageProcessor::BasicPipelineProfile;
+            else if (!strcasecmp (optarg, "advance"))
+                pipeline_mode = CL3aImageProcessor::AdvancedPipelineProfile;
+            else {
+                print_help (bin_name);
+                return -1;
+            }
+            break;
+        }
 #endif
         case 'h':
             print_help (bin_name);
@@ -631,6 +646,7 @@ int main (int argc, char *argv[])
             cl_processor->set_output_format (V4L2_PIX_FMT_XBGR32);
         }
         cl_processor->set_tnr (tnr_type, tnr_level);
+        cl_processor->set_profile (pipeline_mode);
         analyzer->set_parameter_brightness((brightness_level - 128) / 128.0);
         device_manager->add_image_processor (cl_processor);
     }

--- a/xcore/cl_3a_image_processor.cpp
+++ b/xcore/cl_3a_image_processor.cpp
@@ -320,6 +320,9 @@ CL3aImageProcessor::create_handlers ()
         XCAM_RETURN_ERROR_CL,
         "CL3aImageProcessor create bayer pipe handler failed");
     _bayer_pipe->set_stats_callback (_stats_callback);
+    if (get_profile () >= AdvancedPipelineProfile) {
+        _bayer_pipe->set_output_format (V4L2_PIX_FMT_ABGR32);
+    }
     image_handler->set_pool_size (XCAM_CL_3A_IMAGE_MAX_POOL_SIZE);
     add_handler (image_handler);
 
@@ -453,6 +456,10 @@ CL3aImageProcessor::create_handlers ()
         XCAM_RETURN_ERROR_CL,
         "CL3aImageProcessor create tnr handler failed");
     _tnr_rgb->set_mode (CL_TNR_TYPE_RGB & _tnr_mode);
+    if (get_profile () >= AdvancedPipelineProfile) {
+        _tnr_rgb->set_mode (CL_TNR_TYPE_RGB);
+        _tnr_rgb->set_framecount(2);
+    }
     add_handler (image_handler);
 
     /* simple noise reduction */


### PR DESCRIPTION
advance pipeline performance.

* set tnr frame count to 2 in advance pipeline.
* set bayer pipe output to 8bit rgb in advance pipeline.