### PR TITLE
Align the BLC code with bayer pipeline

### DIFF
--- a/cl_kernel/kernel_blc.cl
+++ b/cl_kernel/kernel_blc.cl
@@ -21,17 +21,7 @@ uint decompression(uint data_in, uint color_bits)
 {
     uint data_out = 0;
 
-    if (color_bits == 12) {
-        if (data_in <= 2048)
-            data_out = data_in;
-        else if ((data_in > 2048) && (data_in <= 2944))
-            data_out = 2048 + 16 * (data_in - 2048);
-        else
-            data_out = 16384 + 64 * (data_in - 2944);
-    }
-    else {
-        data_out = data_in << (16 - color_bits);
-    }
+    data_out = data_in << (16 - color_bits);
 
     return data_out;
 }


### PR DESCRIPTION
In most of the sensor, it is using shifting bits directly to move 10 bits input
 to 16 bit raw data.

Customers can customize these code according to their own sensor configuration.