### PR TITLE
cl: adjust tnr frame count and bayer pipe output format to improve

### DIFF
--- a/cl_kernel/kernel_yuv_pipe.cl
+++ b/cl_kernel/kernel_yuv_pipe.cl
@@ -38,28 +38,133 @@ __inline void cl_macc(float *in, __global float *table)
     (*(in + 1)) = vo + 0.5;
 }
 
-__kernel void kernel_yuv_pipe (__read_only image2d_t input, __write_only image2d_t output, uint vertical_offset, __global float *matrix, __global float *table)
+__inline void cl_tnr(float4 *in, __read_only image2d_t inputFrame1, __read_only image2d_t inputFrame2, __read_only image2d_t inputFrame3, uint count, int x, int y, float tnr_gain, float thr_r, float thr_g, float thr_b)
+{
+
+    float4 in1[4], in2[4], in3[4];
+    float4 var[4];
+    float4 out[4];
+    float gain[4];
+    int cond[4];
+
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE | CLK_FILTER_NEAREST;
+    in1[0] = read_imagef(inputFrame1, sampler, (int2)(2 * x, 2 * y));
+    in1[1] = read_imagef(inputFrame1, sampler, (int2)(2 * x + 1, 2 * y));
+    in1[2] = read_imagef(inputFrame1, sampler, (int2)(2 * x, 2 * y + 1));
+    in1[3] = read_imagef(inputFrame1, sampler, (int2)(2 * x + 1, 2 * y + 1));
+
+    if (count == 2)
+    {
+        // write follow code separate intead of using a 'for' circle to improve kernel performace.
+        var[0] = fabs((*(in)) - in1[0]);
+        var[1] = fabs((*(in + 1)) - in1[1]);
+        var[2] = fabs((*(in + 2)) - in1[2]);
+        var[3] = fabs((*(in + 3)) - in1[3]);
+
+        cond[0] = (var[0].x + var[0].y + var[0].z) < (thr_r + thr_g + thr_b);
+        cond[1] = (var[1].x + var[1].y + var[1].z) < (thr_r + thr_g + thr_b);
+        cond[2] = (var[2].x + var[2].y + var[2].z) < (thr_r + thr_g + thr_b);
+        cond[3] = (var[3].x + var[3].y + var[3].z) < (thr_r + thr_g + thr_b);
+
+        gain[0] = cond[0] ? 1.0f : 0.0f;
+        gain[1] = cond[1] ? 1.0f : 0.0f;
+        gain[2] = cond[2] ? 1.0f : 0.0f;
+        gain[3] = cond[3] ? 1.0f : 0.0f;
+
+        out[0] = (gain[0] * (*(in)) + in1[0]) / (1.0f + gain[0]);
+        out[1] = (gain[1] * (*(in + 1)) + in1[1]) / (1.0f + gain[1]);
+        out[2] = (gain[2] * (*(in + 2)) + in1[2]) / (1.0f + gain[2]);
+        out[3] = (gain[3] * (*(in + 3)) + in1[3]) / (1.0f + gain[3]);
+    }
+    else if(count == 3)
+    {
+        in2[0] = read_imagef(inputFrame2, sampler, (int2)(2 * x, 2 * y));
+        in2[1] = read_imagef(inputFrame2, sampler, (int2)(2 * x + 1, 2 * y));
+        in2[2] = read_imagef(inputFrame2, sampler, (int2)(2 * x, 2 * y + 1));
+        in2[3] = read_imagef(inputFrame2, sampler, (int2)(2 * x + 1, 2 * y + 1));
+
+        var[0] = (fabs((*(in)) - in1[0]) + fabs(in1[0] - in2[0])) / 2.0;
+        var[1] = (fabs((*(in + 1)) - in1[1]) + fabs(in1[1] - in2[1])) / 2.0 ;
+        var[2] = (fabs((*(in + 2)) - in1[2]) + fabs(in1[2] - in2[2])) / 2.0;
+        var[3] = (fabs((*(in + 3)) - in1[3]) + fabs(in1[0] - in2[3])) / 2.0;
+
+        cond[0] = (var[0].x + var[0].y + var[0].z) < (thr_r + thr_g + thr_b);
+        cond[1] = (var[1].x + var[1].y + var[1].z) < (thr_r + thr_g + thr_b);
+        cond[2] = (var[2].x + var[2].y + var[2].z) < (thr_r + thr_g + thr_b);
+        cond[3] = (var[3].x + var[3].y + var[3].z) < (thr_r + thr_g + thr_b);
+
+        gain[0] = cond[0] ? 1.0f : 0.0f;
+        gain[1] = cond[1] ? 1.0f : 0.0f;
+        gain[2] = cond[2] ? 1.0f : 0.0f;
+        gain[3] = cond[3] ? 1.0f : 0.0f;
+
+        out[0] = (gain[0] * (*(in)) + gain[0] * in1[0] + in2[0]) / (1.0f + 2 * gain[0]);
+        out[1] = (gain[1] * (*(in + 1)) + gain[1] * in1[1] + in2[1]) / (1.0f + 2 * gain[1]);
+        out[2] = (gain[2] * (*(in + 2)) + gain[2] * in1[2] + in2[2]) / (1.0f + 2 * gain[2]);
+        out[3] = (gain[3] * (*(in + 3)) + gain[3] * in1[3] + in2[3]) / (1.0f + 2 * gain[3]);
+    }
+    else if(count == 4)
+    {
+        in2[0] = read_imagef(inputFrame2, sampler, (int2)(2 * x, 2 * y));
+        in2[1] = read_imagef(inputFrame2, sampler, (int2)(2 * x + 1, 2 * y));
+        in2[2] = read_imagef(inputFrame2, sampler, (int2)(2 * x, 2 * y + 1));
+        in2[3] = read_imagef(inputFrame2, sampler, (int2)(2 * x + 1, 2 * y + 1));
+
+        in3[0] = read_imagef(inputFrame3, sampler, (int2)(2 * x, 2 * y));
+        in3[1] = read_imagef(inputFrame3, sampler, (int2)(2 * x + 1, 2 * y));
+        in3[2] = read_imagef(inputFrame3, sampler, (int2)(2 * x, 2 * y + 1));
+        in3[3] = read_imagef(inputFrame3, sampler, (int2)(2 * x + 1, 2 * y + 1));
+
+        var[0] = (fabs((*(in)) - in1[0]) + fabs(in1[0] - in2[0]) + fabs(in2[0] - in3[0])) / 3.0;
+        var[1] = (fabs((*(in + 1)) - in1[1]) + fabs(in1[1] - in2[1]) + fabs(in2[1] - in3[1])) / 3.0 ;
+        var[2] = (fabs((*(in + 2)) - in1[2]) + fabs(in1[2] - in2[2]) + fabs(in2[2] - in3[2])) / 3.0;
+        var[3] = (fabs((*(in + 3)) - in1[3]) + fabs(in1[0] - in2[3]) + fabs(in2[3] - in3[3])) / 3.0;
+
+        cond[0] = (var[0].x + var[0].y + var[0].z) < (thr_r + thr_g + thr_b);
+        cond[1] = (var[1].x + var[1].y + var[1].z) < (thr_r + thr_g + thr_b);
+        cond[2] = (var[2].x + var[2].y + var[2].z) < (thr_r + thr_g + thr_b);
+        cond[3] = (var[3].x + var[3].y + var[3].z) < (thr_r + thr_g + thr_b);
+
+        gain[0] = cond[0] ? 1.0f : 0.0f;
+        gain[1] = cond[1] ? 1.0f : 0.0f;
+        gain[2] = cond[2] ? 1.0f : 0.0f;
+        gain[3] = cond[3] ? 1.0f : 0.0f;
+
+        out[0] = (gain[0] * (*(in)) + gain[0] * in1[0] + gain[0] * in2[0] + in3[0]) / (1.0f + 3 * gain[0]);
+        out[1] = (gain[1] * (*(in + 1)) + gain[1] * in1[1] + gain[1] * in2[1] + in3[1]) / (1.0f + 3 * gain[1]);
+        out[2] = (gain[2] * (*(in + 2)) + gain[2] * in1[2] + gain[2] * in2[2] + in3[2]) / (1.0f + 3 * gain[2]);
+        out[3] = (gain[3] * (*(in + 3)) + gain[3] * in1[3] + gain[3] * in2[3] + in3[3]) / (1.0f + 3 * gain[3]);
+    }
+
+    (*(in)) = out[0];
+    (*(in + 1)) = out[1];
+    (*(in + 2)) = out[2];
+    (*(in + 3)) = out[3];
+}
+
+__kernel void kernel_yuv_pipe (__write_only image2d_t output, uint vertical_offset, __global float *matrix, __global float *table, uint count, float tnr_gain, float thr_r, float thr_g, float thr_b, __read_only image2d_t inputFrame0, __read_only image2d_t inputFrame1, __read_only image2d_t inputFrame2, __read_only image2d_t inputFrame3)
 {
     int x = get_global_id (0);
     int y = get_global_id (1);
     sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE | CLK_FILTER_NEAREST;
 
-    float4 p_in[4];
-    float p_out[6];
+    float4 in[4];
+    float out[6];
 
-    p_in[0] = read_imagef(input, sampler, (int2)(2 * x, 2 * y));
-    p_in[1] = read_imagef(input, sampler, (int2)(2 * x + 1, 2 * y));
-    p_in[2] = read_imagef(input, sampler, (int2)(2 * x, 2 * y + 1));
-    p_in[3] = read_imagef(input, sampler, (int2)(2 * x + 1, 2 * y + 1));
+    in[0] = read_imagef(inputFrame0, sampler, (int2)(2 * x, 2 * y));
+    in[1] = read_imagef(inputFrame0, sampler, (int2)(2 * x + 1, 2 * y));
+    in[2] = read_imagef(inputFrame0, sampler, (int2)(2 * x, 2 * y + 1));
+    in[3] = read_imagef(inputFrame0, sampler, (int2)(2 * x + 1, 2 * y + 1));
 
-    cl_csc_rgbatonv12(&p_in[0], &p_out[0], matrix);
-    cl_macc(&p_out[4], table);
+    cl_tnr (&in[0], inputFrame1, inputFrame2, inputFrame3, count, x, y, tnr_gain, thr_r, thr_g, thr_b);
+    cl_csc_rgbatonv12(&in[0], &out[0], matrix);
+    cl_macc(&out[4], table);
 
-    write_imagef(output, (int2)(2 * x, 2 * y), (float4)p_out[0]);
-    write_imagef(output, (int2)(2 * x + 1, 2 * y), (float4)p_out[1]);
-    write_imagef(output, (int2)(2 * x, 2 * y + 1), (float4)p_out[2]);
-    write_imagef(output, (int2)(2 * x + 1, 2 * y + 1), (float4)p_out[3]);
-    write_imagef(output, (int2)(2 * x, y + vertical_offset), (float4)p_out[4]);
-    write_imagef(output, (int2)(2 * x + 1, y + vertical_offset), (float4)p_out[5]);
+    write_imagef(output, (int2)(2 * x, 2 * y), (float4)out[0]);
+    write_imagef(output, (int2)(2 * x + 1, 2 * y), (float4)out[1]);
+    write_imagef(output, (int2)(2 * x, 2 * y + 1), (float4)out[2]);
+    write_imagef(output, (int2)(2 * x + 1, 2 * y + 1), (float4)out[3]);
+    write_imagef(output, (int2)(2 * x, y + vertical_offset), (float4)out[4]);
+    write_imagef(output, (int2)(2 * x + 1, y + vertical_offset), (float4)out[5]);
 }
 

--- a/xcore/cl_3a_image_processor.cpp
+++ b/xcore/cl_3a_image_processor.cpp
@@ -245,6 +245,10 @@ CL3aImageProcessor::apply_3a_result (SmartPtr<X3aResult> &result)
             _rgb_pipe->set_tnr_config(tnr_res->get_standard_result ());
             _rgb_pipe->set_3a_result (result);
         }
+        if (_yuv_pipe.ptr ()) {
+            _yuv_pipe->set_tnr_config(tnr_res->get_standard_result ());
+            _yuv_pipe->set_3a_result (result);
+        }
 
         break;
     }
@@ -320,9 +324,11 @@ CL3aImageProcessor::create_handlers ()
         XCAM_RETURN_ERROR_CL,
         "CL3aImageProcessor create bayer pipe handler failed");
     _bayer_pipe->set_stats_callback (_stats_callback);
+#if 0
     if (get_profile () >= AdvancedPipelineProfile) {
         _bayer_pipe->set_output_format (V4L2_PIX_FMT_ABGR32);
     }
+#endif
     image_handler->set_pool_size (XCAM_CL_3A_IMAGE_MAX_POOL_SIZE);
     add_handler (image_handler);
 

--- a/xcore/cl_image_handler.cpp
+++ b/xcore/cl_image_handler.cpp
@@ -64,7 +64,7 @@ CLImageKernel::pre_execute (SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> 
 {
     XCamReturn ret = XCAM_RETURN_NO_ERROR;
     SmartPtr<CLContext> context = get_context ();
-#define XCAM_CL_MAX_ARGS 10
+#define XCAM_CL_MAX_ARGS 256
     CLArgument args[XCAM_CL_MAX_ARGS];
     uint32_t arg_count = XCAM_CL_MAX_ARGS;
     CLWorkSize work_size;

--- a/xcore/cl_yuv_pipe_handler.cpp
+++ b/xcore/cl_yuv_pipe_handler.cpp
@@ -36,6 +36,11 @@ namespace XCam {
 CLYuvPipeImageKernel::CLYuvPipeImageKernel (SmartPtr<CLContext> &context)
     : CLImageKernel (context, "kernel_yuv_pipe")
     , _vertical_offset (0)
+    , _gain_rgb (0.0)
+    , _thr_r (0.064)  // set high initial threshold to get strong denoise effect
+    , _thr_g (0.045)
+    , _thr_b (0.073)
+    , _framecount (2)
 {
     memcpy(_macc_table, default_macc, sizeof(float)*XCAM_CHROMA_AXIS_SIZE * XCAM_CHROMA_MATRIX_SIZE);
     memcpy(_rgbtoyuv_matrix, default_matrix, sizeof(float)*XCAM_COLOR_MATRIX_SIZE);
@@ -57,6 +62,19 @@ CLYuvPipeImageKernel::set_matrix (const XCam3aResultColorMatrix &matrix)
     return true;
 }
 
+bool
+CLYuvPipeImageKernel::set_tnr_config (const XCam3aResultTemporalNoiseReduction& config)
+{
+    _gain_rgb = (float)config.gain;
+    _thr_r  = (float)config.threshold[0];
+    _thr_g  = (float)config.threshold[1];
+    _thr_b  = (float)config.threshold[2];
+    XCAM_LOG_DEBUG ("set YUV-Pipe tnr rgb config: _gain(%f), _thr_r(%f), _thr_g(%f), _thr_b(%f)",
+                    _gain_rgb, _thr_r, _thr_g, _thr_b);
+
+    return true;
+}
+
 XCamReturn
 CLYuvPipeImageKernel::prepare_arguments (
     SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
@@ -65,7 +83,6 @@ CLYuvPipeImageKernel::prepare_arguments (
 {
     SmartPtr<CLContext> context = get_context ();
     const VideoBufferInfo & video_info = output->get_video_info ();
-
 
     _image_in = new CLVaImage (context, input);
     _image_out = new CLVaImage (context, output);
@@ -76,6 +93,14 @@ CLYuvPipeImageKernel::prepare_arguments (
         context, sizeof(float)*XCAM_CHROMA_AXIS_SIZE * XCAM_CHROMA_MATRIX_SIZE,
         CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR , &_macc_table);
 
+    if (_image_in_list.size () < 4) {
+        while (_image_in_list.size () < 4) {
+            _image_in_list.push_back (_image_in);
+        }
+    } else {
+        _image_in_list.pop_front ();
+        _image_in_list.push_back (_image_in);
+    }
 
     _vertical_offset = video_info.aligned_height;
 
@@ -87,18 +112,33 @@ CLYuvPipeImageKernel::prepare_arguments (
         "cl image kernel(%s) in/out memory not available", get_kernel_name ());
 
     //set args;
-    args[0].arg_adress = &_image_in->get_mem_id ();
+    args[0].arg_adress = &_image_out->get_mem_id ();
     args[0].arg_size = sizeof (cl_mem);
-    args[1].arg_adress = &_image_out->get_mem_id ();
-    args[1].arg_size = sizeof (cl_mem);
-    args[2].arg_adress = &_vertical_offset;
-    args[2].arg_size = sizeof (_vertical_offset);
-    args[3].arg_adress = &_matrix_buffer->get_mem_id();
+    args[1].arg_adress = &_vertical_offset;
+    args[1].arg_size = sizeof (_vertical_offset);
+    args[2].arg_adress = &_matrix_buffer->get_mem_id();
+    args[2].arg_size = sizeof (cl_mem);
+    args[3].arg_adress = &_macc_table_buffer->get_mem_id();
     args[3].arg_size = sizeof (cl_mem);
-    args[4].arg_adress = &_macc_table_buffer->get_mem_id();
-    args[4].arg_size = sizeof (cl_mem);
+    args[4].arg_adress = &_framecount;
+    args[4].arg_size = sizeof (_framecount);
+    args[5].arg_adress = &_gain_rgb;
+    args[5].arg_size = sizeof (_gain_rgb);
+    args[6].arg_adress = &_thr_r;
+    args[6].arg_size = sizeof (_thr_r);
+    args[7].arg_adress = &_thr_g;
+    args[7].arg_size = sizeof (_thr_g);
+    args[8].arg_adress = &_thr_b;
+    args[8].arg_size = sizeof (_thr_b);
 
-    arg_count = 5;
+    uint8_t index = 0;
+    for (std::list<SmartPtr<CLImage>>::iterator it = _image_in_list.begin (); it != _image_in_list.end (); it++) {
+        args[9 + index].arg_adress = &(*it)->get_mem_id ();
+        args[9 + index].arg_size = sizeof (cl_mem);
+        index++;
+    }
+
+    arg_count = 9 + index;
 
     work_size.dim = XCAM_DEFAULT_IMAGE_DIM;
     work_size.global[0] = video_info.width / 2 ;
@@ -161,6 +201,18 @@ CLYuvPipeImageHandler::set_yuv_pipe_kernel(SmartPtr<CLYuvPipeImageKernel> &kerne
     SmartPtr<CLImageKernel> image_kernel = kernel;
     add_kernel (image_kernel);
     _yuv_pipe_kernel = kernel;
+    return true;
+}
+
+bool
+CLYuvPipeImageHandler::set_tnr_config (const XCam3aResultTemporalNoiseReduction& config)
+{
+    if (!_yuv_pipe_kernel->is_valid ()) {
+        XCAM_LOG_ERROR ("set config error, invalid YUV-Pipe kernel !");
+    }
+
+    _yuv_pipe_kernel->set_tnr_config (config);
+
     return true;
 }
 

--- a/xcore/cl_yuv_pipe_handler.h
+++ b/xcore/cl_yuv_pipe_handler.h
@@ -30,10 +30,13 @@ namespace XCam {
 class CLYuvPipeImageKernel
     : public CLImageKernel
 {
+    typedef std::list<SmartPtr<CLImage>> CLImagePtrList;
+
 public:
     explicit CLYuvPipeImageKernel (SmartPtr<CLContext> &context);
     bool set_macc (const XCam3aResultMaccMatrix &macc);
     bool set_matrix (const XCam3aResultColorMatrix &matrix);
+    bool set_tnr_config (const XCam3aResultTemporalNoiseReduction& config);
 
 protected:
     virtual XCamReturn prepare_arguments (
@@ -49,6 +52,12 @@ private:
     float               _macc_table[XCAM_CHROMA_AXIS_SIZE * XCAM_CHROMA_MATRIX_SIZE];
     float               _rgbtoyuv_matrix[XCAM_COLOR_MATRIX_SIZE];
     uint32_t       _vertical_offset;
+    CLImagePtrList _image_in_list;
+    float _gain_rgb;
+    float _thr_r;
+    float _thr_g;
+    float _thr_b;
+    unsigned int _framecount;
 };
 
 class CLYuvPipeImageHandler
@@ -59,6 +68,7 @@ public:
     bool set_yuv_pipe_kernel(SmartPtr<CLYuvPipeImageKernel> &kernel);
     bool set_macc_table (const XCam3aResultMaccMatrix &macc);
     bool set_rgbtoyuv_matrix (const XCam3aResultColorMatrix &matrix);
+    bool set_tnr_config (const XCam3aResultTemporalNoiseReduction& config);
 
 protected:
     virtual XCamReturn prepare_buffer_pool_video_info (


### PR DESCRIPTION
advance pipeline performance.

* set tnr frame count to 2 in advance pipeline.
* set bayer pipe output to 8bit rgb in advance pipeline.