### PR TITLE
plugin: add property to set input format

### DIFF
--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -83,7 +83,7 @@ struct _GstXCamSrc
 
     enum v4l2_memory             mem_type;
     enum v4l2_field              field;
-    struct v4l2_format           input_format;
+    uint32_t                     in_format;
     uint32_t                     out_format;
     GstVideoInfo                 gst_video_info;
     VideoBufferInfo              xcam_video_info;


### PR DESCRIPTION
 * set property "input-format" with v4l2 fourcc
 * isp path defaults to NV12, and CL path defaults to BA10
 * test command for CL path with BA12:
   $ gst-launch-1.0 xcamsrc num-buffers=300 io-mode=4 sensor-id=0 enable-3a=true  \
         imageprocessor=1 analyzer=2 input-format="BA12" !                        \
         video/x-raw,format=NV12,width=1920,height=1080,framerate=25/1 ! fakesink