### PR TITLE
histogram implementation

### DIFF
--- a/cl_kernel/kernel_bayer_pipe.cl
+++ b/cl_kernel/kernel_bayer_pipe.cl
@@ -204,14 +204,14 @@ inline void stats_3a_calculate (
         float4 tmp_data;
         int out_index = mad24(g_id_y / STATS_3A_GRID_SIZE,  g_size_x / STATS_3A_GRID_SIZE, g_id_x / STATS_3A_GRID_SIZE);
         tmp_data = input[shared_pos (l_id_x + SHARED_GRID_X_OFFSET, l_id_y + SHARED_GRID_Y_OFFSET)];
-        stats_output[out_index].avg_gr = convert_uint(tmp_data.x * 255.0f);
-        stats_output[out_index].avg_r = convert_uint(tmp_data.y * 255.0f);
-        stats_output[out_index].avg_b = convert_uint(tmp_data.z * 255.0f);
-        stats_output[out_index].avg_gb = convert_uint(tmp_data.w * 255.0f);
+        stats_output[out_index].avg_gr = convert_uchar_sat(tmp_data.x * 255.0f);
+        stats_output[out_index].avg_r = convert_uchar_sat(tmp_data.y * 255.0f);
+        stats_output[out_index].avg_b = convert_uchar_sat(tmp_data.z * 255.0f);
+        stats_output[out_index].avg_gb = convert_uchar_sat(tmp_data.w * 255.0f);
         stats_output[out_index].valid_wb_count = STATS_3A_GRID_SIZE * STATS_3A_GRID_SIZE;
         stats_output[out_index].avg_y =
-            convert_uint(((tmp_data.x * wb_config->gr_gain + tmp_data.w * wb_config->gb_gain) * 0.294f +
-                          tmp_data.y * wb_config->r_gain * 0.299f + tmp_data.z * wb_config->b_gain * 0.114f) * 255.0f);
+            convert_uchar_sat(((tmp_data.x * wb_config->gr_gain + tmp_data.w * wb_config->gb_gain) * 0.2935f +
+                               tmp_data.y * wb_config->r_gain * 0.299f + tmp_data.z * wb_config->b_gain * 0.114f) * 255.0f);
         stats_output[out_index].f_value1 = 0;
         stats_output[out_index].f_value2 = 0;
     }

--- a/xcore/base/xcam_3a_stats.h
+++ b/xcore/base/xcam_3a_stats.h
@@ -32,9 +32,17 @@ typedef struct _XCam3AStatsInfo {
     uint32_t aligned_height;
     uint32_t grid_pixel_size;  // in pixel
     uint32_t bit_depth;
+    uint32_t histogram_bins;
 
     uint32_t reserved[2];
 } XCam3AStatsInfo;
+
+typedef struct _XCamHistogram {
+    uint32_t r;
+    uint32_t gr;
+    uint32_t gb;
+    uint32_t b;
+} XCamHistogram;
 
 typedef struct _XCamGridStat {
     /* ae */
@@ -54,6 +62,8 @@ typedef struct _XCamGridStat {
 
 typedef struct _XCam3AStats {
     XCam3AStatsInfo info;
+    XCamHistogram *hist_rgb;
+    uint32_t *hist_y;
     XCamGridStat stats[0];
 } XCam3AStats;
 

--- a/xcore/cl_bayer_pipe_handler.h
+++ b/xcore/cl_bayer_pipe_handler.h
@@ -75,6 +75,8 @@ public:
 private:
     XCAM_DEAD_COPY (CL3AStatsCalculatorContext);
 
+    bool fill_histogram (XCam3AStats *stats);
+
 private:
     SmartPtr<CLContext>              _context;
     SmartPtr<X3aStatsPool>           _stats_pool;

--- a/xcore/x3a_stats_pool.cpp
+++ b/xcore/x3a_stats_pool.cpp
@@ -88,6 +88,7 @@ X3aStatsPool::fixate_video_info (VideoBufferInfo &info)
     _stats_info.height = info.height / grid;
     _stats_info.grid_pixel_size = grid;
     _stats_info.bit_depth = 8;
+    _stats_info.histogram_bins = 256;
     return true;
 }
 
@@ -100,9 +101,14 @@ X3aStatsPool::allocate_data (const VideoBufferInfo &buffer_info)
     stats =
         (XCam3AStats *) xcam_malloc0 (
             sizeof (XCam3AStats) +
+            sizeof (XCamHistogram) * _stats_info.histogram_bins +
+            sizeof (uint32_t) * _stats_info.histogram_bins +
             sizeof (XCamGridStat) * _stats_info.aligned_width * _stats_info.aligned_height);
     XCAM_ASSERT (stats);
     stats->info = _stats_info;
+    stats->hist_rgb = (XCamHistogram *) (stats->stats +
+                                         _stats_info.aligned_width * _stats_info.aligned_height);
+    stats->hist_y = (uint32_t *) (stats->hist_rgb + _stats_info.histogram_bins);
     return new X3aStatsData (stats);
 }
 


### PR DESCRIPTION
1. cl: clamp 3a grid statistics
    * avg_y stat may exceed 8-bit range after wb calculation, so
      saturated conversion is used to clamp out-of-range values.

2.  histogram: add histogram support
     * libxcam statistics contains r/g/b/y histograms now
     * cl path calculates histogram based on 3a grid statistics
     * isp path converts isp histogram to libxcam standard format