### PR TITLE
cl_3a_image_processor: add varible _capture_stage to specify the stag…

### DIFF
--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -167,6 +167,9 @@ MainDeviceManager::handle_buffer (const SmartPtr<VideoBuffer> &buf)
     case V4L2_PIX_FMT_SRGGB12:
         size = XCAM_ALIGN_UP(frame_info.width, 2) * XCAM_ALIGN_UP(frame_info.height, 2) * 2;
         break;
+    case XCAM_PIX_FMT_RGBA64:
+        size = XCAM_ALIGN_UP(frame_info.width, 2) * XCAM_ALIGN_UP(frame_info.height, 2) * 2 * 4;
+        break;
     default:
         XCAM_LOG_ERROR (
             "unknown v4l2 format(%s) in buffer handle",
@@ -283,6 +286,8 @@ void print_help (const char *bin_name)
             "\t -h            help\n"
 #if HAVE_LIBCL
             "CL features:\n"
+            "\t --capture capture_stage      specify the capture stage of image\n"
+            "\t               capture_stage select from [bayer, tonemapping], default is [tonemapping]\n"
             "\t --hdr         specify hdr type, default is hdr off\n"
             "\t               select from [rgb, lab]\n"
             "\t --tnr         specify temporal noise reduction type, default is tnr off\n"
@@ -330,6 +335,7 @@ int main (int argc, char *argv[])
     uint8_t tnr_level = 0;
     bool dpc_type = false;
     CL3aImageProcessor::PipelineProfile pipeline_mode = CL3aImageProcessor::BasicPipelineProfile;
+    CL3aImageProcessor::CaptureStage capture_stage = CL3aImageProcessor::TonemappingStage;
 #endif
     bool have_cl_processor = false;
     bool need_display = false;
@@ -357,6 +363,7 @@ int main (int argc, char *argv[])
         {"enable-tonemapping", no_argument, NULL, 'M'},
         {"usb", required_argument, NULL, 'U'},
         {"sync", no_argument, NULL, 'Y'},
+        {"capture", required_argument, NULL, 'C'},
         {"pipeline", required_argument, NULL, 'P'},
         {0, 0, 0, 0},
     };
@@ -519,6 +526,11 @@ int main (int argc, char *argv[])
             }
             break;
         }
+        case 'C': {
+            if (!strcmp (optarg, "bayer"))
+                capture_stage = CL3aImageProcessor::BasicbayerStage;
+            break;
+        }
 #endif
         case 'h':
             print_help (bin_name);
@@ -642,6 +654,7 @@ int main (int argc, char *argv[])
         cl_processor->set_hdr (hdr_type);
         cl_processor->set_denoise (denoise_type);
         cl_processor->set_tonemapping(tonemapping_type);
+        cl_processor->set_capture_stage (capture_stage);
         if (need_display) {
             cl_processor->set_output_format (V4L2_PIX_FMT_XBGR32);
         }

--- a/xcore/cl_3a_image_processor.cpp
+++ b/xcore/cl_3a_image_processor.cpp
@@ -47,6 +47,7 @@ CL3aImageProcessor::CL3aImageProcessor ()
     , _output_fourcc (V4L2_PIX_FMT_NV12)
     , _out_smaple_type (OutSampleYuv)
     , _pipeline_profile (BasicPipelineProfile)
+    , _capture_stage (TonemappingStage)
     , _hdr_mode (0)
     , _tnr_mode (0)
     , _enable_gamma (true)
@@ -94,6 +95,13 @@ CL3aImageProcessor::set_output_format (uint32_t fourcc)
     }
 
     _output_fourcc = fourcc;
+    return true;
+}
+
+bool
+CL3aImageProcessor::set_capture_stage (CaptureStage capture_stage)
+{
+    _capture_stage = capture_stage;
     return true;
 }
 
@@ -332,6 +340,8 @@ CL3aImageProcessor::create_handlers ()
     _bayer_pipe->enable_denoise (XCAM_DENOISE_TYPE_BNR & _snr_mode);
     image_handler->set_pool_size (XCAM_CL_3A_IMAGE_MAX_POOL_SIZE * 2);
     add_handler (image_handler);
+    if(_capture_stage == BasicbayerStage)
+        return XCAM_RETURN_NO_ERROR;
 
 #else
     /* black leve as first */

--- a/xcore/cl_3a_image_processor.h
+++ b/xcore/cl_3a_image_processor.h
@@ -63,6 +63,11 @@ public:
         ExtremePipelineProfile,
     };
 
+    enum CaptureStage {
+        BasicbayerStage,
+        TonemappingStage,
+    };
+
 public:
     explicit CL3aImageProcessor ();
     virtual ~CL3aImageProcessor ();
@@ -71,6 +76,7 @@ public:
     void set_stats_callback (const SmartPtr<StatsCallback> &callback);
 
     bool set_output_format (uint32_t fourcc);
+    bool set_capture_stage (CaptureStage capture_stage);
 
     virtual bool set_hdr (uint32_t mode);
     virtual bool set_denoise (uint32_t mode);
@@ -99,7 +105,7 @@ private:
     uint32_t                           _output_fourcc;
     OutSampleType                      _out_smaple_type;
     PipelineProfile                    _pipeline_profile;
-
+    CaptureStage                       _capture_stage;
     SmartPtr<StatsCallback>            _stats_callback;
 
     SmartPtr<CLBlcImageHandler>         _black_level;


### PR DESCRIPTION
…e which image is captured. Current available values are [BasicbayerStage] and [TonemappingStage]. If _capture_stage == BasicbayerStage, image with format RGBA64 can be captured.

test-device-manager.cpp: add command line option '--capture' to specify the value of _capture_stage. Available values are [bayer] and [tonemapping]. Default value is [tonemapping].

*test command:
./tests/test-device-manager -a dynamic -m dma -c -f BA12 -d still -s -i <number> --capture bayer.