### PR TITLE
support imx185 WDR 25/30fps exposure settings

### DIFF
--- a/3alib/aiq/aiq_wrapper.cpp
+++ b/3alib/aiq/aiq_wrapper.cpp
@@ -201,23 +201,46 @@ xcam_configure_3a (XCam3AContext *context, uint32_t width, uint32_t height, doub
     XCamReturn ret = XCAM_RETURN_NO_ERROR;
     struct atomisp_sensor_mode_data sensor_mode_data;
 
-    sensor_mode_data.coarse_integration_time_min = 1;
-    sensor_mode_data.coarse_integration_time_max_margin = 1;
-    sensor_mode_data.fine_integration_time_min = 0;
-    sensor_mode_data.fine_integration_time_max_margin = 0;
-    sensor_mode_data.fine_integration_time_def = 0;
-    sensor_mode_data.frame_length_lines = 1125;
-    sensor_mode_data.line_length_pck = 1320;
-    sensor_mode_data.read_mode = 0;
-    sensor_mode_data.vt_pix_clk_freq_mhz = 37125000;
-    sensor_mode_data.crop_horizontal_start = 0;
-    sensor_mode_data.crop_vertical_start = 0;
-    sensor_mode_data.crop_horizontal_end = 1920;
-    sensor_mode_data.crop_vertical_end = 1080;
-    sensor_mode_data.output_width = 1920;
-    sensor_mode_data.output_height = 1080;
-    sensor_mode_data.binning_factor_x = 1;
-    sensor_mode_data.binning_factor_y = 1;
+    switch ((int)framerate) {
+    case 30:
+        sensor_mode_data.coarse_integration_time_min = 1;
+        sensor_mode_data.coarse_integration_time_max_margin = 1;
+        sensor_mode_data.fine_integration_time_min = 0;
+        sensor_mode_data.fine_integration_time_max_margin = 0;
+        sensor_mode_data.fine_integration_time_def = 0;
+        sensor_mode_data.frame_length_lines = 1125;
+        sensor_mode_data.line_length_pck = 1100;
+        sensor_mode_data.read_mode = 0;
+        sensor_mode_data.vt_pix_clk_freq_mhz = 37125000;
+        sensor_mode_data.crop_horizontal_start = 0;
+        sensor_mode_data.crop_vertical_start = 0;
+        sensor_mode_data.crop_horizontal_end = 1920;
+        sensor_mode_data.crop_vertical_end = 1080;
+        sensor_mode_data.output_width = 1920;
+        sensor_mode_data.output_height = 1080;
+        sensor_mode_data.binning_factor_x = 1;
+        sensor_mode_data.binning_factor_y = 1;
+        break;
+    default:
+        sensor_mode_data.coarse_integration_time_min = 1;
+        sensor_mode_data.coarse_integration_time_max_margin = 1;
+        sensor_mode_data.fine_integration_time_min = 0;
+        sensor_mode_data.fine_integration_time_max_margin = 0;
+        sensor_mode_data.fine_integration_time_def = 0;
+        sensor_mode_data.frame_length_lines = 1125;
+        sensor_mode_data.line_length_pck = 1320;
+        sensor_mode_data.read_mode = 0;
+        sensor_mode_data.vt_pix_clk_freq_mhz = 37125000;
+        sensor_mode_data.crop_horizontal_start = 0;
+        sensor_mode_data.crop_vertical_start = 0;
+        sensor_mode_data.crop_horizontal_end = 1920;
+        sensor_mode_data.crop_vertical_end = 1080;
+        sensor_mode_data.output_width = 1920;
+        sensor_mode_data.output_height = 1080;
+        sensor_mode_data.binning_factor_x = 1;
+        sensor_mode_data.binning_factor_y = 1;
+        break;
+    }
 
     XCAM_ASSERT (aiq_context);
     XCAM_FAIL_RETURN (

--- a/xcore/aiq_handler.cpp
+++ b/xcore/aiq_handler.cpp
@@ -497,6 +497,16 @@ bool AiqAeHandler::ensure_ae_manual ()
         (_sensor_descriptor.line_periods_per_field - _sensor_descriptor.coarse_integration_time_max_margin)
         * _sensor_descriptor.pixel_periods_per_line
         / _sensor_descriptor.pixel_clock_freq_mhz;
+
+    uint64_t exp_min_us = 0, exp_max_us = 0;
+    get_exposure_time_range_unlock (exp_min_us, exp_max_us);
+    if (exp_min_us && (int64_t)exp_min_us > _input.manual_limits->manual_exposure_time_min) {
+        _input.manual_limits->manual_exposure_time_min = exp_min_us;
+    }
+    if (exp_max_us && (int64_t)exp_max_us < _input.manual_limits->manual_exposure_time_max) {
+        _input.manual_limits->manual_exposure_time_max = exp_max_us;
+    }
+
     _input.manual_limits->manual_frame_time_us_min = -1;
     _input.manual_limits->manual_frame_time_us_max = 1000000 / _aiq_compositor->get_framerate ();
     _input.manual_limits->manual_iso_min = -1;

--- a/xcore/aiq_handler.cpp
+++ b/xcore/aiq_handler.cpp
@@ -498,7 +498,7 @@ bool AiqAeHandler::ensure_ae_manual ()
         * _sensor_descriptor.pixel_periods_per_line
         / _sensor_descriptor.pixel_clock_freq_mhz;
     _input.manual_limits->manual_frame_time_us_min = -1;
-    _input.manual_limits->manual_frame_time_us_max = 1000000 / this->get_framerate_unlock ();
+    _input.manual_limits->manual_frame_time_us_max = 1000000 / _aiq_compositor->get_framerate ();
     _input.manual_limits->manual_iso_min = -1;
     _input.manual_limits->manual_iso_max = -1;
 

--- a/xcore/aiq_handler.h
+++ b/xcore/aiq_handler.h
@@ -254,7 +254,10 @@ public:
         out_height = _height;
     }
     void set_framerate (double framerate) {
-        _ae_handler->set_framerate (framerate);
+        _framerate = framerate;
+    }
+    double get_framerate () {
+        return _framerate;
     }
     bool open (ia_binary_data &cpf);
     void close ();
@@ -307,7 +310,7 @@ private:
 
     uint32_t                   _width;
     uint32_t                   _height;
-
+    double                     _framerate;
 };
 
 };

--- a/xcore/base/xcam_params.h
+++ b/xcore/base/xcam_params.h
@@ -48,8 +48,6 @@ typedef struct _XCamAeParam {
 
     /*ev*/
     double                  ev_shift;
-
-    double                  framerate;
 } XCamAeParam;
 
 typedef struct _XCamAwbParam {

--- a/xcore/handler_interface.cpp
+++ b/xcore/handler_interface.cpp
@@ -245,16 +245,6 @@ bool AeHandler::set_exposure_time_range (int64_t min_time_in_us, int64_t max_tim
 }
 
 bool
-AeHandler::set_framerate (double framerate)
-{
-    AnalyzerHandler::HandlerLock lock(this);
-    _params.framerate = framerate;
-
-    XCAM_LOG_DEBUG ("ae set framerate: %.03f", framerate);
-    return true;
-}
-
-bool
 AeHandler::update_parameters (const XCamAeParam &params)
 {
     {

--- a/xcore/handler_interface.h
+++ b/xcore/handler_interface.h
@@ -73,7 +73,6 @@ public:
     bool set_aperture (double fn);
     bool set_max_analog_gain (double max_gain);
     bool set_exposure_time_range (int64_t min_time_in_us, int64_t max_time_in_us);
-    bool set_framerate (double framerate);
 
     bool update_parameters (const XCamAeParam &params);
 
@@ -131,10 +130,6 @@ protected:
 
     double get_max_analog_gain_unlock () const {
         return _params.max_analog_gain;
-    }
-
-    double get_framerate_unlock () const {
-        return _params.framerate;
     }
 
 private:


### PR DESCRIPTION
1. aiq: keep frame rate within aiq handler instead of XCamAeParam
     * frame rate was kept in XCamAeParam of AiqAeHandler, but it may
       lost when XCamAeParam is updated
     * e.g., when 3alib plugin update ae param from DynamicAnalyzer,
       frame rate was lost as it's never set to DynamicAnalyzer

2. 3alib: add 30fps sensor mode data

3. aiq: set exposure range as manual limit to aiq