### PR TITLE
aiq exposure result manual control for imx185 WDR

### DIFF
--- a/xcore/aiq_handler.h
+++ b/xcore/aiq_handler.h
@@ -124,10 +124,13 @@ private:
 
     void adjust_ae_speed (
         ia_aiq_exposure_sensor_parameters &cur_res,
+        ia_aiq_exposure_parameters &cur_aiq_exp,
         const ia_aiq_exposure_sensor_parameters &last_res, double ae_speed);
-    void adjust_ae_limitation (ia_aiq_exposure_sensor_parameters &cur_res);
+    void adjust_ae_limitation (ia_aiq_exposure_sensor_parameters &cur_res,
+                               ia_aiq_exposure_parameters &cur_aiq_exp);
     bool manual_control_result (
         ia_aiq_exposure_sensor_parameters &cur_res,
+        ia_aiq_exposure_parameters &cur_aiq_exp,
         const ia_aiq_exposure_sensor_parameters &last_res);
 
     SmartPtr<X3aResult> pop_result ();


### PR DESCRIPTION
1. aiq: apply manual control to aiq exposure param result
     * previously, manual control only adjusted aiq ae result's sensor
       exposure param, but general exposure param wasn't adjusted.
       however, ae standard result is generated from the latter.
       cl dynamic path thus couldn't populate manual controlled results.

2. tests: set exposure range and max gain for imx185 WDR
     * test cmd: ./test-device-manager -f BA12 -m dma -c -d still -p -a dynamic