### PR TITLE
cl: fix hang issue if snr enabled

### DIFF
--- a/xcore/cl_3a_image_processor.cpp
+++ b/xcore/cl_3a_image_processor.cpp
@@ -488,6 +488,7 @@ CL3aImageProcessor::create_handlers ()
         XCAM_RETURN_ERROR_CL,
         "CL3aImageProcessor create snr handler failed");
     _snr->set_kernels_enable (XCAM_DENOISE_TYPE_SIMPLE & _snr_mode);
+    image_handler->set_pool_size (XCAM_CL_3A_IMAGE_MAX_POOL_SIZE);
     add_handler (image_handler);
 #endif
 


### PR DESCRIPTION
 * tnr moved to yuv-pipe and need cache 4 frames, snr need
   to increase buffer size larger than default 4

Signed-off-by: Wind Yuan <feng.yuan@intel.com>