### PR TITLE
hybrid_analyzer: add cl path support

### DIFF
--- a/3alib/aiq/Makefile.am
+++ b/3alib/aiq/Makefile.am
@@ -15,7 +15,6 @@ plugindir="$(libdir)/xcam"
 
 libxcam_3a_aiq_la_SOURCES =                  \
 			   aiq_wrapper.cpp           \
-			   aiq3a_utils.cpp           \
 			   $(NULL)
 
 libxcam_3a_aiq_la_CXXFLAGS = -I$(top_builddir)/xcore    \
@@ -36,6 +35,3 @@ libxcam_3a_aiq_la_LDFLAGS =                          \
 			  $(NULL)
 
 libxcam_3a_aiq_la_LIBTOOLFLAGS = --tag=disable-static
-
-noinst_HEADERS = aiq3a_utils.h     \
-			   $(NULL)

--- a/3alib/aiq/aiq_wrapper.cpp
+++ b/3alib/aiq/aiq_wrapper.cpp
@@ -303,7 +303,7 @@ xcam_set_3a_stats (XCam3AContext *context, XCam3AStats *stats, int64_t timestamp
     struct atomisp_3a_statistics *raw_stats = isp_stats->get_isp_stats ();
     XCAM_ASSERT (raw_stats);
 
-    XCamAiq3A::translate_3a_stats (stats, raw_stats);
+    translate_3a_stats (stats, raw_stats);
     isp_stats->set_timestamp (timestamp);
 
     ret = analyzer->push_3a_stats (isp_stats);
@@ -386,7 +386,7 @@ xcam_combine_analyze_results (XCam3AContext *context, XCam3aResultHead *results[
     XCAM_ASSERT (result_count < XCAM_3A_LIB_MAX_RESULT_COUNT);
 
     // result_count may changed
-    result_count = XCamAiq3A::translate_3a_results_to_xcam (aiq_results, res_array, XCAM_3A_LIB_MAX_RESULT_COUNT);
+    result_count = translate_3a_results_to_xcam (aiq_results, res_array, XCAM_3A_LIB_MAX_RESULT_COUNT);
 
     for (uint32_t i = 0; i < result_count; ++i) {
         results[i] = res_array[i];
@@ -402,7 +402,7 @@ xcam_free_results (XCam3aResultHead *results[], uint32_t res_count)
 {
     for (uint32_t i = 0; i < res_count; ++i) {
         if (results[i])
-            XCamAiq3A::free_3a_result (results[i]);
+            free_3a_result (results[i]);
     }
 }
 

--- a/xcore/Makefile.am
+++ b/xcore/Makefile.am
@@ -48,6 +48,7 @@ XCAM_CORE_CXXFLAGS +=        \
 endif
 
 xcam_sources =               \
+        aiq3a_utils.cpp          \
 	atomisp_device.cpp       \
 	analyzer_loader.cpp      \
 	buffer_pool.cpp          \

--- a/xcore/aiq3a_utils.cpp
+++ b/xcore/aiq3a_utils.cpp
@@ -22,9 +22,7 @@
 #include "aiq3a_utils.h"
 #include "x3a_isp_config.h"
 
-using namespace XCam;
-
-namespace XCamAiq3A {
+namespace XCam {
 
 bool
 translate_3a_stats (XCam3AStats *from, struct atomisp_3a_statistics *to)
@@ -60,7 +58,7 @@ translate_3a_stats (XCam3AStats *from, struct atomisp_3a_statistics *to)
     return true;
 }
 
-void
+static void
 matrix_3x3_mutiply (double *dest, const double *src1, const double *src2)
 {
     dest[0] = src1[0] * src2[0] + src1[1] * src2[3] + src1[2] * src2[6];
@@ -76,7 +74,7 @@ matrix_3x3_mutiply (double *dest, const double *src1, const double *src2)
     dest[8] = src1[6] * src2[2] + src1[7] * src2[5] + src1[8] * src2[8];
 }
 
-uint32_t
+static uint32_t
 translate_atomisp_parameters (
     const struct atomisp_parameters &atomisp_params,
     XCam3aResultHead *results[], uint32_t max_count)

--- a/xcore/aiq3a_utils.h
+++ b/xcore/aiq3a_utils.h
@@ -29,7 +29,7 @@
 #include <base/xcam_3a_stats.h>
 #include <linux/atomisp.h>
 
-namespace XCamAiq3A {
+namespace XCam {
 bool translate_3a_stats (XCam3AStats *from, struct atomisp_3a_statistics *to);
 uint32_t translate_3a_results_to_xcam (XCam::X3aResultList &list,
                                        XCam3aResultHead *results[], uint32_t max_count);

--- a/xcore/dynamic_analyzer.h
+++ b/xcore/dynamic_analyzer.h
@@ -64,9 +64,9 @@ protected:
     SmartPtr<X3aStats> get_cur_stats () const {
         return _cur_stats;
     }
+    XCamReturn convert_results (XCam3aResultHead *from[], uint32_t from_count, X3aResultList &to);
 
 private:
-    XCamReturn convert_results (XCam3aResultHead *from[], uint32_t from_count, X3aResultList &to);
     XCAM_DEAD_COPY (DynamicAnalyzer);
 
 private:

--- a/xcore/hybrid_analyzer.h
+++ b/xcore/hybrid_analyzer.h
@@ -26,6 +26,8 @@
 namespace XCam {
 class IspController;
 class X3aAnalyzerAiq;
+class X3aStatisticsQueue;
+class X3aIspStatistics;
 
 class HybridAnalyzer
     : public DynamicAnalyzer
@@ -55,10 +57,13 @@ protected:
 
 private:
     XCAM_DEAD_COPY (HybridAnalyzer);
+    XCamReturn setup_stats_pool (const XCam3AStats *stats);
+    SmartPtr<X3aIspStatistics> convert_to_isp_stats (SmartPtr<X3aStats>& stats);
 
-    SmartPtr <IspController>       _isp;
+    SmartPtr<IspController>       _isp;
     const char                    *_cpf_path;
-    SmartPtr <X3aAnalyzerAiq>      _analyzer_aiq;
+    SmartPtr<X3aAnalyzerAiq>      _analyzer_aiq;
+    SmartPtr<X3aStatisticsQueue>  _stats_pool;
 };
 
 }


### PR DESCRIPTION
 * convert X3aStats to X3aIspStatistics for underlying aiq analyzer
 * convert isp X3aResult to standard format for cl processor
 * move aiq3a_utils into xcore
 * cl + hybrid_analyzer test cmd:
   $ gst-launch-1.0 xcamsrc num-buffers=300 io-mode=4 sensor-id=0 enable-3a=true     \
         imageprocessor=1 analyzer=3 path-3alib=/usr/lib/xcam/libxcam_3a_hybrid.so ! \
         video/x-raw,format=NV12,width=1920,height=1080,framerate=25/1 ! fakesink