### PR TITLE
cl image handler: add bilateral yuv

### DIFF
--- a/cl_kernel/kernel_biyuv.cl
+++ b/cl_kernel/kernel_biyuv.cl
@@ -1,0 +1,149 @@
+/*
+ * function: kernel_denoise
+ *     bi-laterial filter for denoise usage
+ * input:    image2d_t as read only
+ * output:   image2d_t as write only
+ * sigma_r:  the parameter to set sigma_r in the Gaussian filtering
+ * imw:      image width, used for edge detect
+ * imh:      image height, used for edge detect
+ * vertical_offset: used for get the uv plane
+ */
+
+__constant float gausssingle[25]={0.6411,0.7574,0.8007,0.7574,0.6411,0.7574,0.8948,0.9459,0.8948,0.7574,0.8007,0.94595945,1,0.9459,0.8007,0.7574,0.8948,0.9459,0.8948,0.7574,0.6411,0.7574,0.8007,0.7574,0.6411};
+
+#define LOCAL_SIZE_X 16
+#define LOCAL_SIZE_Y 15
+
+__kernel void kernel_biyuv(__read_only image2d_t srcYUV, __write_only image2d_t dstYUV,float sigma_r, unsigned int imw, unsigned int imh, uint vertical_offset )
+{
+    int x = get_global_id(1);    //[0,imw-1]
+    int y = get_global_id(0);    //[0,imh-1]
+    int localX = get_local_id(1);    //[0,imw/120-1]
+    int localY = get_local_id(0);    //[0,imh/72-1]
+    //printf("localX=%d,localY=%d\n",localX,localY);
+
+    float normF=0;
+    float H=0;
+    float delta=0;
+    int i=0,j=0;
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE |CLK_FILTER_NEAREST;
+    sigma_r = 2*pown(sigma_r,2);
+
+    //coord in srcY
+    float4 line;
+    line.x=0;
+    line.y=0;
+    line.z=0;
+    line.w=1.0;
+    float4 uv_in;
+
+    // cpy UV
+    if(y % 2 == 0) {
+        uv_in = read_imagef(srcYUV, sampler, (int2)(x, y / 2 + vertical_offset));
+        write_imagef(dstYUV, (int2)(x, y / 2 + vertical_offset), uv_in);
+    }
+
+
+    __local float4 pixel[LOCAL_SIZE_X+4][LOCAL_SIZE_Y+4];
+    bool interior = x > 1 && x <(imw-3)
+    && y>1 && y< (imh-3);
+    if(interior)
+    {
+        pixel[localX+2][localY+2]=read_imagef(srcYUV, sampler,(int2)(x,y));
+
+        if(localX==0)
+        {
+            if(localY==0)
+            {
+                pixel[0][0]=read_imagef(srcYUV, sampler,(int2)(x-2,y-2));
+                pixel[0][1]=read_imagef(srcYUV, sampler,(int2)(x-2,y-1));
+                pixel[0][2]=read_imagef(srcYUV, sampler,(int2)(x-2,y  ));
+                pixel[1][0]=read_imagef(srcYUV, sampler,(int2)(x-1,y-2));
+                pixel[1][1]=read_imagef(srcYUV, sampler,(int2)(x-1,y-1));
+                pixel[1][2]=read_imagef(srcYUV, sampler,(int2)(x-1,y  ));
+                pixel[2][0]=read_imagef(srcYUV, sampler,(int2)(x  ,y-2));
+                pixel[2][1]=read_imagef(srcYUV, sampler,(int2)(x  ,y-1));
+            }
+            else if(localY==LOCAL_SIZE_Y-1)
+            {
+                pixel[0][LOCAL_SIZE_Y-1+2]=read_imagef(srcYUV, sampler,(int2)(x-2,y  ));
+                pixel[0][LOCAL_SIZE_Y  +2]=read_imagef(srcYUV, sampler,(int2)(x-2,y+1));
+                pixel[0][LOCAL_SIZE_Y+1+2]=read_imagef(srcYUV, sampler,(int2)(x-2,y+2));
+                pixel[1][LOCAL_SIZE_Y-1+2]=read_imagef(srcYUV, sampler,(int2)(x-1,y  ));
+                pixel[1][LOCAL_SIZE_Y  +2]=read_imagef(srcYUV, sampler,(int2)(x-1,y+1));
+                pixel[1][LOCAL_SIZE_Y+1+2]=read_imagef(srcYUV, sampler,(int2)(x-1,y+2));
+                pixel[2][LOCAL_SIZE_Y  +2]=read_imagef(srcYUV, sampler,(int2)(x  ,y+1));
+                pixel[2][LOCAL_SIZE_Y+1+2]=read_imagef(srcYUV, sampler,(int2)(x  ,y+2));
+            }
+            else
+            {
+                pixel[0][localY+2]=read_imagef(srcYUV, sampler,(int2)(x-2,y));
+                pixel[1][localY+2]=read_imagef(srcYUV, sampler,(int2)(x-1,y));
+            }
+        }
+        else if(localX==LOCAL_SIZE_X-1)
+        {
+            if(localY==0)
+            {
+                pixel[LOCAL_SIZE_X-1+2+0][0]=read_imagef(srcYUV, sampler,(int2)(x  ,y-2));
+                pixel[LOCAL_SIZE_X-1+2+0][1]=read_imagef(srcYUV, sampler,(int2)(x  ,y-1));
+                //pixel[LOCAL_SIZE_X-1+2+0][2]=read_imagef(srcYUV, sampler,(int2)(x  ,y));
+                pixel[LOCAL_SIZE_X-1+2+1][0]=read_imagef(srcYUV, sampler,(int2)(x+1,y-2));
+                pixel[LOCAL_SIZE_X-1+2+1][1]=read_imagef(srcYUV, sampler,(int2)(x+1,y-1));
+                pixel[LOCAL_SIZE_X-1+2+1][2]=read_imagef(srcYUV, sampler,(int2)(x+1,y  ));
+                pixel[LOCAL_SIZE_X-1+2+2][0]=read_imagef(srcYUV, sampler,(int2)(x+2,y-2));
+                pixel[LOCAL_SIZE_X-1+2+2][1]=read_imagef(srcYUV, sampler,(int2)(x+2,y-1));
+                pixel[LOCAL_SIZE_X-1+2+2][2]=read_imagef(srcYUV, sampler,(int2)(x+2,y  ));
+            }
+            else if(localY==LOCAL_SIZE_Y-1)
+            {
+                //	pixel[LOCAL_SIZE_X-1+2+0][LOCAL_SIZE_Y-1+2+0]=read_imagef(srcYUV, sampler,(int2)(x  ,y  ));
+                pixel[LOCAL_SIZE_X-1+2+0][LOCAL_SIZE_Y-1+2+1]=read_imagef(srcYUV, sampler,(int2)(x  ,y+1));
+                pixel[LOCAL_SIZE_X-1+2+0][LOCAL_SIZE_Y-1+2+2]=read_imagef(srcYUV, sampler,(int2)(x  ,y+2));
+                pixel[LOCAL_SIZE_X-1+2+1][LOCAL_SIZE_Y-1+2+0]=read_imagef(srcYUV, sampler,(int2)(x+1,y  ));
+                pixel[LOCAL_SIZE_X-1+2+1][LOCAL_SIZE_Y-1+2+1]=read_imagef(srcYUV, sampler,(int2)(x+1,y+1));
+                pixel[LOCAL_SIZE_X-1+2+1][LOCAL_SIZE_Y-1+2+2]=read_imagef(srcYUV, sampler,(int2)(x+1,y+2));
+                pixel[LOCAL_SIZE_X-1+2+2][LOCAL_SIZE_Y-1+2+0]=read_imagef(srcYUV, sampler,(int2)(x+2,y  ));
+                pixel[LOCAL_SIZE_X-1+2+2][LOCAL_SIZE_Y-1+2+1]=read_imagef(srcYUV, sampler,(int2)(x+2,y+1));
+                pixel[LOCAL_SIZE_X-1+2+2][LOCAL_SIZE_Y-1+2+2]=read_imagef(srcYUV, sampler,(int2)(x+2,y+2));
+            }
+            else
+            {
+                pixel[LOCAL_SIZE_X-1+2+1][localY+2]=read_imagef(srcYUV, sampler,(int2)(x+1,y  ));
+                pixel[LOCAL_SIZE_X-1+2+2][localY+2]=read_imagef(srcYUV, sampler,(int2)(x+2,y  ));
+            }
+        }
+        else if(localY==0)
+        {
+            pixel[localX+2][0]=read_imagef(srcYUV,sampler,(int2)(x,y-2));
+            pixel[localX+2][1]=read_imagef(srcYUV,sampler,(int2)(x,y-1));
+        }
+        else if(localY==LOCAL_SIZE_Y-1)
+        {
+        pixel[localX+2][LOCAL_SIZE_Y-1+2+1]=read_imagef(srcYUV,sampler,(int2)(x,y+1));
+        pixel[localX+2][LOCAL_SIZE_Y-1+2+2]=read_imagef(srcYUV,sampler,(int2)(x,y+2));
+    }
+    }else{
+        line=read_imagef(srcYUV, sampler,(int2)(x,y));
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (interior) {
+#pragma unroll
+        for(i=0;i<5;i++)
+        {
+#pragma unroll
+             for(j=0;j<5;j++)
+             {
+                  delta=pown(pixel[localX+i][localY+j].x-pixel[localX+2][localY+2].x,2);
+                  H = (exp(-(delta/sigma_r)))*gausssingle[i*5+j];
+                  normF+=H;
+                  line.x+=pixel[localX+i][localY+j].x*H;
+             }
+        }
+
+        line.x=line.x/normF;
+    }
+
+    write_imagef(dstYUV,(int2)(x,y),line);
+}

--- a/clx_kernel/Makefile.am
+++ b/clx_kernel/Makefile.am
@@ -24,6 +24,7 @@ clx_kernel_sources = \
 	kernel_bnr.clx                \
 	kernel_yuv_pipe.clx           \
 	kernel_tonemapping.clx        \
+	kernel_biyuv.clx        \
 	$(NULL)
 
 cl_quote_sh = \

--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -473,6 +473,7 @@ int main (int argc, char *argv[])
         }
         case 'I': {
             denoise_type |= XCAM_DENOISE_TYPE_BILATERAL;
+            denoise_type |= XCAM_DENOISE_TYPE_BIYUV;
             break;
         }
         case 'S': {

--- a/xcore/Makefile.am
+++ b/xcore/Makefile.am
@@ -137,6 +137,7 @@ xcam_sources +=              \
 	cl_yuv_pipe_handler.cpp    \
 	cl_rgb_pipe_handler.cpp       \
 	cl_tonemapping_handler.cpp	\
+	cl_biyuv_handler.cpp	\
 	$(NULL)
 endif
 

--- a/xcore/base/xcam_3a_types.h
+++ b/xcore/base/xcam_3a_types.h
@@ -151,6 +151,7 @@ typedef enum {
     XCAM_DENOISE_TYPE_EE        = (1UL << 2), // luminance noise reduction and edge enhancement
     XCAM_DENOISE_TYPE_BNR       = (1UL << 3), // bayer noise reduction
     XCAM_DENOISE_TYPE_ANR       = (1UL << 4), // advanced bayer noise reduction
+    XCAM_DENOISE_TYPE_BIYUV     = (1UL << 5), // bilateral on yuv noise reduction
 } XCamDenoiseType;
 
 XCAM_END_DECLARE

--- a/xcore/cl_3a_image_processor.cpp
+++ b/xcore/cl_3a_image_processor.cpp
@@ -37,6 +37,7 @@
 #include "cl_yuv_pipe_handler.h"
 #include "cl_rgb_pipe_handler.h"
 #include "cl_tonemapping_handler.h"
+#include "cl_biyuv_handler.h"
 
 #define XCAM_CL_3A_IMAGE_MAX_POOL_SIZE 6
 
@@ -564,6 +565,21 @@ CL3aImageProcessor::create_handlers ()
     image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
     image_handler->set_pool_size (XCAM_CL_3A_IMAGE_MAX_POOL_SIZE);
     add_handler (image_handler);
+
+
+    /* biyuv */
+    image_handler = create_cl_biyuv_image_handler (context);
+    _biyuv = image_handler.dynamic_cast_ptr<CLBiyuvImageHandler> ();
+    XCAM_FAIL_RETURN (
+        WARNING,
+        _biyuv.ptr (),
+        XCAM_RETURN_ERROR_CL,
+        "CL3aImageProcessor create biyuv handler failed");
+    _biyuv->set_kernels_enable (XCAM_DENOISE_TYPE_BIYUV & _snr_mode);
+    image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+    image_handler->set_pool_size (XCAM_CL_3A_IMAGE_MAX_POOL_SIZE);
+    add_handler (image_handler);
+
 
     if (_out_smaple_type == OutSampleRGB) {
         image_handler = create_cl_csc_image_handler (context, CL_CSC_TYPE_NV12TORGBA);

--- a/xcore/cl_3a_image_processor.h
+++ b/xcore/cl_3a_image_processor.h
@@ -46,6 +46,7 @@ class CLBayerPipeImageHandler;
 class CLYuvPipeImageHandler;
 class CLRgbPipeImageHandler;
 class CLTonemappingImageHandler;
+class CLBiyuvImageHandler;
 
 class CL3aImageProcessor
     : public CLImageProcessor
@@ -124,6 +125,7 @@ private:
     SmartPtr<CLDenoiseImageHandler>     _binr;
     SmartPtr<CLEeImageHandler>          _ee;
     SmartPtr<CLDpcImageHandler>         _dpc;
+    SmartPtr<CLBiyuvImageHandler>       _biyuv;
 
     // simple 3a bayer pipeline
     SmartPtr<CLBayerPipeImageHandler>  _bayer_pipe;

--- a/xcore/cl_biyuv_handler.cpp
+++ b/xcore/cl_biyuv_handler.cpp
@@ -1,0 +1,128 @@
+/*
+ * cl_biyuv_handler.cpp - CL edge enhancement handler
+ *
+ *  Copyright (c) 2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Juan Zhao <juan.j.zhao@intel.com>
+ */
+
+
+
+#include "xcam_utils.h"
+#include "cl_biyuv_handler.h"
+
+namespace XCam {
+
+CLBiyuvImageKernel::CLBiyuvImageKernel (SmartPtr<CLContext> &context)
+    : CLImageKernel (context, "kernel_biyuv")
+    , _sigma_r (10.0)
+    , _imw (1920)
+    , _imh (1080)
+{
+}
+
+XCamReturn
+CLBiyuvImageKernel::prepare_arguments (
+    SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
+    CLArgument args[], uint32_t &arg_count,
+    CLWorkSize &work_size)
+{
+    SmartPtr<CLContext> context = get_context ();
+    const VideoBufferInfo & video_info = input->get_video_info ();
+
+    _imw = video_info.width;
+    _imh = video_info.height;
+    //sigma_r = 0.1*100
+    _sigma_r = 10.0;
+
+    _image_in = new CLVaImage (context, input);
+    _image_out = new CLVaImage (context, output);
+
+    XCAM_ASSERT (_image_in->is_valid () && _image_out->is_valid ());
+    XCAM_FAIL_RETURN (
+        WARNING,
+        _image_in->is_valid () && _image_out->is_valid (),
+        XCAM_RETURN_ERROR_MEM,
+        "cl image kernel(%s) in/out memory not available", get_kernel_name ());
+
+    _vertical_offset = video_info.aligned_height;
+
+    //set args;
+    args[0].arg_adress = &_image_in->get_mem_id ();
+    args[0].arg_size = sizeof (cl_mem);
+    args[1].arg_adress = &_image_out->get_mem_id ();
+    args[1].arg_size = sizeof (cl_mem);
+    args[2].arg_adress = &_sigma_r;
+    args[2].arg_size = sizeof (_sigma_r);
+    args[3].arg_adress = &_imw;
+    args[3].arg_size = sizeof (_imw);
+    args[4].arg_adress = &_imh;
+    args[4].arg_size = sizeof (_imh);
+
+    args[5].arg_adress = &_vertical_offset;
+    args[5].arg_size = sizeof (_vertical_offset);
+    arg_count = 6;
+
+    work_size.dim = XCAM_DEFAULT_IMAGE_DIM;
+    work_size.global[0] = _imh;
+    work_size.global[1] = _imw;
+    work_size.local[0] = _imh / 72;
+    work_size.local[1] = _imw / 120;
+
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+CLBiyuvImageHandler::CLBiyuvImageHandler (const char *name)
+    : CLImageHandler (name)
+{
+}
+
+bool
+CLBiyuvImageHandler::set_biyuv_kernel(SmartPtr<CLBiyuvImageKernel> &kernel)
+{
+    SmartPtr<CLImageKernel> image_kernel = kernel;
+    add_kernel (image_kernel);
+    _biyuv_kernel = kernel;
+    return true;
+}
+
+SmartPtr<CLImageHandler>
+create_cl_biyuv_image_handler (SmartPtr<CLContext> &context)
+{
+    SmartPtr<CLBiyuvImageHandler> biyuv_handler;
+    SmartPtr<CLBiyuvImageKernel> biyuv_kernel;
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+
+    biyuv_kernel = new CLBiyuvImageKernel (context);
+    {
+        XCAM_CL_KERNEL_FUNC_SOURCE_BEGIN(kernel_biyuv)
+#include "kernel_biyuv.clx"
+        XCAM_CL_KERNEL_FUNC_END;
+        ret = biyuv_kernel->load_from_source (kernel_biyuv_body, strlen (kernel_biyuv_body));
+        XCAM_FAIL_RETURN (
+            WARNING,
+            ret == XCAM_RETURN_NO_ERROR,
+            NULL,
+            "CL image handler(%s) load source failed", biyuv_kernel->get_kernel_name());
+    }
+    XCAM_ASSERT (biyuv_kernel->is_valid ());
+    biyuv_handler = new CLBiyuvImageHandler ("cl_handler_biyuv");
+    biyuv_handler->set_biyuv_kernel (biyuv_kernel);
+
+    return biyuv_handler;
+}
+
+};

--- a/xcore/cl_biyuv_handler.h
+++ b/xcore/cl_biyuv_handler.h
@@ -1,0 +1,69 @@
+/*
+ * cl_biyuv_handler.h - CL Biyuv handler
+ *
+ *  Copyright (c) 2015 Intel Corporation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Juan Zhao <juan.j.zhao@intel.com>
+ */
+
+#ifndef XCAM_CL_BIYUV_HANLDER_H
+#define XCAM_CL_BIYUV_HANLDER_H
+
+#include "xcam_utils.h"
+#include "cl_image_handler.h"
+
+namespace XCam {
+
+class CLBiyuvImageKernel
+    : public CLImageKernel
+{
+public:
+    explicit CLBiyuvImageKernel (SmartPtr<CLContext> &context);
+
+protected:
+    virtual XCamReturn prepare_arguments (
+        SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
+        CLArgument args[], uint32_t &arg_count,
+        CLWorkSize &work_size);
+
+private:
+    XCAM_DEAD_COPY (CLBiyuvImageKernel);
+    float    _sigma_r;
+    uint32_t _imw;
+    uint32_t _imh;
+    uint32_t _vertical_offset;
+};
+
+class CLBiyuvImageHandler
+    : public CLImageHandler
+{
+public:
+    explicit CLBiyuvImageHandler (const char *name);
+    bool set_enable (bool enable);
+
+    bool set_biyuv_kernel (SmartPtr<CLBiyuvImageKernel> &kernel);
+
+private:
+    XCAM_DEAD_COPY (CLBiyuvImageHandler);
+
+private:
+    SmartPtr<CLBiyuvImageKernel>   _biyuv_kernel;
+};
+
+SmartPtr<CLImageHandler>
+create_cl_biyuv_image_handler (SmartPtr<CLContext> &context);
+
+};
+
+#endif //XCAM_CL_BIYUV_HANLDER_H


### PR DESCRIPTION
Enable bilateral in Y color space could help to reduce the noise in Y.
So enable the Y color space bilateral noise reduction.

And with the posibility, it could reduce the IO output than operation in RGB color space.
corrently, we only operate bilateral on Y color space.

Signed-off-by: Juan Zhao <juan.j.zhao@intel.com>