### PR TITLE
cl-bayer: set gamma table as optional

### DIFF
--- a/cl_kernel/kernel_bayer_pipe.cl
+++ b/cl_kernel/kernel_bayer_pipe.cl
@@ -115,6 +115,7 @@ inline float4 simple_calculate (
     __local float4 *stats_cache,
     CLBLCConfig *blc_config,
     CLWBConfig *wb_config,
+    uint enable_gamma,
     __global float *gamma_table)
 {
     float4 data;
@@ -135,7 +136,8 @@ inline float4 simple_calculate (
     stats_cache[index] = data;
 
     wb (&data, wb_config);
-    gamma_correct (&data, gamma_table);
+    if (enable_gamma)
+        gamma_correct (&data, gamma_table);
 
     px[index] = data.x;
     py[index] = data.y;
@@ -490,6 +492,7 @@ __kernel void kernel_bayer_pipe (__read_only image2d_t input,
                                  CLBLCConfig blc_config,
                                  CLWBConfig wb_config,
                                  uint has_denoise,
+                                 uint enable_gamma,
                                  __global float * gamma_table,
                                  __global XCamGridStat * stats_output)
 {
@@ -520,6 +523,7 @@ __kernel void kernel_bayer_pipe (__read_only image2d_t input,
                           stats_cache,
                           &blc_config,
                           &wb_config,
+                          enable_gamma,
                           gamma_table);
     }
     barrier(CLK_LOCAL_MEM_FENCE);

--- a/xcore/cl_3a_image_processor.cpp
+++ b/xcore/cl_3a_image_processor.cpp
@@ -639,6 +639,8 @@ CL3aImageProcessor::set_gamma (bool enable)
 
     if (_gamma.ptr ())
         return _gamma->set_kernels_enable (enable);
+    if (_bayer_pipe.ptr ())
+        _bayer_pipe->enable_gamma (enable);
 
     return true;
 }

--- a/xcore/cl_bayer_pipe_handler.cpp
+++ b/xcore/cl_bayer_pipe_handler.cpp
@@ -220,6 +220,7 @@ CLBayerPipeImageKernel::CLBayerPipeImageKernel (
     SmartPtr<CLBayerPipeImageHandler> &handler)
     : CLImageKernel (context, "kernel_bayer_pipe")
     , _enable_denoise (0)
+    , _enable_gamma (1)
     , _handler (handler)
 {
     _blc_config.level_gr = XCAM_CL_BLC_DEFAULT_LEVEL;
@@ -278,6 +279,13 @@ CLBayerPipeImageKernel::enable_denoise (bool enable)
     return true;
 }
 
+bool
+CLBayerPipeImageKernel::enable_gamma (bool enable)
+{
+    _enable_gamma = (enable ? 1 : 0);
+    return true;
+}
+
 XCamReturn
 CLBayerPipeImageKernel::prepare_arguments (
     SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
@@ -326,12 +334,15 @@ CLBayerPipeImageKernel::prepare_arguments (
     args[4].arg_adress = &_enable_denoise;
     args[4].arg_size = sizeof (_enable_denoise);
 
-    args[5].arg_adress = &_gamma_table_buffer->get_mem_id ();
-    args[5].arg_size = sizeof (cl_mem);
+    args[5].arg_adress = &_enable_gamma;
+    args[5].arg_size = sizeof (_enable_gamma);
 
-    args[6].arg_adress = &_stats_cl_buffer->get_mem_id ();
+    args[6].arg_adress = &_gamma_table_buffer->get_mem_id ();
     args[6].arg_size = sizeof (cl_mem);
-    arg_count = 7;
+
+    args[7].arg_adress = &_stats_cl_buffer->get_mem_id ();
+    args[7].arg_size = sizeof (cl_mem);
+    arg_count = 8;
 
     work_size.dim = XCAM_DEFAULT_IMAGE_DIM;
     work_size.global[0] = XCAM_ALIGN_UP(out_video_info.width, 16) / WORK_ITEM_X_SIZE;
@@ -432,6 +443,12 @@ bool
 CLBayerPipeImageHandler::enable_denoise (bool enable)
 {
     return _bayer_kernel->enable_denoise (enable);
+}
+
+bool
+CLBayerPipeImageHandler::enable_gamma (bool enable)
+{
+    return _bayer_kernel->enable_gamma (enable);
 }
 
 XCamReturn

--- a/xcore/cl_bayer_pipe_handler.h
+++ b/xcore/cl_bayer_pipe_handler.h
@@ -98,6 +98,7 @@ public:
     bool set_wb (const XCam3aResultWhiteBalance &wb);
     bool set_gamma_table (const XCam3aResultGammaTable &gamma);
     bool enable_denoise (bool enable);
+    bool enable_gamma (bool enable);
 
 protected:
     virtual XCamReturn prepare_arguments (
@@ -115,6 +116,7 @@ private:
     CLBLCConfig               _blc_config;
     CLWBConfig                _wb_config;
     uint32_t                  _enable_denoise;
+    uint32_t                  _enable_gamma;
     float                     _gamma_table[XCAM_GAMMA_TABLE_SIZE + 1];
     SmartPtr<CLBuffer>        _gamma_table_buffer;
     SmartPtr<CL3AStatsCalculatorContext>  _3a_stats_context;
@@ -142,6 +144,7 @@ public:
     bool set_wb_config (const XCam3aResultWhiteBalance &wb);
     bool set_gamma_table (const XCam3aResultGammaTable &gamma);
     bool enable_denoise (bool enable);
+    bool enable_gamma (bool enable);
 
 protected:
     virtual XCamReturn prepare_buffer_pool_video_info (


### PR DESCRIPTION
 * gamma table 256 is not good enough for every case. need to disable
   it on case like WDR mode