### PR TITLE
usbcam: Add support to xcamsrc GST path for USB cam

### DIFF
--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -75,6 +75,7 @@ struct _GstXCamSrc
     char                        *path_to_cpf;
     char                        *path_to_3alib;
     gboolean                     enable_3a;
+    gboolean                     enable_usb;
 
     gboolean                     time_offset_ready;
     int64_t                      time_offset;

--- a/xcore/device_manager.cpp
+++ b/xcore/device_manager.cpp
@@ -274,7 +274,9 @@ DeviceManager::stop ()
     if (_3a_process_center.ptr())
         _3a_process_center->stop ();
 
-    _subdevice->stop ();
+    if (_subdevice.ptr ())
+        _subdevice->stop ();
+
     _device->stop ();
 
     _isp_controller.release ();


### PR DESCRIPTION
Enabled gstreamer path with USB camera by adding
support to the xcamsrc plugin. Tested with Logitech
C920 USB webcam.

Test:

gst-launch-1.0 -v xcamsrc enable-usb=true device="/dev/videoX" \
sensor-id=3 io-mode=4 analyzer=1 blocksize=1024000 ! \
video/x-raw, format=YUY2, width=1920, height=1080, \
framerate=25/1 ! queue ! vaapipostproc format=nv12 \
width=1920 height=1080 ! vaapiencode_h264 rate-control=cbr \
! filesink location=out.h264

Signed-off-by: Sameer Kibey <sameer.kibey@intel.com>