### PR TITLE
Specify that tonemapping is only applicable under format BA12. If --e…

### DIFF
--- a/cl_kernel/kernel_tonemapping.cl
+++ b/cl_kernel/kernel_tonemapping.cl
@@ -5,14 +5,102 @@
  * output:   image2d_t as write only
  */
 
-__kernel void kernel_tonemapping (__read_only image2d_t input, __write_only image2d_t output, uint color_bits)
-{
-    int x = get_global_id (0);
-    int y = get_global_id (1);
-    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
-    //printf("In tonemapping kernel input color_bits = %d\n", color_bits);
+#define STATS_BLOCK_FACTOR 7
 
-    float4 p;
-    p = read_imagef(input, sampler, (int2)(x , y));
-    write_imagef(output, (int2)(x, y), p);
+typedef struct
+{
+    float r_gain;
+    float gr_gain;
+    float gb_gain;
+    float b_gain;
+} CLWBConfig;
+
+typedef struct _XCamGridStat {
+    unsigned int avg_y;
+
+    unsigned int avg_r;
+    unsigned int avg_gr;
+    unsigned int avg_gb;
+    unsigned int avg_b;
+    unsigned int valid_wb_count;
+
+    unsigned int f_value1;
+    unsigned int f_value2;
+} XCamGridStat;
+
+__kernel void kernel_tonemapping (__read_only image2d_t input, __write_only image2d_t output, __global XCamGridStat *stats_input, CLWBConfig wb_config, float tm_gamma)
+{
+    int g_id_x = get_global_id (0);
+    int g_id_y = get_global_id (1);
+
+    int g_size_x = get_global_size (0);
+    int g_size_y = get_global_size (1);
+
+    int group_id_x = get_group_id(0);
+    int group_id_y = get_group_id(1);
+
+    int group_size_x = get_num_groups(0);
+    int group_size_y = get_num_groups(1);
+
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+    float4 data = read_imagef (input, sampler, (int2)(g_id_x, g_id_y));
+
+    float4 local_avg = 0.0f;
+
+    int index;
+#if 1
+    int x_start = g_id_x - 8;
+    int x_end = g_id_x + 8;
+    int y_start = g_id_y - 8;
+    int y_end = g_id_y + 8;
+    int x, y, index_x, index_y;
+
+    for(y = y_start; y <= y_end; y++)
+    {
+        for(x = x_start; x <= x_end; x++)
+        {
+            index_y = y > 0 ? y : 0;
+            index_y = index_y < g_size_y ? index_y : (g_size_y - 1);
+            index_x = x > 0 ? x : 0;
+            index_x = index_x < g_size_x ? index_x : (g_size_x - 1);
+
+            local_avg = local_avg + read_imagef (input, sampler, (int2)(index_x, index_y));
+        }
+    }
+
+    local_avg = local_avg / (17 * 17);
+#else
+    int x_start = group_id_x - STATS_BLOCK_FACTOR / 2;
+    int x_end = group_id_x + STATS_BLOCK_FACTOR / 2;
+    int y_start = group_id_y - STATS_BLOCK_FACTOR / 2;
+    int y_end = group_id_y + STATS_BLOCK_FACTOR / 2;
+    int x, y, index_x, index_y;
+    for(y = y_start; y <= y_end; y++)
+    {
+        for(x = x_start; x <= x_end; x++)
+        {
+            index_y = y > 0 ? y : 0;
+            index_y = index_y < group_size_y ? index_y : (group_size_y - 1);
+            index_x = x > 0 ? x : 0;
+            index_x = index_x < group_size_x ? index_x : (group_size_x - 1);
+            index = index_y * group_size_x + index_x;
+            local_avg.x = local_avg.x + stats_input[index].avg_r * wb_config.r_gain;
+            local_avg.y = local_avg.y + (stats_input[index].avg_gr * wb_config.gr_gain + stats_input[index].avg_gb * wb_config.gb_gain) * 0.5f;
+            local_avg.z = local_avg.z + stats_input[index].avg_b * wb_config.b_gain;
+            local_avg.w = 0.0f;
+        }
+    }
+
+    local_avg = local_avg / (STATS_BLOCK_FACTOR * STATS_BLOCK_FACTOR);
+    local_avg = local_avg / 255.0f;
+#endif
+
+    float4 gain = 2.0f;
+    float4 delta = data - local_avg;
+
+    local_avg = pow(local_avg, 1 / tm_gamma);
+    data = local_avg + gain * delta;
+
+    write_imagef(output, (int2)(g_id_x, g_id_y), data);
 }

--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -618,6 +618,10 @@ int main (int argc, char *argv[])
     else {
         frame_rate = 25;
         device->set_framerate (frame_rate, 1);
+        if(tonemapping_type == true) {
+            XCAM_LOG_WARNING("Tonemapping is only applicable under BA12 format. Disable tonemapping automatically.");
+            tonemapping_type = false;
+        }
     }
     ret = device->open ();
     CHECK (ret, "device(%s) open failed", device->get_device_name());

--- a/xcore/cl_3a_image_processor.cpp
+++ b/xcore/cl_3a_image_processor.cpp
@@ -172,6 +172,9 @@ CL3aImageProcessor::apply_3a_result (SmartPtr<X3aResult> &result)
             _bayer_pipe->set_wb_config (wb_res->get_standard_result ());
             _bayer_pipe->set_3a_result (result);
         }
+        if (_tonemapping.ptr ()) {
+            _tonemapping->set_wb_config (wb_res->get_standard_result ());
+        }
         break;
     }
 

--- a/xcore/cl_tonemapping_handler.cpp
+++ b/xcore/cl_tonemapping_handler.cpp
@@ -24,15 +24,24 @@ namespace XCam {
 
 CLTonemappingImageKernel::CLTonemappingImageKernel (SmartPtr<CLContext> &context,
         const char *name)
-    : CLImageKernel (context, name),
-      _initial_color_bits (12)
+    : CLImageKernel (context, name)
 {
+    _wb_config.r_gain = 1.0;
+    _wb_config.gr_gain = 1.0;
+    _wb_config.gb_gain = 1.0;
+    _wb_config.b_gain = 1.0;
+
+    _tm_gamma = 2.0f;
 }
 
-void
-CLTonemappingImageKernel::set_initial_color_bits(uint32_t color_bits)
+bool
+CLTonemappingImageKernel::set_wb (const XCam3aResultWhiteBalance &wb)
 {
-    _initial_color_bits = color_bits;
+    _wb_config.r_gain = (float)wb.r_gain;
+    _wb_config.gr_gain = (float)wb.gr_gain;
+    _wb_config.gb_gain = (float)wb.gb_gain;
+    _wb_config.b_gain = (float)wb.b_gain;
+    return true;
 }
 
 
@@ -54,23 +63,31 @@ CLTonemappingImageKernel::prepare_arguments (
         XCAM_RETURN_ERROR_MEM,
         "cl image kernel(%s) in/out memory not available", get_kernel_name ());
 
-    //XCAM_LOG_INFO ("IN tonemapping color bits = %d\n",_initial_color_bits);
+    SmartPtr<X3aStats> stats = input->find_3a_stats ();
+    XCam3AStats *stats_ptr = stats->get_stats ();
+    _stats_buffer = new CLBuffer(
+        context, stats_ptr->info.aligned_width * stats_ptr->info.aligned_height * sizeof (XCamGridStat),
+        CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR , &(stats_ptr->stats));
 
     //set args;
     args[0].arg_adress = &_image_in->get_mem_id ();
     args[0].arg_size = sizeof (cl_mem);
     args[1].arg_adress = &_image_out->get_mem_id ();
     args[1].arg_size = sizeof (cl_mem);
-    args[2].arg_adress = &_initial_color_bits;
-    args[2].arg_size = sizeof (_initial_color_bits);
-    arg_count = 3;
+    args[2].arg_adress = &_stats_buffer->get_mem_id ();
+    args[2].arg_size = sizeof (cl_mem);
+    args[3].arg_adress = &_wb_config;
+    args[3].arg_size = sizeof (_wb_config);
+    args[4].arg_adress = &_tm_gamma;
+    args[4].arg_size = sizeof (float);
+    arg_count = 5;
 
     const CLImageDesc out_info = _image_out->get_image_desc ();
     work_size.dim = XCAM_DEFAULT_IMAGE_DIM;
     work_size.global[0] = out_info.width;
-    work_size.global[1] = out_info.height;
-    work_size.local[0] = 8;
-    work_size.local[1] = 4;
+    work_size.global[1] = stats_ptr->info.aligned_height * 16;
+    work_size.local[0] = 16;
+    work_size.local[1] = 16;
 
     return XCAM_RETURN_NO_ERROR;
 }
@@ -90,10 +107,10 @@ CLTonemappingImageHandler::set_tonemapping_kernel(SmartPtr<CLTonemappingImageKer
     return true;
 }
 
-void
-CLTonemappingImageHandler::set_initial_color_bits(uint32_t color_bits)
+bool
+CLTonemappingImageHandler::set_wb_config (const XCam3aResultWhiteBalance &wb)
 {
-    _tonemapping_kernel->set_initial_color_bits(color_bits);
+    return _tonemapping_kernel->set_wb (wb);
 }
 
 

--- a/xcore/cl_tonemapping_handler.h
+++ b/xcore/cl_tonemapping_handler.h
@@ -23,6 +23,9 @@
 
 #include "xcam_utils.h"
 #include "cl_image_handler.h"
+#include "cl_wb_handler.h"
+#include "x3a_stats_pool.h"
+
 
 namespace XCam {
 
@@ -32,7 +35,7 @@ class CLTonemappingImageKernel
 public:
     explicit CLTonemappingImageKernel (SmartPtr<CLContext> &context,
                                        const char *name);
-    void set_initial_color_bits(uint32_t color_bits);
+    bool set_wb (const XCam3aResultWhiteBalance &wb);
 
 protected:
     virtual XCamReturn prepare_arguments (
@@ -42,7 +45,10 @@ protected:
 
 private:
     XCAM_DEAD_COPY (CLTonemappingImageKernel);
-    uint32_t _initial_color_bits;// color bits from ISP
+    CLWBConfig                _wb_config;
+    float                     _tm_gamma;
+
+    SmartPtr<CLBuffer>        _stats_buffer;
 };
 
 class CLTonemappingImageHandler
@@ -51,7 +57,7 @@ class CLTonemappingImageHandler
 public:
     explicit CLTonemappingImageHandler (const char *name);
     bool set_tonemapping_kernel(SmartPtr<CLTonemappingImageKernel> &kernel);
-    void set_initial_color_bits(uint32_t color_bits);
+    bool set_wb_config (const XCam3aResultWhiteBalance &wb);
 
 protected:
     virtual XCamReturn prepare_buffer_pool_video_info (


### PR DESCRIPTION
…nable-tonemapping flag is on under format other than BA12, program will print a warning log and disable tonemapping automatically.

* test cmd:
  ./tests/test-device-manager -a dynamic -m dma -c -f BA10 -d still --enable-tonemapping