### PR TITLE
poll_thread: implement FakePollThread to read from raw image

### DIFF
--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -21,6 +21,7 @@
 #include "device_manager.h"
 #include "atomisp_device.h"
 #include "uvc_device.h"
+#include "fake_v4l2_device.h"
 #include "isp_controller.h"
 #include "isp_image_processor.h"
 #include "x3a_analyzer_simple.h"
@@ -37,6 +38,8 @@
 #include "drm_display.h"
 #endif
 #include "x3a_analyzer_loader.h"
+#include "poll_thread.h"
+#include "fake_poll_thread.h"
 #include <base/xcam_3a_types.h>
 #include <unistd.h>
 #include <signal.h>
@@ -283,6 +286,7 @@ void print_help (const char *bin_name)
             "\t -e display_mode    preview mode\n"
             "\t                select from [primary, overlay], default is [primary]\n"
             "\t --sync        set analyzer in sync mode\n"
+            "\t -r raw_input  specify the path of raw image as input source instead of live camera\n"
             "\t -h            help\n"
 #if HAVE_LIBCL
             "CL features:\n"
@@ -351,8 +355,9 @@ int main (int argc, char *argv[])
     char*   usb_device_name = NULL;
     bool sync_mode = false;
     int frame_rate;
+    char *path_to_raw = NULL;
 
-    const char *short_opts = "sca:n:m:f:d:b:pi:e:h";
+    const char *short_opts = "sca:n:m:f:d:b:pi:e:r:h";
     const struct option long_opts[] = {
         {"hdr", required_argument, NULL, 'H'},
         {"tnr", required_argument, NULL, 'T'},
@@ -539,6 +544,13 @@ int main (int argc, char *argv[])
             break;
         }
 #endif
+        case 'r': {
+            if (optarg) {
+                XCAM_LOG_INFO ("use raw image %s as input source", optarg);
+                path_to_raw = strdup(optarg);
+            }
+            break;
+        }
         case 'h':
             print_help (bin_name);
             return 0;
@@ -554,7 +566,9 @@ int main (int argc, char *argv[])
         device_manager->set_display_mode (display_mode);
     }
     if (!device.ptr ())  {
-        if (have_usbcam) {
+        if (path_to_raw) {
+            device = new FakeV4l2Device ();
+        } else if (have_usbcam) {
             device = new UVCDevice (usb_device_name);
         } else {
             if (capture_mode == V4L2_CAPTURE_MODE_STILL)
@@ -681,6 +695,13 @@ int main (int argc, char *argv[])
     }
 #endif
 
+    SmartPtr<PollThread> poll_thread;
+    if (path_to_raw)
+        poll_thread = new FakePollThread (path_to_raw);
+    else
+        poll_thread = new PollThread ();
+    device_manager->set_poll_thread (poll_thread);
+
     ret = device_manager->start ();
     CHECK (ret, "device manager start failed");
 
@@ -704,6 +725,10 @@ int main (int argc, char *argv[])
     CHECK_CONTINUE (ret, "device manager stop failed");
     device->close ();
     event_device->close ();
+    if (usb_device_name)
+        free (usb_device_name);
+    if (path_to_raw)
+        free (path_to_raw);
 
     return 0;
 }

--- a/tests/test-poll-thread.cpp
+++ b/tests/test-poll-thread.cpp
@@ -58,7 +58,7 @@ public:
     ~PollCB() {
         close_file ();
     };
-    XCamReturn poll_buffer_ready (SmartPtr<V4l2BufferProxy> &buf);
+    XCamReturn poll_buffer_ready (SmartPtr<VideoBuffer> &buf);
     XCamReturn poll_buffer_failed (int64_t timestamp, const char *msg)
     {
         XCAM_UNUSED(timestamp);
@@ -89,7 +89,7 @@ private:
 };
 
 XCamReturn
-PollCB::poll_buffer_ready (SmartPtr<V4l2BufferProxy> &buf) {
+PollCB::poll_buffer_ready (SmartPtr<VideoBuffer> &buf) {
 
     SmartPtr<VideoBuffer> base = buf;
     XCAM_LOG_DEBUG("%s", __FUNCTION__);

--- a/wrapper/gstreamer/gstxcamsrc.cpp
+++ b/wrapper/gstreamer/gstxcamsrc.cpp
@@ -41,6 +41,9 @@
 #include "x3a_analyzer_loader.h"
 #include "smart_analyzer_loader.h"
 #include "smart_analysis_handler.h"
+#include "poll_thread.h"
+#include "fake_poll_thread.h"
+#include "fake_v4l2_device.h"
 
 #include <signal.h>
 #include <uvc_device.h>
@@ -220,7 +223,8 @@ enum {
     PROP_CPF,
     PROP_3A_LIB,
     PROP_INPUT_FMT,
-    PROP_ENABLE_USB
+    PROP_ENABLE_USB,
+    PROP_RAW
 };
 
 static void gst_xcam_src_xcam_3a_interface_init (GstXCam3AInterface *iface);
@@ -378,6 +382,11 @@ gst_xcam_src_class_init (GstXCamSrcClass * klass)
         g_param_spec_string ("input-format", "input format", "Input pixel format",
                              NULL, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
+    g_object_class_install_property (
+        gobject_class, PROP_RAW,
+        g_param_spec_string ("path-raw", "raw input", "Use the specified raw file as input instead of live camera",
+                             NULL, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
     gst_element_class_set_details_simple (element_class,
                                           "Libxcam Source",
                                           "Source/Base",
@@ -416,6 +425,7 @@ gst_xcam_src_init (GstXCamSrc *xcamsrc)
     xcamsrc->path_to_3alib = strdup(DEFAULT_DYNAMIC_3A_LIB);
     xcamsrc->enable_3a = DEFAULT_PROP_ENABLE_3A;
     xcamsrc->enable_usb = DEFAULT_PROP_ENABLE_USB;
+    xcamsrc->path_to_raw = NULL;
     xcamsrc->time_offset_ready = FALSE;
     xcamsrc->time_offset = -1;
     xcamsrc->buf_mark = 0;
@@ -518,6 +528,9 @@ gst_xcam_src_get_property (
         g_value_set_string (value, xcam_fourcc_to_string (src->in_format));
         break;
     }
+    case PROP_RAW:
+        g_value_set_string (value, src->path_to_raw);
+        break;
 
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -620,6 +633,15 @@ gst_xcam_src_set_property (
             GST_ERROR_OBJECT (src, "Invalid input format: not fourcc");
         break;
     }
+    case PROP_RAW: {
+        const char * raw = g_value_get_string (value);
+        if (src->path_to_raw)
+            xcam_free (src->path_to_raw);
+        src->path_to_raw = NULL;
+        if (raw)
+            src->path_to_raw = strdup (raw);
+        break;
+    }
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
         break;
@@ -685,6 +707,7 @@ gst_xcam_src_start (GstBaseSrc *src)
     SmartPtr<V4l2Device> capture_device;
     SmartPtr<V4l2SubDevice> event_device;
     SmartPtr<IspController> isp_controller;
+    SmartPtr<PollThread> poll_thread;
 
     // Check device
     if (xcamsrc->device == NULL) {
@@ -705,7 +728,9 @@ gst_xcam_src_start (GstBaseSrc *src)
             xcamsrc->in_format = V4L2_PIX_FMT_NV12;
     }
 
-    if (!xcamsrc->enable_usb) {
+    if (xcamsrc->path_to_raw) {
+        capture_device = new FakeV4l2Device ();
+    } else if (!xcamsrc->enable_usb) {
         capture_device = new AtomispDevice (xcamsrc->device);
     } else {
         capture_device = new UVCDevice (xcamsrc->device);
@@ -717,7 +742,7 @@ gst_xcam_src_start (GstBaseSrc *src)
     capture_device->open ();
     device_manager->set_capture_device (capture_device);
 
-    if (!xcamsrc->enable_usb) { // USB camera does not use the v4l2 subdevice
+    if (!xcamsrc->enable_usb && !xcamsrc->path_to_raw) {
         event_device = new V4l2SubDevice (DEFAULT_EVENT_DEVICE);
         ret = event_device->open ();
         if (ret == XCAM_RETURN_NO_ERROR) {
@@ -814,6 +839,11 @@ gst_xcam_src_start (GstBaseSrc *src)
         device_manager->set_smart_analyzer (smart_analyzer);
     }
 
+    if (xcamsrc->path_to_raw)
+        poll_thread = new FakePollThread (xcamsrc->path_to_raw);
+    else
+        poll_thread = new PollThread ();
+    device_manager->set_poll_thread (poll_thread);
     return TRUE;
 }
 
@@ -881,7 +911,7 @@ translate_format_to_xcam (GstVideoFormat format)
     case GST_VIDEO_FORMAT_Y42B:
         return V4L2_PIX_FMT_YUV422P;
 
-    //RGB
+        //RGB
     case GST_VIDEO_FORMAT_RGBx:
         return V4L2_PIX_FMT_RGB32;
     case GST_VIDEO_FORMAT_BGRx:

--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -76,6 +76,7 @@ struct _GstXCamSrc
     char                        *path_to_3alib;
     gboolean                     enable_3a;
     gboolean                     enable_usb;
+    char                        *path_to_raw;
 
     gboolean                     time_offset_ready;
     int64_t                      time_offset;

--- a/xcore/Makefile.am
+++ b/xcore/Makefile.am
@@ -58,6 +58,7 @@ xcam_sources =               \
 	dynamic_analyzer.cpp     \
 	smart_analyzer.cpp       \
 	smart_analysis_handler.cpp \
+        fake_poll_thread.cpp \
 	handler_interface.cpp    \
 	image_processor.cpp      \
 	isp_controller.cpp       \

--- a/xcore/device_manager.cpp
+++ b/xcore/device_manager.cpp
@@ -159,6 +159,17 @@ DeviceManager::add_image_processor (SmartPtr<ImageProcessor> processor)
     return _3a_process_center->insert_processor (processor);
 }
 
+bool
+DeviceManager::set_poll_thread (SmartPtr<PollThread> thread)
+{
+    if (is_running ())
+        return false;
+
+    XCAM_ASSERT (thread.ptr () && !_poll_thread.ptr ());
+    _poll_thread = thread;
+    return true;
+}
+
 XCamReturn
 DeviceManager::start ()
 {
@@ -238,7 +249,7 @@ DeviceManager::start ()
     }
 
     //Initialize and start poll thread
-    _poll_thread = new PollThread;
+    XCAM_ASSERT (_poll_thread.ptr ());
     _poll_thread->set_capture_device (_device);
     if (_subdevice.ptr ())
         _poll_thread->set_event_device (_subdevice);
@@ -330,11 +341,10 @@ DeviceManager::scaled_image_ready (const SmartPtr<ScaledVideoBuffer> &buffer)
 
 
 XCamReturn
-DeviceManager::poll_buffer_ready (SmartPtr<V4l2BufferProxy> &buf)
+DeviceManager::poll_buffer_ready (SmartPtr<VideoBuffer> &buf)
 {
     if (_has_3a) {
-        SmartPtr<VideoBuffer> video_buf = buf;
-        if (_3a_process_center->put_buffer (video_buf) == false)
+        if (_3a_process_center->put_buffer (buf) == false)
             return XCAM_RETURN_ERROR_UNKNOWN;
     }
     return XCAM_RETURN_NO_ERROR;

--- a/xcore/device_manager.h
+++ b/xcore/device_manager.h
@@ -78,6 +78,7 @@ public:
     bool set_3a_analyzer (SmartPtr<X3aAnalyzer> analyzer);
     bool set_smart_analyzer (SmartPtr<SmartAnalyzer> analyzer);
     bool add_image_processor (SmartPtr<ImageProcessor> processor);
+    bool set_poll_thread (SmartPtr<PollThread> thread);
 
     SmartPtr<V4l2Device>& get_capture_device () {
         return _device;
@@ -105,7 +106,7 @@ protected:
 
 protected:
     //virtual functions derived from PollCallback
-    virtual XCamReturn poll_buffer_ready (SmartPtr<V4l2BufferProxy> &buf);
+    virtual XCamReturn poll_buffer_ready (SmartPtr<VideoBuffer> &buf);
     virtual XCamReturn poll_buffer_failed (int64_t timestamp, const char *msg);
     virtual XCamReturn x3a_stats_ready (const SmartPtr<X3aStats> &stats);
     virtual XCamReturn dvs_stats_ready ();

--- a/xcore/fake_poll_thread.cpp
+++ b/xcore/fake_poll_thread.cpp
@@ -1,0 +1,126 @@
+/*
+ * fake_poll_thread.cpp - poll thread for raw image
+ *
+ *  Copyright (c) 2014-2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Jia Meng <jia.meng@intel.com>
+ */
+
+#include "fake_poll_thread.h"
+#include "drm_bo_buffer.h"
+
+#define DEFAULT_FPT_BUF_COUNT 4
+
+namespace XCam {
+
+FakePollThread::FakePollThread (const char *raw_path)
+{
+    if (raw_path) {
+        _raw = fopen (raw_path, "rb");
+        XCAM_LOG_INFO ("FakePollThread created (%s)", raw_path);
+    }
+    XCAM_ASSERT (_raw);
+}
+
+FakePollThread::~FakePollThread ()
+{
+    if (_raw)
+        fclose (_raw);
+}
+
+XCamReturn
+FakePollThread::read_buf (SmartPtr<DrmBoBuffer> &buf)
+{
+    uint8_t *dst = buf->map ();
+    const VideoBufferInfo info = buf->get_video_info ();
+    VideoBufferPlanarInfo planar;
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+
+    for (uint32_t index = 0; index < info.components; index++) {
+        info.get_planar_info(info.format, info.width, info.height, planar, index);
+        uint32_t line_bytes = planar.width * planar.pixel_bytes;
+
+        for (uint32_t i = 0; i < planar.height; i++) {
+            if (fread (dst + info.offsets [index] + i * info.strides [index], 1, line_bytes, _raw) < line_bytes) {
+                if (feof (_raw)) {
+                    fseek (_raw, 0, SEEK_SET);
+                    ret = XCAM_RETURN_BYPASS;
+                } else {
+                    XCAM_LOG_ERROR ("poll_buffer_loop failed to read file");
+                    ret = XCAM_RETURN_ERROR_FILE;
+                }
+                goto done;
+            }
+        }
+    }
+
+done:
+    buf->unmap ();
+    return ret;
+}
+
+XCamReturn
+FakePollThread::poll_buffer_loop ()
+{
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+
+    if (!_buf_pool.ptr () && init_buffer_pool () != XCAM_RETURN_NO_ERROR)
+        return XCAM_RETURN_ERROR_MEM;
+
+    SmartPtr<DrmBoBuffer> buf =
+        _buf_pool->get_buffer (_buf_pool).dynamic_cast_ptr<DrmBoBuffer> ();
+    if (!buf.ptr ()) {
+        XCAM_LOG_WARNING ("FakePollThread get buffer failed");
+        return XCAM_RETURN_ERROR_MEM;
+    }
+
+    ret = read_buf (buf);
+    if (ret == XCAM_RETURN_BYPASS) {
+        ret = read_buf (buf);
+    }
+
+    SmartPtr<VideoBuffer> video_buf = buf;
+    if (ret == XCAM_RETURN_NO_ERROR && _poll_callback)
+        return _poll_callback->poll_buffer_ready (video_buf);
+
+    return ret;
+}
+
+XCamReturn
+FakePollThread::init_buffer_pool ()
+{
+    struct v4l2_format format;
+    if (!_capture_dev.ptr () ||
+            _capture_dev->get_format (format) != XCAM_RETURN_NO_ERROR) {
+        XCAM_LOG_ERROR ("Can't init buffer pool without format");
+        return XCAM_RETURN_ERROR_PARAM;
+    }
+    VideoBufferInfo info;
+    info.init(format.fmt.pix.pixelformat,
+              format.fmt.pix.width,
+              format.fmt.pix.height, 0, 0, 0);
+#if HAVE_LIBDRM
+    SmartPtr<DrmDisplay> drm_disp = DrmDisplay::instance ();
+    _buf_pool = new DrmBoBufferPool (drm_disp);
+    XCAM_ASSERT (_buf_pool.ptr ());
+
+    if (_buf_pool->set_video_info (info) && _buf_pool->reserve (DEFAULT_FPT_BUF_COUNT))
+        return XCAM_RETURN_NO_ERROR;
+#endif
+
+    return XCAM_RETURN_ERROR_MEM;
+}
+
+};

--- a/xcore/fake_poll_thread.h
+++ b/xcore/fake_poll_thread.h
@@ -1,0 +1,58 @@
+/*
+ * fake_poll_thread.h - poll thread for raw image
+ *
+ *  Copyright (c) 2014-2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Jia Meng <jia.meng@intel.com>
+ */
+
+#ifndef XCAM_FAKE_POLL_THREAD_H
+#define XCAM_FAKE_POLL_THREAD_H
+
+#include "poll_thread.h"
+
+namespace XCam {
+
+class DrmBoBufferPool;
+class DrmBoBuffer;
+
+class FakePollThread
+    : public PollThread
+{
+public:
+    explicit FakePollThread (const char *raw_path);
+    ~FakePollThread ();
+
+protected:
+    virtual XCamReturn poll_buffer_loop ();
+
+private:
+    XCAM_DEAD_COPY (FakePollThread);
+
+    virtual XCamReturn init_3a_stats_pool () {
+        return XCAM_RETURN_ERROR_UNKNOWN;
+    }
+    XCamReturn init_buffer_pool ();
+    XCamReturn read_buf (SmartPtr<DrmBoBuffer> &buf);
+
+    FILE                        *_raw;
+#if HAVE_LIBDRM
+    SmartPtr<DrmBoBufferPool>    _buf_pool;
+#endif
+};
+
+};
+
+#endif //XCAM_FAKE_POLL_THREAD_H

--- a/xcore/fake_v4l2_device.h
+++ b/xcore/fake_v4l2_device.h
@@ -1,0 +1,73 @@
+/*
+ * fake_v4l2_device.h - fake v4l2 device
+ *
+ *  Copyright (c) 2014-2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Jia Meng <jia.meng@intel.com>
+ */
+
+#ifndef XCAM_FAKE_V4L2_DEVICE_H
+#define XCAM_FAKE_V4L2_DEVICE_H
+
+#include "v4l2_device.h"
+
+namespace XCam {
+
+class FakeV4l2Device
+    : public V4l2Device
+{
+public:
+    FakeV4l2Device ()
+        : V4l2Device ("/dev/null")
+    {}
+
+    int io_control (int cmd, void *arg)
+    {
+        int ret = 0;
+
+        switch (cmd) {
+        case ATOMISP_IOC_G_SENSOR_MODE_DATA: {
+            struct atomisp_sensor_mode_data *sensor_mode_data = (struct atomisp_sensor_mode_data *)arg;
+            sensor_mode_data->coarse_integration_time_min = 1;
+            sensor_mode_data->coarse_integration_time_max_margin = 1;
+            sensor_mode_data->fine_integration_time_min = 0;
+            sensor_mode_data->fine_integration_time_max_margin = 0;
+            sensor_mode_data->fine_integration_time_def = 0;
+            sensor_mode_data->frame_length_lines = 1125;
+            sensor_mode_data->line_length_pck = 1320;
+            sensor_mode_data->read_mode = 0;
+            sensor_mode_data->vt_pix_clk_freq_mhz = 37125000;
+            sensor_mode_data->crop_horizontal_start = 0;
+            sensor_mode_data->crop_vertical_start = 0;
+            sensor_mode_data->crop_horizontal_end = 1920;
+            sensor_mode_data->crop_vertical_end = 1080;
+            sensor_mode_data->output_width = 1920;
+            sensor_mode_data->output_height = 1080;
+            sensor_mode_data->binning_factor_x = 1;
+            sensor_mode_data->binning_factor_y = 1;
+            break;
+        }
+        case VIDIOC_ENUM_FMT:
+            ret = -1;
+            break;
+        default:
+            break;
+        }
+        return ret;
+    }
+};
+
+};
+#endif // XCAM_FAKE_V4L2_DEVICE_H

--- a/xcore/poll_thread.cpp
+++ b/xcore/poll_thread.cpp
@@ -313,10 +313,10 @@ PollThread::poll_buffer_loop ()
     XCAM_ASSERT (buf.ptr());
     XCAM_ASSERT (_poll_callback);
 
-    SmartPtr<V4l2BufferProxy> buf_proxy = new V4l2BufferProxy (buf, _capture_dev);
+    SmartPtr<VideoBuffer> video_buf = new V4l2BufferProxy (buf, _capture_dev);
 
     if (_poll_callback)
-        return _poll_callback->poll_buffer_ready (buf_proxy);
+        return _poll_callback->poll_buffer_ready (video_buf);
 
     return ret;
 }

--- a/xcore/poll_thread.h
+++ b/xcore/poll_thread.h
@@ -39,7 +39,7 @@ class PollCallback
 public:
     PollCallback () {}
     virtual ~PollCallback() {}
-    virtual XCamReturn poll_buffer_ready (SmartPtr<V4l2BufferProxy> &buf) = 0;
+    virtual XCamReturn poll_buffer_ready (SmartPtr<VideoBuffer> &buf) = 0;
     virtual XCamReturn poll_buffer_failed (int64_t timestamp, const char *msg) = 0;
 
 private:
@@ -57,9 +57,10 @@ class PollThread
 {
     friend class EventPollThread;
     friend class CapturePollThread;
+    friend class FakePollThread;
 public:
     explicit PollThread ();
-    ~PollThread ();
+    virtual ~PollThread ();
 
     bool set_capture_device (SmartPtr<V4l2Device> &dev);
     bool set_event_device (SmartPtr<V4l2SubDevice> &sub_dev);
@@ -72,13 +73,13 @@ public:
 
 protected:
     XCamReturn poll_subdev_event_loop ();
-    XCamReturn poll_buffer_loop ();
+    virtual XCamReturn poll_buffer_loop ();
 
     XCamReturn handle_events (struct v4l2_event &event);
     XCamReturn handle_3a_stats_event (struct v4l2_event &event);
 
 private:
-    XCamReturn init_3a_stats_pool ();
+    virtual XCamReturn init_3a_stats_pool ();
     XCamReturn capture_3a_stats (SmartPtr<X3aStats> &stats);
 
 

--- a/xcore/v4l2_device.h
+++ b/xcore/v4l2_device.h
@@ -105,7 +105,7 @@ public:
     XCamReturn queue_buffer (SmartPtr<V4l2Buffer> &buf);
 
     // use as less as possible
-    int io_control (int cmd, void *arg);
+    virtual int io_control (int cmd, void *arg);
 
 protected:
 


### PR DESCRIPTION
 * FakePollThead reads from specified raw image iteratively
 * FakeV4l2Device is an auxiliry class to mimic /dev/videox
 * add property path-raw to xcamsrc
 * add command option "-r raw_input" to test-device-manager
 * test commands:
   * gst-launch-1.0 xcamsrc io-mode=4 sensor-id=0 enable-3a=true imageprocessor=1 analyzer=2 path-raw="ba10.raw" input-format="BA10" ! video/x-raw,format=NV12,width=1920,height=1080,framerate=25/1 ! fakesink
   * ./test-device-manager -f BA10 -m dma -c -d still -p -a dynamic -r ba10.raw