### PR TITLE
bayer-pipe change to RGB planar output

### DIFF
--- a/cl_kernel/kernel_bayer_pipe.cl
+++ b/cl_kernel/kernel_bayer_pipe.cl
@@ -9,32 +9,29 @@
  *   stats_output: 3a stats output
  */
 
-#define GRID_X_SIZE 2
-#define GRID_Y_SIZE 2
 
-#define SHARED_PIXEL_WIDTH 16
-#define SHARED_PIXEL_HEIGHT 16
-#define SHARED_PIXEL_X_OFFSET 2
-#define SHARED_PIXEL_Y_OFFSET 2
-#define SHARED_PIXEL_X_SIZE  (SHARED_PIXEL_WIDTH + SHARED_PIXEL_X_OFFSET * 2)
-#define SHARED_PIXEL_Y_SIZE  (SHARED_PIXEL_HEIGHT + SHARED_PIXEL_Y_OFFSET * 2)
+#define WORKGROUP_PIXEL_WIDTH 16
+#define WORKGROUP_PIXEL_HEIGHT 16
 
-#define SHARED_GRID_WIDTH (SHARED_PIXEL_WIDTH/GRID_X_SIZE)
-#define SHARED_GRID_HEIGHT (SHARED_PIXEL_HEIGHT/GRID_Y_SIZE)
-#define SHARED_GRID_X_OFFSET (SHARED_PIXEL_X_OFFSET/GRID_X_SIZE)
-#define SHARED_GRID_Y_OFFSET (SHARED_PIXEL_Y_OFFSET/GRID_Y_SIZE)
-#define SHARED_GRID_X_SIZE (SHARED_PIXEL_X_SIZE/GRID_X_SIZE)
-#define SHARED_GRID_Y_SIZE (SHARED_PIXEL_Y_SIZE/GRID_Y_SIZE)
+#define DEMOSAIC_X_CELL_PER_WORKITEM 2
 
-#define WORK_ITEM_X_SIZE GRID_X_SIZE
-#define WORK_ITEM_Y_SIZE GRID_Y_SIZE
+#define PIXEL_PER_CELL 2
 
-#define STATS_3A_GRID_SIZE (16/GRID_X_SIZE)
+#define SLM_CELL_X_OFFSET 1
+#define SLM_CELL_Y_OFFSET 1
 
-#define X 0
-#define Y 1
-#define Z 2
-#define W 3
+// 8x8
+#define SLM_CELL_X_VALID_SIZE (WORKGROUP_PIXEL_WIDTH/PIXEL_PER_CELL)
+#define SLM_CELL_Y_VALID_SIZE (WORKGROUP_PIXEL_HEIGHT/PIXEL_PER_CELL)
+
+// 10x10
+#define SLM_CELL_X_SIZE (SLM_CELL_X_VALID_SIZE + SLM_CELL_X_OFFSET * 2)
+#define SLM_CELL_Y_SIZE (SLM_CELL_Y_VALID_SIZE + SLM_CELL_Y_OFFSET * 2)
+
+#define SLM_PIXEL_X_OFFSET (SLM_CELL_X_OFFSET * PIXEL_PER_CELL)
+#define SLM_PIXEL_Y_OFFSET (SLM_CELL_Y_OFFSET * PIXEL_PER_CELL)
+
+#define STATS_3A_GRID_SIZE (16/PIXEL_PER_CELL)
 
 typedef struct  {
     float  level_gr;  /* Black level for GR pixels */
@@ -95,32 +92,33 @@ inline void gamma_correct(float4 *in_out, __global float *table)
 
 inline int get_shared_pos_x (int i)
 {
-    return i % SHARED_GRID_X_SIZE;
+    return i % SLM_CELL_X_SIZE;
 }
 
 inline int get_shared_pos_y (int i)
 {
-    return i / SHARED_GRID_X_SIZE;
+    return i / SLM_CELL_X_SIZE;
 }
 
 inline int shared_pos (int x, int y)
 {
-    return mad24(y, SHARED_GRID_X_SIZE, x);
+    return mad24(y, SLM_CELL_X_SIZE, x);
 }
 
 /* BA10=> GRBG  */
-inline float4 simple_calculate (
+inline void simple_calculate (
     __local float *px, __local float *py, __local float *pz, __local float *pw,
-    int index, __read_only image2d_t input, sampler_t sampler, int x_start, int y_start,
+    int index, __read_only image2d_t input, int x_start, int y_start,
     __local float4 *stats_cache,
     CLBLCConfig *blc_config,
     CLWBConfig *wb_config,
     uint enable_gamma,
     __global float *gamma_table)
 {
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
     float4 data;
-    int x0 = get_shared_pos_x (index) * WORK_ITEM_X_SIZE + x_start;
-    int y0 = get_shared_pos_y (index) * WORK_ITEM_Y_SIZE + y_start;
+    int x0 = get_shared_pos_x (index) * PIXEL_PER_CELL + x_start;
+    int y0 = get_shared_pos_y (index) * PIXEL_PER_CELL + y_start;
     //Gr
     data.x = read_imagef (input, sampler, (int2)(x0, y0)).x;
     //R
@@ -149,297 +147,201 @@ inline float4 simple_calculate (
 #define MIN_DELTA_COFF 1.0f
 #define DEFAULT_DELTA_COFF 4.0f
 
-inline float delta_coff (float delta)
+inline float2 delta_coff (float2 delta)
 {
-    float coff = MAX_DELTA_COFF - 20.0f * fabs(delta);
+    float2 coff = MAX_DELTA_COFF - 20.0f * fabs(delta);
     return fmax (1.0f, coff);
 }
 
-inline float4
-demosaic_x0y0_gr (__local float *in_x, __local float *in_y, __local float *in_z, __local float *in_w, int x, int y)
+inline float2 dot_denoise (float2 value, float2 in1, float2 in2, float2 in3, float2 in4)
 {
-    float4 out_data;
-    out_data.x = (in_y[shared_pos(x - 1, y)] + in_y[shared_pos(x, y)]) * 0.5f;
-    out_data.y = (in_x[shared_pos(x, y)] * 4.0f + in_w[shared_pos(x - 1, y - 1)] +
-                  in_w[shared_pos(x, y - 1)] + in_w[shared_pos(x - 1, y)] + in_w[shared_pos(x, y)]) * 0.125f;
-    out_data.z = (in_z[shared_pos(x, y - 1)] + in_z[shared_pos(x, y)]) * 0.5f;
-    return out_data;
+    float2 coff0, coff1, coff2, coff3, coff4, coff5;
+    coff0 = DEFAULT_DELTA_COFF;
+    coff1 = delta_coff (in1 - value);
+    coff2 = delta_coff (in2 - value);
+    coff3 = delta_coff (in3 - value);
+    coff4 = delta_coff (in4 - value);
+    return  (in1 * coff1 + in2 * coff2 + in3 * coff3 + in4 * coff4 + value * coff0) /
+            (coff0 + coff1 + coff2 + coff3 + coff4);
 }
 
-inline float4
-demosaic_x1y0_r (__local float *in_x, __local float *in_y, __local float *in_z, __local float *in_w, int x, int y)
+void demosaic_2_cell (
+    __local float *x_data_in, __local float *y_data_in, __local float *z_data_in, __local float *w_data_in,
+    int in_x, int in_y,
+    __write_only image2d_t out, uint out_height, int out_x, int out_y)
 {
     float4 out_data;
-    out_data.x = in_y[shared_pos(x, y)];
-    out_data.y = (in_x[shared_pos(x, y)] + in_w[shared_pos(x, y)] +
-                  in_x[shared_pos(x + 1, y)] + in_w[shared_pos(x, y - 1)]) * 0.25f;
-    out_data.z = (in_z[shared_pos(x, y - 1)] + in_z[shared_pos(x + 1, y - 1)] +
-                  in_z[shared_pos(x, y)] + in_z[shared_pos(x + 1, y)]) * 0.25f;
-    return out_data;
+    float2 value;
+    int index;
+    {
+        float3 R_y[2];
+        index = shared_pos (in_x - 1, in_y);
+        R_y[0] = *(__local float3*)(y_data_in + index);
+        index = shared_pos (in_x - 1, in_y + 1);
+        R_y[1] = *(__local float3*)(y_data_in + index);
+
+        out_data.s02 = (R_y[0].s01 + R_y[0].s12) * 0.5f;
+        out_data.s13 = R_y[0].s12;
+        write_imagef (out, (int2)(out_x / 4, out_y), out_data);
+
+        out_data.s02 = (R_y[0].s01 + R_y[0].s12 + R_y[1].s01 + R_y[1].s12) * 0.25f;
+        out_data.s13 = (R_y[0].s12 + R_y[1].s12) * 0.5f;
+        write_imagef (out, (int2)(out_x / 4, out_y + 1), out_data);
+    }
+
+    {
+        float3 B_z[2];
+        index = shared_pos (in_x, in_y - 1);
+        B_z[0] = *(__local float3*)(z_data_in + index);
+        index = shared_pos (in_x, in_y);
+        B_z[1] = *(__local float3*)(z_data_in + index);
+
+        out_data.s02 = (B_z[0].s01 + B_z[1].s01) * 0.5f;
+        out_data.s13 = (B_z[0].s01 + B_z[0].s12 + B_z[1].s01 + B_z[1].s12) * 0.25f;
+        write_imagef (out, (int2)(out_x / 4, out_y + out_height * 2), out_data);
+
+        out_data.s02 = B_z[1].s01;
+        out_data.s13 = (B_z[1].s01 + B_z[1].s12) * 0.5f;
+        write_imagef (out, (int2)(out_x / 4, out_y + 1 + out_height * 2), out_data);
+    }
+
+    {
+        float3 Gr_x[2], Gb_w[2];
+        index = shared_pos (in_x, in_y);
+        Gr_x[0] = *(__local float3*)(x_data_in + index);
+        index = shared_pos (in_x, in_y + 1);
+        Gr_x[1] = *(__local float3*)(x_data_in + index);
+
+        index = shared_pos (in_x - 1, in_y - 1);
+        Gb_w[0] = *(__local float3*)(w_data_in + index);
+        index = shared_pos (in_x - 1, in_y);
+        Gb_w[1] = *(__local float3*)(w_data_in + index);
+
+        out_data.s02 = (Gr_x[0].s01 * 4.0f + Gb_w[0].s01 +
+                        Gb_w[0].s12 + Gb_w[1].s01 + Gb_w[1].s12) * 0.125f;
+        out_data.s13 = (Gr_x[0].s01 + Gr_x[0].s12 + Gb_w[0].s12 + Gb_w[1].s12) * 0.25f;
+        write_imagef (out, (int2)(out_x / 4, out_y + out_height), out_data);
+
+        out_data.s02 = (Gr_x[0].s01 + Gr_x[1].s01 + Gb_w[1].s01 + Gb_w[1].s12) * 0.25f;
+
+        out_data.s13 = (Gb_w[1].s12 * 4.0f + Gr_x[0].s01 +
+                        Gr_x[0].s12 + Gr_x[1].s01 + Gr_x[1].s12) * 0.125f;
+        write_imagef (out, (int2)(out_x / 4, out_y + 1 + out_height), out_data);
+    }
 }
 
-inline float4
-demosaic_x0y1_b (__local float *in_x, __local float *in_y, __local float *in_z, __local float *in_w, int x, int y)
+void demosaic_denoise_2_cell (
+    __local float *x_data_in, __local float *y_data_in, __local float *z_data_in, __local float *w_data_in,
+    int in_x, int in_y,
+    __write_only image2d_t out, uint out_height, int out_x, int out_y)
 {
-    float4 out_data;
-    out_data.x = (in_y[shared_pos(x - 1, y)] + in_y[shared_pos(x, y)] +
-                  in_y[shared_pos(x - 1, y + 1)] + in_y[shared_pos(x, y + 1)]) * 0.25f;
-    out_data.y = (in_x[shared_pos(x, y)] + in_w[shared_pos(x, y)] +
-                  in_w[shared_pos(x - 1, y)] + in_x[shared_pos(x, y + 1)]) * 0.25f;
-    out_data.z = in_z[shared_pos(x, y)];
-    return out_data;
-}
+    float4 out_data[2];
+    float2 value;
+    int index;
 
-inline float4
-demosaic_x1y1_gb (__local float *in_x, __local float *in_y, __local float *in_z, __local float *in_w, int x, int y)
-{
-    float4 out_data;
-    out_data.x = (in_y[shared_pos(x, y)] + in_y[shared_pos(x, y + 1)]) * 0.5f;
-    out_data.y = (in_w[shared_pos(x, y)] * 4.0f + in_x[shared_pos(x, y)] +
-                  in_x[shared_pos(x + 1, y)] + in_x[shared_pos(x, y + 1)] + in_x[shared_pos(x + 1, y + 1)]) * 0.125f;
-    out_data.z = (in_z[shared_pos(x, y)] + in_z[shared_pos(x + 1, y)]) * 0.5f;
-    return out_data;
-}
+    ////////////////////////////////R//////////////////////////////////////////
+    {
+        float4 R_y[3];
+        index = shared_pos (in_x - 1, in_y - 1);
+        R_y[0] = *(__local float4*)(y_data_in + index);
+        index = shared_pos (in_x - 1, in_y);
+        R_y[1] = *(__local float4*)(y_data_in + index);
+        index = shared_pos (in_x - 1, in_y + 1);
+        R_y[2] = *(__local float4*)(y_data_in + index);
 
-inline float4
-demosaic_denoise_x0y0_gr (__local float *in_x, __local float *in_y, __local float *in_z, __local float *in_w, int x, int y)
-{
-    float4 out_data;
-    float value;
-    float coff[5];
+        value = (R_y[1].s01 + R_y[1].s12) * 0.5f;
+        out_data[0].s02 = dot_denoise (value, R_y[0].s01, R_y[0].s12, R_y[2].s01, R_y[2].s12);
 
-    coff[0] = DEFAULT_DELTA_COFF;
+        value = R_y[1].s12;
+        out_data[0].s13 = dot_denoise (value, R_y[0].s12, R_y[1].s01, R_y[1].s23, R_y[2].s12);
 
-    value = (in_y[shared_pos(x - 1, y)] + in_y[shared_pos(x, y)]) * 0.5f;
-    coff[1] = delta_coff(in_y[shared_pos(x - 1, y - 1)] - value);
-    coff[2] = delta_coff(in_y[shared_pos(x, y - 1)] - value);
-    coff[3] = delta_coff(in_y[shared_pos(x - 1, y + 1)] - value);
-    coff[4] = delta_coff(in_y[shared_pos(x, y + 1)] - value);
-    out_data.x = (in_y[shared_pos(x - 1, y - 1)] * coff[1] +
-                  in_y[shared_pos(x, y - 1)] * coff[2] +
-                  in_y[shared_pos(x - 1, y + 1)] * coff[3] +
-                  in_y[shared_pos(x, y + 1)] * coff[4] +
-                  value * coff[0]) /
-                 (coff[0] + coff[1] + coff[2] + coff[3] + coff[4]);
+        value = (R_y[1].s01 + R_y[1].s12 +
+                 R_y[2].s01 + R_y[2].s12) * 0.25f;
+        out_data[1].s02 = dot_denoise (value, R_y[1].s01, R_y[1].s12, R_y[2].s01, R_y[2].s12);
 
+        value = (R_y[1].s12 + R_y[2].s12) * 0.5f;
+        out_data[1].s13 = dot_denoise (value, R_y[1].s01, R_y[1].s23, R_y[2].s01, R_y[2].s23);
 
-    value = (in_x[shared_pos(x, y)] * 4.0f + in_w[shared_pos(x - 1, y - 1)] +
-             in_w[shared_pos(x, y - 1)] + in_w[shared_pos(x - 1, y)] + in_w[shared_pos(x, y)]) * 0.125f;
-    coff[1] = delta_coff(in_x[shared_pos(x, y - 1)] - value);
-    coff[2] = delta_coff(in_x[shared_pos(x - 1, y)] - value);
-    coff[3] = delta_coff(in_x[shared_pos(x + 1, y)] - value);
-    coff[4] = delta_coff(in_x[shared_pos(x, y + 1)] - value);
-    out_data.y = (in_x[shared_pos(x, y - 1)] * coff[1] +
-                  in_x[shared_pos(x - 1, y)] * coff[2] +
-                  in_x[shared_pos(x + 1, y)] * coff[3] +
-                  in_x[shared_pos(x, y + 1)] * coff[4] +
-                  value * coff[0]) /
-                 (coff[0] + coff[1] + coff[2] + coff[3] + coff[4]);
+        write_imagef (out, (int2)(out_x / 4, out_y), out_data[0]);
+        write_imagef (out, (int2)(out_x / 4, out_y + 1), out_data[1]);
 
-    value = (in_z[shared_pos(x, y - 1)] + in_z[shared_pos(x, y)]) * 0.5f;
-    coff[1] = delta_coff(in_z[shared_pos(x - 1, y - 1)] - value);
-    coff[2] = delta_coff(in_z[shared_pos(x + 1, y - 1)] - value);
-    coff[3] = delta_coff(in_z[shared_pos(x - 1, y)] - value);
-    coff[4] = delta_coff(in_z[shared_pos(x + 1, y)] - value);
-    out_data.z = (in_z[shared_pos(x - 1, y - 1)] * coff[1] +
-                  in_z[shared_pos(x + 1, y - 1)] * coff[2] +
-                  in_z[shared_pos(x - 1, y)] * coff[3] +
-                  in_z[shared_pos(x + 1, y)] * coff[4] +
-                  value * coff[0]) /
-                 (coff[0] + coff[1] + coff[2] + coff[3] + coff[4]);
-    out_data.w = 0.0f;
+    }
 
-    return out_data;
-}
+    ////////////////////////////////B//////////////////////////////////////////
+    {
+        float4 B_z[3];
+        index = shared_pos (in_x - 1, in_y - 1);
+        B_z[0] = *(__local float4*)(z_data_in + index);
+        index = shared_pos (in_x - 1, in_y);
+        B_z[1] = *(__local float4*)(z_data_in + index);
+        index = shared_pos (in_x - 1, in_y + 1);
+        B_z[2] = *(__local float4*)(z_data_in + index);
 
-inline float4
-demosaic_denoise_x1y0_r (__local float *in_x, __local float *in_y, __local float *in_z, __local float *in_w, int x, int y)
-{
-    float4 out_data;
-    float value;
-    float coff[5];
+        value = (B_z[0].s12 + B_z[1].s12) * 0.5f;
+        out_data[0].s02 = dot_denoise (value, B_z[0].s01, B_z[0].s23, B_z[1].s01, B_z[1].s23);
 
-    coff[0] = DEFAULT_DELTA_COFF;
+        value = (B_z[0].s12 + B_z[0].s23 +
+                 B_z[1].s12 + B_z[1].s23) * 0.25f;
+        out_data[0].s13 = dot_denoise (value, B_z[0].s12, B_z[0].s23, B_z[1].s12, B_z[1].s23);
 
-    value = in_y[shared_pos(x, y)];
-    coff[1] = delta_coff(in_y[shared_pos(x, y - 1)] - value);
-    coff[2] = delta_coff(in_y[shared_pos(x - 1, y)] - value);
-    coff[3] = delta_coff(in_y[shared_pos(x + 1, y)] - value);
-    coff[4] = delta_coff(in_y[shared_pos(x, y + 1)] - value);
-    out_data.x = (in_y[shared_pos(x, y - 1)] * coff[1] +
-                  in_y[shared_pos(x - 1, y)] * coff[2] +
-                  in_y[shared_pos(x + 1, y)] * coff[3] +
-                  in_y[shared_pos(x, y + 1)] * coff[4] +
-                  value * coff[0]) /
-                 (coff[0] + coff[1] + coff[2] + coff[3] + coff[4]);
+        value = B_z[1].s12;
+        out_data[1].s02 = dot_denoise (value, B_z[0].s12, B_z[1].s01, B_z[1].s23, B_z[2].s12);
 
-    value = (in_x[shared_pos(x, y)] + in_w[shared_pos(x, y)] +
-             in_x[shared_pos(x + 1, y)] + in_w[shared_pos(x, y - 1)]) * 0.25f;
-    coff[1] = delta_coff(in_x[shared_pos(x, y)] - value);
-    coff[2] = delta_coff(in_w[shared_pos(x, y)] - value);
-    coff[3] = delta_coff(in_x[shared_pos(x + 1, y)] - value);
-    coff[4] = delta_coff(in_w[shared_pos(x, y - 1)] - value);
-    out_data.y = (in_x[shared_pos(x, y)] * coff[1] +
-                  in_w[shared_pos(x, y)] * coff[2] +
-                  in_x[shared_pos(x + 1, y)] * coff[3] +
-                  in_w[shared_pos(x, y - 1)] * coff[4] +
-                  value * coff[0]) /
-                 (coff[0] + coff[1] + coff[2] + coff[3] + coff[4]);
+        value = (B_z[1].s12 + B_z[1].s23) * 0.5f;
+        out_data[1].s13 = dot_denoise (value, B_z[0].s12, B_z[0].s23, B_z[2].s12, B_z[2].s23);
 
-    value = (in_z[shared_pos(x, y - 1)] + in_z[shared_pos(x + 1, y - 1)] +
-             in_z[shared_pos(x, y)] + in_z[shared_pos(x + 1, y)]) * 0.25f;
+        write_imagef (out, (int2)(out_x / 4, out_y + out_height * 2), out_data[0]);
+        write_imagef (out, (int2)(out_x / 4, out_y + 1 + out_height * 2), out_data[1]);
+    }
 
-    coff[1] = delta_coff(in_z[shared_pos(x, y - 1)] - value);
-    coff[2] = delta_coff(in_z[shared_pos(x + 1, y - 1)] - value);
-    coff[3] = delta_coff(in_z[shared_pos(x, y)] - value);
-    coff[4] = delta_coff(in_z[shared_pos(x + 1, y)] - value);
-    out_data.z = (in_z[shared_pos(x, y - 1)] * coff[1] +
-                  in_z[shared_pos(x + 1, y - 1)] * coff[2] +
-                  in_z[shared_pos(x, y)] * coff[3] +
-                  in_z[shared_pos(x + 1, y)] * coff[4] +
-                  value * coff[0]) /
-                 (coff[0] + coff[1] + coff[2] + coff[3] + coff[4]);
-    out_data.w = 0.0f;
+    ///////////////////////////////////////G///////////////////////////////////
+    {
+        float3 Gr_x[2], Gb_w[2];
+        index = shared_pos (in_x - 1, in_y - 1);
+        Gb_w[0] = *(__local float3*)(w_data_in + index);
+        index = shared_pos (in_x - 1, in_y);
+        Gb_w[1] = *(__local float3*)(w_data_in + index);
 
-    return out_data;
-}
+        index = shared_pos (in_x, in_y);
+        Gr_x[0] = *(__local float3*)(x_data_in + index);
+        index = shared_pos (in_x, in_y + 1);
+        Gr_x[1] = *(__local float3*)(x_data_in + index);
 
-inline float4
-demosaic_denoise_x0y1_b (__local float *in_x, __local float *in_y, __local float *in_z, __local float *in_w, int x, int y)
-{
-    float4 out_data;
-    float value;
-    float coff[5];
+        value = (Gr_x[0].s01 * 4.0f + Gb_w[0].s01 +
+                 Gb_w[0].s12 + Gb_w[1].s01 + Gb_w[1].s12) * 0.125f;
+        out_data[0].s02 = dot_denoise (value, Gb_w[0].s01, Gb_w[0].s12, Gb_w[1].s01, Gb_w[1].s12);
+        value = (Gr_x[0].s01 + Gr_x[0].s12 +
+                 Gb_w[0].s12 + Gb_w[1].s12) * 0.25f;
+        out_data[0].s13 = dot_denoise(value, Gr_x[0].s01, Gr_x[0].s12, Gb_w[0].s12, Gb_w[1].s12);
 
-    coff[0] = DEFAULT_DELTA_COFF;
+        value = (Gr_x[0].s01 + Gr_x[1].s01 +
+                 Gb_w[1].s01 + Gb_w[1].s12) * 0.25f;
+        out_data[1].s02 = dot_denoise (value, Gr_x[0].s01, Gr_x[1].s01, Gb_w[1].s01, Gb_w[1].s12);
 
-    value = (in_y[shared_pos(x - 1, y)] + in_y[shared_pos(x, y)] +
-             in_y[shared_pos(x - 1, y + 1)] + in_y[shared_pos(x, y + 1)]) * 0.25f;
-    coff[1] = delta_coff(in_y[shared_pos(x - 1, y)] - value);
-    coff[2] = delta_coff(in_y[shared_pos(x, y)] - value);
-    coff[3] = delta_coff(in_y[shared_pos(x - 1, y + 1)] - value);
-    coff[4] = delta_coff(in_y[shared_pos(x, y + 1)] - value);
-    out_data.x = (in_y[shared_pos(x - 1, y)] * coff[1] +
-                  in_y[shared_pos(x, y)] * coff[2] +
-                  in_y[shared_pos(x - 1, y + 1)] * coff[3] +
-                  in_y[shared_pos(x, y + 1)] * coff[4] +
-                  value * coff[0]) /
-                 (coff[0] + coff[1] + coff[2] + coff[3] + coff[4]);
+        value = (Gb_w[1].s12 * 4.0f + Gr_x[0].s01 +
+                 Gr_x[0].s12 + Gr_x[1].s01 + Gr_x[1].s12) * 0.125f;
+        out_data[1].s13 = dot_denoise (value, Gr_x[0].s01, Gr_x[0].s12, Gr_x[1].s01, Gr_x[1].s12);
 
-
-    value = (in_x[shared_pos(x, y)] + in_w[shared_pos(x, y)] +
-             in_w[shared_pos(x - 1, y)] + in_x[shared_pos(x, y + 1)]) * 0.25f;
-    coff[1] = delta_coff(in_x[shared_pos(x, y)] - value);
-    coff[2] = delta_coff(in_w[shared_pos(x, y)] - value);
-    coff[3] = delta_coff(in_w[shared_pos(x - 1, y)] - value);
-    coff[4] = delta_coff(in_x[shared_pos(x, y + 1)] - value);
-    out_data.y = (in_x[shared_pos(x, y)] * coff[1] +
-                  in_w[shared_pos(x, y)] * coff[2] +
-                  in_w[shared_pos(x - 1, y + 1)] * coff[3] +
-                  in_x[shared_pos(x, y + 1)] * coff[4] +
-                  value * coff[0]) /
-                 (coff[0] + coff[1] + coff[2] + coff[3] + coff[4]);
-
-    value = in_z[shared_pos(x, y)];
-    coff[1] = delta_coff(in_z[shared_pos(x, y - 1)] - value);
-    coff[2] = delta_coff(in_z[shared_pos(x - 1, y)] - value);
-    coff[3] = delta_coff(in_z[shared_pos(x + 1, y)] - value);
-    coff[4] = delta_coff(in_z[shared_pos(x, y + 1)] - value);
-    out_data.z = (in_z[shared_pos(x, y - 1)] * coff[1] +
-                  in_z[shared_pos(x - 1, y)] * coff[2] +
-                  in_z[shared_pos(x + 1, y)] * coff[3] +
-                  in_z[shared_pos(x, y + 1)] * coff[4] +
-                  value * coff[0]) /
-                 (coff[0] + coff[1] + coff[2] + coff[3] + coff[4]);
-    out_data.w = 0.0f;
-    return out_data;
-};
-
-inline float4
-demosaic_denoise_x1y1_gb (__local float *in_x, __local float *in_y, __local float *in_z, __local float *in_w, int x, int y)
-{
-    float4 out_data;
-    float value;
-    float coff[5];
-
-    coff[0] = DEFAULT_DELTA_COFF;
-
-    value = (in_y[shared_pos(x, y)] + in_y[shared_pos(x, y + 1)]) * 0.5f;
-    coff[1] = delta_coff(in_y[shared_pos(x - 1, y)] - value);
-    coff[2] = delta_coff(in_y[shared_pos(x + 1, y)] - value);
-    coff[3] = delta_coff(in_y[shared_pos(x - 1, y + 1)] - value);
-    coff[4] = delta_coff(in_y[shared_pos(x + 1, y + 1)] - value);
-    out_data.x = (in_y[shared_pos(x - 1, y)] * coff[1] +
-                  in_y[shared_pos(x + 1, y)] * coff[2] +
-                  in_y[shared_pos(x - 1, y + 1)] * coff[3] +
-                  in_y[shared_pos(x + 1, y + 1)] * coff[4] +
-                  value * coff[0]) /
-                 (coff[0] + coff[1] + coff[2] + coff[3] + coff[4]);
-
-    value = (in_w[shared_pos(x, y)] * 4.0f + in_x[shared_pos(x, y)] +
-             in_x[shared_pos(x + 1, y)] + in_x[shared_pos(x, y + 1)] + in_x[shared_pos(x + 1, y + 1)]) * 0.125f;
-    coff[1] = delta_coff(in_w[shared_pos(x, y - 1)] - value);
-    coff[2] = delta_coff(in_w[shared_pos(x - 1, y)] - value);
-    coff[3] = delta_coff(in_w[shared_pos(x + 1, y)] - value);
-    coff[4] = delta_coff(in_w[shared_pos(x, y + 1)] - value);
-    out_data.y = (in_w[shared_pos(x, y - 1)] * coff[1] +
-                  in_w[shared_pos(x - 1, y)] * coff[2] +
-                  in_w[shared_pos(x + 1, y)] * coff[3] +
-                  in_w[shared_pos(x, y + 1)] * coff[4] +
-                  value * coff[0]) /
-                 (coff[0] + coff[1] + coff[2] + coff[3] + coff[4]);
-    value = (in_z[shared_pos(x, y)] + in_z[shared_pos(x + 1, y)]) * 0.5f;
-    coff[1] = delta_coff(in_z[shared_pos(x, y - 1)] - value);
-    coff[2] = delta_coff(in_z[shared_pos(x + 1, y - 1)] - value);
-    coff[3] = delta_coff(in_z[shared_pos(x, y + 1)] - value);
-    coff[4] = delta_coff(in_z[shared_pos(x + 1, y + 1)] - value);
-    out_data.z = (in_z[shared_pos(x, y - 1)] * coff[1] +
-                  in_z[shared_pos(x + 1, y - 1)] * coff[2] +
-                  in_z[shared_pos(x, y + 1)] * coff[3] +
-                  in_z[shared_pos(x + 1, y + 1)] * coff[4] +
-                  value * coff[0]) /
-                 (coff[0] + coff[1] + coff[2] + coff[3] + coff[4]);
-    out_data.w = 0.0f;
-
-    return out_data;
+        write_imagef (out, (int2)(out_x / 4, out_y + out_height), out_data[0]);
+        write_imagef (out, (int2)(out_x / 4, out_y + 1 + out_height), out_data[1]);
+    }
 }
 
 void shared_demosaic (
     __local float *x_data_in, __local float *y_data_in, __local float *z_data_in, __local float *w_data_in,
     int in_x, int in_y,
-    __write_only image2d_t out, int out_x, int out_y,
+    __write_only image2d_t out, uint output_height, int out_x, int out_y,
     uint has_denoise)
 {
-    float4 out_data;
-
     if (has_denoise) {
-        out_data = demosaic_denoise_x0y0_gr (x_data_in, y_data_in, z_data_in, w_data_in, in_x, in_y);
-        write_imagef(out, (int2)(out_x, out_y), out_data);
-
-
-        out_data = demosaic_denoise_x1y0_r (x_data_in, y_data_in, z_data_in, w_data_in, in_x, in_y);
-        write_imagef(out, (int2)(out_x + 1, out_y), out_data);
-
-        out_data = demosaic_denoise_x0y1_b (x_data_in, y_data_in, z_data_in, w_data_in, in_x, in_y);
-        write_imagef(out, (int2)(out_x, out_y + 1), out_data);
-
-        out_data = demosaic_denoise_x1y1_gb (x_data_in, y_data_in, z_data_in, w_data_in, in_x, in_y);
-        write_imagef(out, (int2)(out_x + 1, out_y + 1), out_data);
+        demosaic_denoise_2_cell (
+            x_data_in, y_data_in, z_data_in, w_data_in, in_x, in_y,
+            out, output_height, out_x, out_y);
     } else {
-        out_data = demosaic_x0y0_gr (x_data_in, y_data_in, z_data_in, w_data_in, in_x, in_y);
-        write_imagef(out, (int2)(out_x, out_y), out_data);
-
-
-        out_data = demosaic_x1y0_r (x_data_in, y_data_in, z_data_in, w_data_in, in_x, in_y);
-        write_imagef(out, (int2)(out_x + 1, out_y), out_data);
-
-        out_data = demosaic_x0y1_b (x_data_in, y_data_in, z_data_in, w_data_in, in_x, in_y);
-        write_imagef(out, (int2)(out_x, out_y + 1), out_data);
-
-        out_data = demosaic_x1y1_gb (x_data_in, y_data_in, z_data_in, w_data_in, in_x, in_y);
-        write_imagef(out, (int2)(out_x + 1, out_y + 1), out_data);
+        demosaic_2_cell (
+            x_data_in, y_data_in, z_data_in, w_data_in, in_x, in_y,
+            out, output_height, out_x, out_y);
     }
-
 }
 
 inline void stats_3a_calculate (
@@ -458,13 +360,13 @@ inline void stats_3a_calculate (
 
     for (; count > 0; count /= 4) {
         if ((l_id_x % STATS_3A_GRID_SIZE) + (l_id_y % STATS_3A_GRID_SIZE)* STATS_3A_GRID_SIZE < count) {
-            int index1 = shared_pos (l_id_x + SHARED_GRID_X_OFFSET, l_id_y + SHARED_GRID_Y_OFFSET);
-            int index2 = shared_pos (SHARED_GRID_X_OFFSET + ((l_id_x + count) % STATS_3A_GRID_SIZE),
-                                     SHARED_GRID_Y_OFFSET + l_id_y + (l_id_x + count) / STATS_3A_GRID_SIZE);
-            int index3 = shared_pos (SHARED_GRID_X_OFFSET + ((l_id_x + count * 2) % STATS_3A_GRID_SIZE),
-                                     SHARED_GRID_Y_OFFSET + l_id_y + (l_id_x + count * 2) / STATS_3A_GRID_SIZE);
-            int index4 = shared_pos (SHARED_GRID_X_OFFSET + ((l_id_x + count * 3) % STATS_3A_GRID_SIZE),
-                                     SHARED_GRID_Y_OFFSET + l_id_y + (l_id_x + count * 3) / STATS_3A_GRID_SIZE);
+            int index1 = shared_pos (l_id_x + SLM_CELL_X_OFFSET, l_id_y + SLM_CELL_Y_OFFSET);
+            int index2 = shared_pos (SLM_CELL_X_OFFSET + ((l_id_x + count) % STATS_3A_GRID_SIZE),
+                                     SLM_CELL_Y_OFFSET + l_id_y + (l_id_x + count) / STATS_3A_GRID_SIZE);
+            int index3 = shared_pos (SLM_CELL_X_OFFSET + ((l_id_x + count * 2) % STATS_3A_GRID_SIZE),
+                                     SLM_CELL_Y_OFFSET + l_id_y + (l_id_x + count * 2) / STATS_3A_GRID_SIZE);
+            int index4 = shared_pos (SLM_CELL_X_OFFSET + ((l_id_x + count * 3) % STATS_3A_GRID_SIZE),
+                                     SLM_CELL_Y_OFFSET + l_id_y + (l_id_x + count * 3) / STATS_3A_GRID_SIZE);
             input[index1] = (input[index1] + input[index2] + input[index3] + input[index4]) / 4.0f;
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -473,7 +375,7 @@ inline void stats_3a_calculate (
     if (l_id_x % STATS_3A_GRID_SIZE == 0 && l_id_y % STATS_3A_GRID_SIZE == 0) {
         float4 tmp_data;
         int out_index = mad24(g_id_y / STATS_3A_GRID_SIZE,  g_size_x / STATS_3A_GRID_SIZE, g_id_x / STATS_3A_GRID_SIZE);
-        tmp_data = input[shared_pos (l_id_x + SHARED_GRID_X_OFFSET, l_id_y + SHARED_GRID_Y_OFFSET)];
+        tmp_data = input[shared_pos (l_id_x + SLM_CELL_X_OFFSET, l_id_y + SLM_CELL_Y_OFFSET)];
         stats_output[out_index].avg_gr = convert_uchar_sat(tmp_data.x * 255.0f);
         stats_output[out_index].avg_r = convert_uchar_sat(tmp_data.y * 255.0f);
         stats_output[out_index].avg_b = convert_uchar_sat(tmp_data.z * 255.0f);
@@ -489,6 +391,7 @@ inline void stats_3a_calculate (
 
 __kernel void kernel_bayer_pipe (__read_only image2d_t input,
                                  __write_only image2d_t output,
+                                 uint output_height,
                                  CLBLCConfig blc_config,
                                  CLWBConfig wb_config,
                                  uint has_denoise,
@@ -506,20 +409,19 @@ __kernel void kernel_bayer_pipe (__read_only image2d_t input,
     int l_size_x = get_local_size (0);
     int l_size_y = get_local_size (1);
 
-    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
-
-    __local float p1_x[SHARED_GRID_X_SIZE * SHARED_GRID_Y_SIZE], p1_y[SHARED_GRID_X_SIZE * SHARED_GRID_Y_SIZE], p1_z[SHARED_GRID_X_SIZE * SHARED_GRID_Y_SIZE], p1_w[SHARED_GRID_X_SIZE * SHARED_GRID_Y_SIZE];
-    __local float4 p2[SHARED_GRID_X_SIZE * SHARED_GRID_Y_SIZE];
+    __local float p1_x[SLM_CELL_X_SIZE * SLM_CELL_Y_SIZE], p1_y[SLM_CELL_X_SIZE * SLM_CELL_Y_SIZE], p1_z[SLM_CELL_X_SIZE * SLM_CELL_Y_SIZE], p1_w[SLM_CELL_X_SIZE * SLM_CELL_Y_SIZE];
+    __local float4 p2[SLM_CELL_X_SIZE * SLM_CELL_Y_SIZE];
     __local float4 *stats_cache = p2;
 
     int out_x_start, out_y_start;
-    int x_start = (g_id_x - l_id_x) * WORK_ITEM_X_SIZE - SHARED_PIXEL_X_OFFSET;
-    int y_start = (g_id_y - l_id_y) * WORK_ITEM_Y_SIZE - SHARED_PIXEL_Y_OFFSET;
-    int i = l_id_x + l_id_y * l_size_x;
+    int x_start = get_group_id (0) * WORKGROUP_PIXEL_WIDTH;
+    int y_start = get_group_id (1) * WORKGROUP_PIXEL_HEIGHT;
+    int i = mad24 (l_id_y, l_size_x, l_id_x);
 
-    for (; i < SHARED_GRID_X_SIZE * SHARED_GRID_Y_SIZE; i += l_size_x * l_size_y) {
+    for (; i < SLM_CELL_X_SIZE * SLM_CELL_Y_SIZE; i += l_size_x * l_size_y) {
         simple_calculate (p1_x, p1_y, p1_z, p1_w, i,
-                          input, sampler, x_start, y_start,
+                          input,
+                          x_start - SLM_PIXEL_X_OFFSET, y_start - SLM_PIXEL_Y_OFFSET,
                           stats_cache,
                           &blc_config,
                           &wb_config,
@@ -530,8 +432,15 @@ __kernel void kernel_bayer_pipe (__read_only image2d_t input,
 
     stats_3a_calculate (stats_cache, stats_output, &wb_config);
 
+    i = mad24 (l_id_y, l_size_x, l_id_x);
+    int workitem_x_size = (SLM_CELL_X_VALID_SIZE / DEMOSAIC_X_CELL_PER_WORKITEM);
+    int input_x = (i % workitem_x_size) * DEMOSAIC_X_CELL_PER_WORKITEM;
+    int input_y = i / workitem_x_size;
+
     shared_demosaic (
-        p1_x, p1_y, p1_z, p1_w, l_id_x + SHARED_GRID_X_OFFSET, l_id_y + SHARED_GRID_Y_OFFSET,
-        output, g_id_x * WORK_ITEM_X_SIZE, g_id_y * WORK_ITEM_Y_SIZE, has_denoise);
+        p1_x, p1_y, p1_z, p1_w,
+        input_x + SLM_CELL_X_OFFSET, input_y + SLM_CELL_Y_OFFSET,
+        output, output_height,
+        mad24 (input_x, PIXEL_PER_CELL, x_start), mad24 (input_y, PIXEL_PER_CELL, y_start), has_denoise);
 }
 

--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -175,6 +175,11 @@ MainDeviceManager::handle_buffer (const SmartPtr<VideoBuffer> &buf)
     case XCAM_PIX_FMT_RGBA64:
         size = XCAM_ALIGN_UP(frame_info.width, 2) * XCAM_ALIGN_UP(frame_info.height, 2) * 2 * 4;
         break;
+    case XCAM_PIX_FMT_RGB48_planar:
+    case XCAM_PIX_FMT_RGB24_planar:
+        size = XCAM_ALIGN_UP(frame_info.width, 2) * XCAM_ALIGN_UP(frame_info.height, 2)
+               * frame_info.components * XCAM_ALIGN_UP (frame_info.color_bits, 8) / 8;
+        break;
     default:
         XCAM_LOG_ERROR (
             "unknown v4l2 format(%s) in buffer handle",

--- a/wrapper/gstreamer/gstxcambufferpool.cpp
+++ b/wrapper/gstreamer/gstxcambufferpool.cpp
@@ -167,6 +167,7 @@ gst_xcam_buffer_pool_acquire_buffer (
     SmartPtr<MainDeviceManager> device_manager = pool->device_manager;
     SmartPtr<VideoBuffer> video_buf = device_manager->dequeue_buffer ();
     VideoBufferInfo video_info;
+    gsize offsets[XCAM_VIDEO_MAX_COMPONENTS];
 
     XCAM_UNUSED (params);
 
@@ -174,6 +175,9 @@ gst_xcam_buffer_pool_acquire_buffer (
         return GST_FLOW_ERROR;
 
     video_info = video_buf->get_video_info ();
+    for (int i = 0; i < XCAM_VIDEO_MAX_COMPONENTS; i++) {
+        offsets[i] = video_info.offsets[i];
+    }
 
     out_buf = gst_buffer_new ();
     meta = gst_buffer_add_xcam_buffer_meta (out_buf, video_buf);
@@ -205,7 +209,7 @@ gst_xcam_buffer_pool_acquire_buffer (
                 video_info.width,
                 video_info.height,
                 video_info.components,
-                video_info.offsets,
+                offsets,
                 (gint*)(video_info.strides));
         XCAM_ASSERT (video_meta);
         // TODO, consider map and unmap later

--- a/xcore/cl_3a_image_processor.cpp
+++ b/xcore/cl_3a_image_processor.cpp
@@ -344,7 +344,7 @@ CL3aImageProcessor::create_handlers ()
     _bayer_pipe->set_stats_callback (_stats_callback);
 #if 0
     if (get_profile () >= AdvancedPipelineProfile) {
-        _bayer_pipe->set_output_format (V4L2_PIX_FMT_ABGR32);
+        _bayer_pipe->set_output_format (XCAM_PIX_FMT_RGB24_planar);
     }
 #endif
     _bayer_pipe->enable_denoise (XCAM_DENOISE_TYPE_BNR & _snr_mode);

--- a/xcore/cl_bayer_pipe_handler.cpp
+++ b/xcore/cl_bayer_pipe_handler.cpp
@@ -301,7 +301,14 @@ CLBayerPipeImageKernel::prepare_arguments (
         return XCAM_RETURN_ERROR_MEM;
     }
 
-    _image_in = new CLVaImage (context, input);
+    CLImageDesc in_image_info;
+    in_image_info.format.image_channel_order = CL_RGBA;
+    in_image_info.format.image_channel_data_type = CL_UNORM_INT16; //CL_UNSIGNED_INT32;
+    in_image_info.width = in_video_info.width / 4;
+    in_image_info.height = in_video_info.height;
+    in_image_info.row_pitch = in_video_info.strides[0];
+
+    _image_in = new CLVaImage (context, input, in_image_info);
     _image_out = new CLVaImage (context, output);
     _output_height = out_video_info.aligned_height;
 

--- a/xcore/cl_bayer_pipe_handler.h
+++ b/xcore/cl_bayer_pipe_handler.h
@@ -113,6 +113,7 @@ private:
     XCAM_DEAD_COPY (CLBayerPipeImageKernel);
 
 private:
+    uint32_t                  _output_height;
     CLBLCConfig               _blc_config;
     CLWBConfig                _wb_config;
     uint32_t                  _enable_denoise;

--- a/xcore/cl_context.cpp
+++ b/xcore/cl_context.cpp
@@ -291,7 +291,8 @@ CLContext::generate_kernel_id (
     CLKernel *kernel,
     const uint8_t *source, size_t length,
     CLContext::KernelBuildType type,
-    uint8_t **program_binaries, size_t *binary_sizes)
+    uint8_t **gen_binary, size_t *binary_size,
+    const char *build_option)
 {
     struct CLProgram {
         cl_program id;
@@ -338,7 +339,7 @@ CLContext::generate_kernel_id (
         "cl create program failed with error_cod:%d", error_code);
     XCAM_ASSERT (program.id);
 
-    error_code = clBuildProgram (program.id, 1, &device_id, NULL, CLContext::program_pfn_notify, this);
+    error_code = clBuildProgram (program.id, 1, &device_id, build_option, CLContext::program_pfn_notify, this);
     if (error_code != CL_SUCCESS) {
         char error_log [XCAM_CL_MAX_STR_SIZE];
         xcam_mem_clear (error_log);
@@ -347,15 +348,15 @@ CLContext::generate_kernel_id (
         return NULL;
     }
 
-    if (program_binaries != NULL && binary_sizes != NULL) {
-        error_code = clGetProgramInfo (program.id, CL_PROGRAM_BINARY_SIZES, sizeof (size_t) * 1, binary_sizes, NULL);
+    if (gen_binary != NULL && binary_size != NULL) {
+        error_code = clGetProgramInfo (program.id, CL_PROGRAM_BINARY_SIZES, sizeof (size_t) * 1, binary_size, NULL);
         if (error_code != CL_SUCCESS) {
             XCAM_LOG_WARNING ("CL query binary sizes failed on %s", name);
         }
 
-        *program_binaries = (uint8_t *) xcam_malloc0 (sizeof (uint8_t) * (*binary_sizes));
+        *gen_binary = (uint8_t *) xcam_malloc0 (sizeof (uint8_t) * (*binary_size));
 
-        error_code = clGetProgramInfo (program.id, CL_PROGRAM_BINARIES, sizeof (uint8_t *) * 1, program_binaries, NULL);
+        error_code = clGetProgramInfo (program.id, CL_PROGRAM_BINARIES, sizeof (uint8_t *) * 1, gen_binary, NULL);
         if (error_code != CL_SUCCESS) {
             XCAM_LOG_WARNING ("CL query program binaries failed on %s", name);
         }

--- a/xcore/cl_context.h
+++ b/xcore/cl_context.h
@@ -82,8 +82,9 @@ private:
         const uint8_t *source,
         size_t length,
         KernelBuildType type,
-        uint8_t **program_binaries = NULL,
-        size_t *binary_sizes = NULL);
+        uint8_t **gen_binary,
+        size_t *binary_size,
+        const char *build_option);
     void destroy_kernel_id (cl_kernel &kernel_id);
     XCamReturn execute_kernel (
         CLKernel *kernel,

--- a/xcore/cl_image_bo_buffer.cpp
+++ b/xcore/cl_image_bo_buffer.cpp
@@ -140,8 +140,10 @@ CLBoBufferPool::fixate_video_info (VideoBufferInfo &info)
             need_reset_info = true;
     }
     if (need_reset_info) {
-        uint32_t aligned_width = desc.row_pitch / image->get_pixel_bytes ();
-        uint32_t aligned_height = 0;
+        VideoBufferPlanarInfo plane_info;
+        info.get_planar_info (plane_info, 0);
+        uint32_t aligned_width = desc.row_pitch / plane_info.pixel_bytes;
+        uint32_t aligned_height = info.aligned_height;
         if (info.components > 0)
             aligned_height = desc.slice_pitch / desc.row_pitch;
         info.init (info.format, info.width, info.height, aligned_width, aligned_height, desc.size);

--- a/xcore/cl_kernel.cpp
+++ b/xcore/cl_kernel.cpp
@@ -58,7 +58,8 @@ CLKernel::destroy ()
 XCamReturn
 CLKernel::load_from_source (
     const char *source, size_t length,
-    uint8_t **program_binaries, size_t *binary_sizes)
+    uint8_t **gen_binary, size_t *binary_size,
+    const char *build_option)
 {
     cl_kernel new_kernel_id = NULL;
 
@@ -83,7 +84,8 @@ CLKernel::load_from_source (
             this,
             (const uint8_t *)source, length,
             CLContext::KERNEL_BUILD_SOURCE,
-            program_binaries, binary_sizes);
+            gen_binary, binary_size,
+            build_option);
     XCAM_FAIL_RETURN(
         WARNING,
         new_kernel_id != NULL,
@@ -116,7 +118,9 @@ CLKernel::load_from_binary (const uint8_t *binary, size_t length)
         _context->generate_kernel_id (
             this,
             binary, length,
-            CLContext::KERNEL_BUILD_BINARY);
+            CLContext::KERNEL_BUILD_BINARY,
+            NULL, NULL,
+            NULL);
     XCAM_FAIL_RETURN(
         WARNING,
         new_kernel_id != NULL,

--- a/xcore/cl_kernel.h
+++ b/xcore/cl_kernel.h
@@ -60,8 +60,9 @@ public:
 
     XCamReturn load_from_source (
         const char *source, size_t length = 0,
-        uint8_t **program_binaries = NULL,
-        size_t *binary_sizes = NULL);
+        uint8_t **gen_binary = NULL,
+        size_t *binary_size = NULL,
+        const char *build_option = NULL);
     XCamReturn load_from_binary (const uint8_t *binary, size_t length);
     cl_kernel get_kernel_id () {
         return _kernel_id;

--- a/xcore/cl_memory.cpp
+++ b/xcore/cl_memory.cpp
@@ -604,8 +604,8 @@ CLImage2DArray::CLImage2DArray (
     XCAM_ASSERT (cl_desc.array_size >= 2);
 
     //special process for BYT platform for slice-pitch
-    if (video_info.format == V4L2_PIX_FMT_NV12)
-        cl_desc.height = XCAM_ALIGN_UP (cl_desc.height, 16);
+    //if (video_info.format == V4L2_PIX_FMT_NV12)
+    cl_desc.height = XCAM_ALIGN_UP (cl_desc.height, 16);
 
     init_image_2d_array (context, cl_desc, flags);
 }

--- a/xcore/libtbd.c
+++ b/xcore/libtbd.c
@@ -74,7 +74,7 @@ uint32_t get_checksum(void *a_data_ptr, size_t a_data_size)
             checksum32 += *ptr32++;
             size32 -= 2;
         }
-        for (; size32 > 0; size32-=4) {
+        for (; size32 > 0; size32 -= 4) {
             checksum32 += *ptr32++;
             checksum32 += *ptr32++;
             checksum32 += *ptr32++;
@@ -207,7 +207,7 @@ tbd_error_t validate(void *a_data_ptr, size_t a_data_size)
  * return                         Return code indicating possible errors
  */
 tbd_error_t tbd_create(void *a_data_ptr, size_t a_data_size
-    , tbd_tag_t a_tag, size_t *a_new_size)
+                       , tbd_tag_t a_tag, size_t *a_new_size)
 {
     tbd_header_t *header_ptr;
 
@@ -284,7 +284,7 @@ tbd_error_t tbd_validate_anytag(void *a_data_ptr, size_t a_data_size)
  * return                         Return code indicating possible errors
  */
 tbd_error_t tbd_validate(void *a_data_ptr, size_t a_data_size
-    , tbd_tag_t a_tag)
+                         , tbd_tag_t a_tag)
 {
     tbd_header_t *header_ptr;
 
@@ -301,9 +301,9 @@ tbd_error_t tbd_validate(void *a_data_ptr, size_t a_data_size
     if (header_ptr->tag != a_tag) {
         /* See if we have wrong endianness or incorrect tag */
         uint32_t reverse_tag = ( (((a_tag) >> 24) & 0x000000FF)
-            | (((a_tag) >> 8) & 0x0000FF00)
-            | (((a_tag) << 8) & 0x00FF0000)
-            | (((a_tag) << 24) & 0xFF000000) );
+                                 | (((a_tag) >> 8) & 0x0000FF00)
+                                 | (((a_tag) << 8) & 0x00FF0000)
+                                 | (((a_tag) << 24) & 0xFF000000) );
 
         if (reverse_tag == header_ptr->tag) {
             MSG_ERR("LIBTBD ERROR: Wrong endianness of data!");
@@ -342,8 +342,8 @@ tbd_error_t tbd_validate(void *a_data_ptr, size_t a_data_size
  * return                         Return code indicating possible errors
  */
 tbd_error_t tbd_get_record(void *a_data_ptr
-    , tbd_class_t a_record_class, tbd_format_t a_record_format
-    , void **a_record_data, size_t *a_record_size)
+                           , tbd_class_t a_record_class, tbd_format_t a_record_format
+                           , void **a_record_data, uint32_t *a_record_size)
 {
     tbd_header_t *header_ptr;
     uint8_t *byte_ptr, *eof_ptr;
@@ -371,7 +371,7 @@ tbd_error_t tbd_get_record(void *a_data_ptr
         uint32_t record_size = record_ptr->size;
 
         if (((a_record_class == tbd_class_any) || (a_record_class == record_class))
-            && ((a_record_format == tbd_format_any) || (a_record_format == record_format))) {
+                && ((a_record_format == tbd_format_any) || (a_record_format == record_format))) {
 
             /* Match found */
             *a_record_data = record_ptr + 1;
@@ -410,9 +410,9 @@ tbd_error_t tbd_get_record(void *a_data_ptr
  * return                         Return code indicating possible errors
  */
 tbd_error_t tbd_insert_record(void *a_data_ptr, size_t a_data_size
-    , tbd_class_t a_record_class, tbd_format_t a_record_format
-    , void *a_record_data, size_t a_record_size
-    , size_t *a_new_size)
+                              , tbd_class_t a_record_class, tbd_format_t a_record_format
+                              , void *a_record_data, size_t a_record_size
+                              , size_t *a_new_size)
 {
     tbd_header_t *header_ptr;
     size_t new_size;
@@ -483,8 +483,8 @@ tbd_error_t tbd_insert_record(void *a_data_ptr, size_t a_data_size
  * return                         Return code indicating possible errors
  */
 tbd_error_t tbd_remove_record(void *a_data_ptr
-    , tbd_class_t a_record_class, tbd_format_t a_record_format
-    , size_t *a_new_size)
+                              , tbd_class_t a_record_class, tbd_format_t a_record_format
+                              , size_t *a_new_size)
 {
     tbd_header_t *header_ptr;
     uint8_t *byte_ptr, *eof_ptr;
@@ -513,7 +513,7 @@ tbd_error_t tbd_remove_record(void *a_data_ptr
         uint32_t record_size = record_ptr->size;
 
         if (((a_record_class == tbd_class_any) || (a_record_class == record_class))
-            && ((a_record_format == tbd_format_any) || (a_record_format == record_format))) {
+                && ((a_record_format == tbd_format_any) || (a_record_format == record_format))) {
 
             /* Match found, remove the record */
             memcpy(byte_ptr, byte_ptr + record_size, eof_ptr - (byte_ptr + record_size));
@@ -549,7 +549,7 @@ tbd_error_t tbd_remove_record(void *a_data_ptr
  * return                         Return code indicating possible errors
  */
 tbd_error_t tbd_infoprint(void *a_data_ptr, size_t a_data_size
-    , FILE *a_outfile)
+                          , FILE *a_outfile)
 {
     tbd_header_t *header_ptr;
     uint8_t *byte_ptr, *eof_ptr, record_format, record_packing;

--- a/xcore/libtbd.h
+++ b/xcore/libtbd.h
@@ -16,7 +16,7 @@
 
 /*
  * \file libtbd.h
- * \brief Tagged Binary Data handling 
+ * \brief Tagged Binary Data handling
  */
 
 #ifndef __LIBTBD_H__
@@ -80,11 +80,11 @@ typedef struct
 #define CHTOU32(a,b,c,d) ((uint32_t)(a)|((uint32_t)(b)<<8)|((uint32_t)(c)<<16)|((uint32_t)(d)<<24))
 typedef enum
 {
-    tbd_tag_cpff = CHTOU32('C','P','F','F'),  /*!< CPF File */
-    tbd_tag_aiqb = CHTOU32('A','I','Q','B'),  /*!< AIQ configuration */
-    tbd_tag_aiqd = CHTOU32('A','I','Q','D'),  /*!< AIQ data */
-    tbd_tag_halb = CHTOU32('H','A','L','B'),  /*!< CameraHAL configuration */
-    tbd_tag_drvb = CHTOU32('D','R','V','B')   /*!< Sensor driver configuration */
+    tbd_tag_cpff = CHTOU32('C', 'P', 'F', 'F'), /*!< CPF File */
+    tbd_tag_aiqb = CHTOU32('A', 'I', 'Q', 'B'), /*!< AIQ configuration */
+    tbd_tag_aiqd = CHTOU32('A', 'I', 'Q', 'D'), /*!< AIQ data */
+    tbd_tag_halb = CHTOU32('H', 'A', 'L', 'B'), /*!< CameraHAL configuration */
+    tbd_tag_drvb = CHTOU32('D', 'R', 'V', 'B') /*!< Sensor driver configuration */
 } tbd_tag_t;
 
 /*!
@@ -132,9 +132,9 @@ typedef enum
  * @return                         Return code indicating possible errors
  */
 tbd_error_t tbd_create(void *a_data_ptr,
-    size_t a_data_size,
-    tbd_tag_t a_tag,
-    size_t *a_new_size);
+                       size_t a_data_size,
+                       tbd_tag_t a_tag,
+                       size_t *a_new_size);
 
 /*!
  * \brief Checks if Tagged Binary Data is valid. All tags are accepted.
@@ -146,7 +146,7 @@ tbd_error_t tbd_create(void *a_data_ptr,
  * @return                         Return code indicating possible errors
  */
 tbd_error_t tbd_validate_anytag(void *a_data_ptr,
-    size_t a_data_size);
+                                size_t a_data_size);
 
 /*!
  * \brief Checks if Tagged Binary Data is valid, and tagged properly.
@@ -160,8 +160,8 @@ tbd_error_t tbd_validate_anytag(void *a_data_ptr,
  * @return                         Return code indicating possible errors
  */
 tbd_error_t tbd_validate(void *a_data_ptr,
-    size_t a_data_size,
-    tbd_tag_t a_tag);
+                         size_t a_data_size,
+                         tbd_tag_t a_tag);
 
 /*!
  * \brief Finds a record of given kind from within the container.
@@ -177,10 +177,10 @@ tbd_error_t tbd_validate(void *a_data_ptr,
  * @return                         Return code indicating possible errors
  */
 tbd_error_t tbd_get_record(void *a_data_ptr,
-    tbd_class_t a_record_class,
-    tbd_format_t a_record_format,
-    void **a_record_data,
-    size_t *a_record_size);
+                           tbd_class_t a_record_class,
+                           tbd_format_t a_record_format,
+                           void **a_record_data,
+                           uint32_t *a_record_size);
 
 /*!
  * \brief Updates the Tagged Binary Data with the given record inserted.
@@ -202,12 +202,12 @@ tbd_error_t tbd_get_record(void *a_data_ptr,
  * @return                         Return code indicating possible errors
  */
 tbd_error_t tbd_insert_record(void *a_data_ptr,
-    size_t a_data_size,
-    tbd_class_t a_record_class,
-    tbd_format_t a_record_format,
-    void *a_record_data,
-    size_t a_record_size,
-    size_t *a_new_size);
+                              size_t a_data_size,
+                              tbd_class_t a_record_class,
+                              tbd_format_t a_record_format,
+                              void *a_record_data,
+                              size_t a_record_size,
+                              size_t *a_new_size);
 
 /*!
  * \brief Updates the Tagged Binary Data with the given record removed.
@@ -225,9 +225,9 @@ tbd_error_t tbd_insert_record(void *a_data_ptr,
  * @return                         Return code indicating possible errors
  */
 tbd_error_t tbd_remove_record(void *a_data_ptr,
-    tbd_class_t a_record_class,
-    tbd_format_t a_record_format,
-    size_t *a_new_size);
+                              tbd_class_t a_record_class,
+                              tbd_format_t a_record_format,
+                              size_t *a_new_size);
 
 /*!
  * \brief Writes all possible information about the Tagged Binary Data.
@@ -240,8 +240,8 @@ tbd_error_t tbd_remove_record(void *a_data_ptr,
  * @return                         Return code indicating possible errors
  */
 tbd_error_t tbd_infoprint(void *a_data_ptr,
-    size_t a_data_size,
-    FILE *a_outfile);
+                          size_t a_data_size,
+                          FILE *a_outfile);
 
 #ifdef __cplusplus
 }

--- a/xcore/xcam_cpf_reader.c
+++ b/xcore/xcam_cpf_reader.c
@@ -103,7 +103,7 @@ xcam_cpf_read (const char *cpf_file, XCamCpfBlob *aiq_cpf, XCamCpfBlob *hal_cpf)
     int32_t cpf_size;
 
     uint8_t *blob;
-    int32_t blob_size;
+    uint32_t blob_size;
 
     XCAM_FAIL_RETURN_VAL (cpf_file, FALSE);
     XCAM_FAIL_RETURN_VAL (aiq_cpf, FALSE);
@@ -122,7 +122,7 @@ xcam_cpf_read (const char *cpf_file, XCamCpfBlob *aiq_cpf, XCamCpfBlob *hal_cpf)
 
     /* fetch AIQ */
     if ( (tbd_get_record (cpf_buf, tbd_class_aiq, tbd_format_any,
-                          (void**)&blob, (size_t*)&blob_size) != tbd_err_none) ||
+                          (void**)&blob, &blob_size) != tbd_err_none) ||
             !blob || blob_size <= 0) {
         XCAM_LOG_ERROR ("CPF parse AIQ record failed.");
         goto free_buf;


### PR DESCRIPTION
* bayer-pipe change to RGB planar output
* mad replace multiply/add for performance
* change bayer input order from R to RGBA

* This patch is for co-debug with YUV-pipe.