### PR TITLE
drm: close prime fd on destruction of DrmBoData

### DIFF
--- a/xcore/drm_bo_buffer.cpp
+++ b/xcore/drm_bo_buffer.cpp
@@ -40,6 +40,8 @@ DrmBoData::~DrmBoData ()
     unmap ();
     if (_bo)
         drm_intel_bo_unreference (_bo);
+    if (_prime_fd != -1)
+        close (_prime_fd);
 }
 
 uint8_t *
@@ -95,7 +97,7 @@ DrmBoData::get_fd ()
     if (_prime_fd == -1) {
         if (drm_intel_bo_gem_export_to_prime (_bo, &_prime_fd) < 0) {
             _prime_fd = -1;
-            XCAM_LOG_DEBUG ("DrmBoData: failed to obtain prime fd");
+            XCAM_LOG_ERROR ("DrmBoData: failed to obtain prime fd: %s", strerror(errno));
         }
     }
 


### PR DESCRIPTION
 * on cl path, DrmBoData will be created for every incoming v4l2
   buffer, and a prime fd will be requested for each; close the
   fd on destruction is necessary to prevent fd exhaustion.

This is user space fix for issue https://github.com/01org/libxcam/issues/216. Linux kernel fix has been submitted separately.