### PR TITLE
FakePollThread: stop buffer pool to prevent dead lock

### DIFF
--- a/xcore/fake_poll_thread.cpp
+++ b/xcore/fake_poll_thread.cpp
@@ -41,6 +41,16 @@ FakePollThread::~FakePollThread ()
 }
 
 XCamReturn
+FakePollThread::stop ()
+{
+    if (_buf_pool.ptr ())
+        _buf_pool->stop ();
+
+    PollThread::stop ();
+    return XCAM_RETURN_NO_ERROR;
+}
+
+XCamReturn
 FakePollThread::read_buf (SmartPtr<DrmBoBuffer> &buf)
 {
     uint8_t *dst = buf->map ();

--- a/xcore/fake_poll_thread.h
+++ b/xcore/fake_poll_thread.h
@@ -35,6 +35,8 @@ public:
     explicit FakePollThread (const char *raw_path);
     ~FakePollThread ();
 
+    virtual XCamReturn stop ();
+
 protected:
     virtual XCamReturn poll_buffer_loop ();
 

--- a/xcore/poll_thread.h
+++ b/xcore/poll_thread.h
@@ -69,7 +69,7 @@ public:
     bool set_stats_callback (StatsCallback *callback);
 
     XCamReturn start();
-    XCamReturn stop ();
+    virtual XCamReturn stop ();
 
 protected:
     XCamReturn poll_subdev_event_loop ();


### PR DESCRIPTION
 * stop buffer pool will wake up the thread waiting for buffer
   from this pool

Fix for issue https://github.com/01org/libxcam/issues/220.