### PR TITLE
3a-stats: cpu/gpu of cl 3a-stats work in parallel mode

### DIFF
--- a/xcore/cl_3a_stats_calculator.cpp
+++ b/xcore/cl_3a_stats_calculator.cpp
@@ -72,8 +72,9 @@ CL3AStatsCalculatorKernel::prepare_arguments (
 }
 
 XCamReturn
-CL3AStatsCalculatorKernel::post_execute ()
+CL3AStatsCalculatorKernel::post_execute (SmartPtr<DrmBoBuffer> &output)
 {
+    XCAM_UNUSED (output);
     SmartPtr<CLContext> context = get_context ();
     SmartPtr<BufferProxy> buffer;
     SmartPtr<X3aStats> stats;

--- a/xcore/cl_3a_stats_calculator.h
+++ b/xcore/cl_3a_stats_calculator.h
@@ -45,7 +45,7 @@ public:
         CLArgument args[], uint32_t &arg_count,
         CLWorkSize &work_size);
 
-    virtual XCamReturn post_execute ();
+    virtual XCamReturn post_execute (SmartPtr<DrmBoBuffer> &output);
 
     virtual void pre_stop ();
 

--- a/xcore/cl_3a_stats_context.h
+++ b/xcore/cl_3a_stats_context.h
@@ -56,7 +56,8 @@ public:
     void pre_stop ();
     void clean_up_data ();
 
-    SmartPtr<CLBuffer> get_next_buffer ();
+    SmartPtr<CLBuffer> get_buffer ();
+    bool release_buffer (SmartPtr<CLBuffer> &buf);
     SmartPtr<X3aStats> copy_stats_out (const SmartPtr<CLBuffer> &stats_cl_buf);
 
 private:
@@ -67,9 +68,8 @@ private:
 private:
     SmartPtr<CLContext>              _context;
     SmartPtr<X3aStatsPool>           _stats_pool;
-    SmartPtr<CLBuffer>               _stats_cl_buffer[XCAM_CL_3A_STATS_BUFFER_COUNT];
+    SafeList<CLBuffer>               _stats_cl_buffers;
     uint32_t                         _stats_mem_size;
-    uint32_t                         _buf_index;
     uint32_t                         _width_factor;
     uint32_t                         _height_factor;
     uint32_t                         _factor_shift;

--- a/xcore/cl_bayer_basic_handler.h
+++ b/xcore/cl_bayer_basic_handler.h
@@ -32,19 +32,22 @@
 namespace XCam {
 
 class CLBayerBasicImageHandler;
+class CLBayer3AStatsThread;
 
 class CLBayerBasicImageKernel
     : public CLImageKernel
 {
+    friend class CLBayer3AStatsThread;
 public:
     explicit CLBayerBasicImageKernel (SmartPtr<CLContext> &context, SmartPtr<CLBayerBasicImageHandler>& handler);
+    virtual ~CLBayerBasicImageKernel ();
     void set_stats_bits (uint32_t stats_bits);
 
     bool set_blc (const XCam3aResultBlackLevel &blc);
     bool set_wb (const XCam3aResultWhiteBalance &wb);
     bool set_gamma_table (const XCam3aResultGammaTable &gamma);
 
-    virtual XCamReturn post_execute ();
+    virtual XCamReturn post_execute (SmartPtr<DrmBoBuffer> &output);
     virtual void pre_stop ();
 
 protected:
@@ -54,6 +57,8 @@ protected:
         CLWorkSize &work_size);
 
 private:
+    XCamReturn process_stats_buffer (SmartPtr<DrmBoBuffer> &buffer, SmartPtr<CLBuffer> &cl_stats);
+
     XCAM_DEAD_COPY (CLBayerBasicImageKernel);
 
 private:
@@ -65,12 +70,15 @@ private:
 
     float                     _gamma_table[XCAM_GAMMA_TABLE_SIZE + 1];
     SmartPtr<CLBuffer>        _gamma_table_buffer;
-    SmartPtr<DrmBoBuffer>     _output_buffer;
 
-    SmartPtr<CLBuffer>        _stats_cl_buffer;
+    bool                      _is_first_buf;
+
+    SmartPtr<CLBuffer>                    _stats_cl_buffer;
     SmartPtr<CL3AStatsCalculatorContext>  _3a_stats_context;
+    SmartPtr<CLBayer3AStatsThread>        _3a_stats_thread;
     SmartPtr<CLBayerBasicImageHandler>    _handler;
 
+    XCAM_OBJ_PROFILING_DEFINES;
 };
 
 class CLBayerBasicImageHandler

--- a/xcore/cl_bayer_pipe_handler.cpp
+++ b/xcore/cl_bayer_pipe_handler.cpp
@@ -155,8 +155,10 @@ CLBayerPipeImageKernel::prepare_arguments (
 
 
 XCamReturn
-CLBayerPipeImageKernel::post_execute ()
+CLBayerPipeImageKernel::post_execute (SmartPtr<DrmBoBuffer> &output)
 {
+    XCAM_UNUSED (output);
+
     _image_in.release ();
     _image_out.release ();
     _bnr_table_buffer.release ();

--- a/xcore/cl_bayer_pipe_handler.h
+++ b/xcore/cl_bayer_pipe_handler.h
@@ -77,7 +77,7 @@ protected:
         CLArgument args[], uint32_t &arg_count,
         CLWorkSize &work_size);
 
-    virtual XCamReturn post_execute ();
+    virtual XCamReturn post_execute (SmartPtr<DrmBoBuffer> &output);
 
 private:
     XCAM_DEAD_COPY (CLBayerPipeImageKernel);

--- a/xcore/cl_demo_handler.cpp
+++ b/xcore/cl_demo_handler.cpp
@@ -64,9 +64,9 @@ CLDemoImageKernel::prepare_arguments (
 
 
 XCamReturn
-CLDemoImageKernel::post_execute ()
+CLDemoImageKernel::post_execute (SmartPtr<DrmBoBuffer> &output)
 {
-    return CLImageKernel::post_execute ();
+    return CLImageKernel::post_execute (output);
 }
 
 SmartPtr<CLImageHandler>

--- a/xcore/cl_demo_handler.h
+++ b/xcore/cl_demo_handler.h
@@ -32,7 +32,7 @@ class CLDemoImageKernel
 public:
     explicit CLDemoImageKernel (SmartPtr<CLContext> &context);
 
-    virtual XCamReturn post_execute ();
+    virtual XCamReturn post_execute (SmartPtr<DrmBoBuffer> &output);
 protected:
     virtual XCamReturn prepare_arguments (
         SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,

--- a/xcore/cl_image_handler.h
+++ b/xcore/cl_image_handler.h
@@ -62,7 +62,7 @@ public:
     }
 
     XCamReturn pre_execute (SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output);
-    virtual XCamReturn post_execute ();
+    virtual XCamReturn post_execute (SmartPtr<DrmBoBuffer> &output);
     virtual void pre_stop () {}
 
 protected:

--- a/xcore/cl_image_processor.cpp
+++ b/xcore/cl_image_processor.cpp
@@ -178,10 +178,12 @@ CLImageProcessor::process_cl_buffer_queue ()
         ret = handler->execute (data, out_data);
         XCAM_FAIL_RETURN (
             WARNING,
-            ret == XCAM_RETURN_NO_ERROR,
+            (ret == XCAM_RETURN_NO_ERROR || ret == XCAM_RETURN_BYPASS),
             ret,
             "CLImageProcessor execute image handler failed");
         XCAM_ASSERT (out_data.ptr ());
+        if (ret == XCAM_RETURN_BYPASS)
+            return ret;
 
         // for loop in handler, find next handler
         ImageHandlerList::iterator i_handler = _handlers.begin ();

--- a/xcore/cl_image_scaler.cpp
+++ b/xcore/cl_image_scaler.cpp
@@ -127,8 +127,9 @@ CLImageScalerKernel::prepare_arguments (
 }
 
 XCamReturn
-CLImageScalerKernel::post_execute ()
+CLImageScalerKernel::post_execute (SmartPtr<DrmBoBuffer> &output)
 {
+    XCAM_UNUSED (output);
     XCamReturn ret = XCAM_RETURN_NO_ERROR;
 
     if ((V4L2_PIX_FMT_NV12 != get_pixel_format ()) ||

--- a/xcore/cl_image_scaler.h
+++ b/xcore/cl_image_scaler.h
@@ -50,7 +50,7 @@ public:
         CLArgument args[], uint32_t &arg_count,
         CLWorkSize &work_size);
 
-    virtual XCamReturn post_execute ();
+    virtual XCamReturn post_execute (SmartPtr<DrmBoBuffer> &output);
 
     virtual void pre_stop ();
     CLImageScalerMemoryLayout get_mem_layout () const {

--- a/xcore/cl_tnr_handler.cpp
+++ b/xcore/cl_tnr_handler.cpp
@@ -213,13 +213,13 @@ CLTnrImageKernel::prepare_arguments (
 
 
 XCamReturn
-CLTnrImageKernel::post_execute ()
+CLTnrImageKernel::post_execute (SmartPtr<DrmBoBuffer> &output)
 {
     if ((CL_TNR_TYPE_YUV == _type) && _image_out->is_valid ()) {
         _image_out_prev = _image_out;
     }
 
-    return CLImageKernel::post_execute ();
+    return CLImageKernel::post_execute (output);
 }
 
 bool

--- a/xcore/cl_tnr_handler.h
+++ b/xcore/cl_tnr_handler.h
@@ -98,7 +98,7 @@ public:
     bool set_yuv_config (const XCam3aResultTemporalNoiseReduction& config);
     bool set_framecount (uint8_t count) ;
 
-    virtual XCamReturn post_execute ();
+    virtual XCamReturn post_execute (SmartPtr<DrmBoBuffer> &output);
 protected:
     virtual XCamReturn prepare_arguments (
         SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,

--- a/xcore/cl_yuv_pipe_handler.cpp
+++ b/xcore/cl_yuv_pipe_handler.cpp
@@ -177,8 +177,10 @@ CLYuvPipeImageKernel::prepare_arguments (
 }
 
 XCamReturn
-CLYuvPipeImageKernel::post_execute ()
+CLYuvPipeImageKernel::post_execute (SmartPtr<DrmBoBuffer> &output)
 {
+    XCAM_UNUSED (output);
+
     if (_buffer_out->is_valid ()) {
         _buffer_out_prev = _buffer_out;
     }

--- a/xcore/cl_yuv_pipe_handler.h
+++ b/xcore/cl_yuv_pipe_handler.h
@@ -44,7 +44,7 @@ protected:
         SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
         CLArgument args[], uint32_t &arg_count,
         CLWorkSize &work_size);
-    virtual XCamReturn post_execute ();
+    virtual XCamReturn post_execute (SmartPtr<DrmBoBuffer> &output);
 
 private:
     XCAM_DEAD_COPY (CLYuvPipeImageKernel);

--- a/xcore/x3a_ciq_tnr_tuning_handler.cpp
+++ b/xcore/x3a_ciq_tnr_tuning_handler.cpp
@@ -69,6 +69,8 @@ X3aCiqTnrTuningHandler::analyze (X3aResultList &output)
     int64_t et = get_current_exposure_time ();
     double analog_gain = get_current_analog_gain ();
     double max_analog_gain = get_max_analog_gain ();
+    XCAM_UNUSED (et);
+    XCAM_UNUSED (max_analog_gain);
     XCAM_LOG_DEBUG ("get current AG = (%f), max AG = (%f), et = (%lld)", analog_gain, max_analog_gain, et);
 
     uint8_t i_curr = 0;

--- a/xcore/xcam_thread.cpp
+++ b/xcore/xcam_thread.cpp
@@ -108,6 +108,14 @@ bool Thread::start ()
     return true;
 }
 
+bool
+Thread::emit_stop ()
+{
+    SmartLock locker(_mutex);
+    _started = false;
+    return true;
+}
+
 bool Thread::stop ()
 {
     SmartLock locker(_mutex);

--- a/xcore/xcam_thread.h
+++ b/xcore/xcam_thread.h
@@ -32,6 +32,7 @@ public:
     virtual ~Thread ();
 
     bool start ();
+    virtual bool emit_stop ();
     bool stop ();
     bool is_running ();
 


### PR DESCRIPTION
 * cl-3a-stats calculation of GPU and CPU work together in
   parallel mode to improve performance. side-effect: may bring
   1 frame latency.
 * cl-framework changed to support output buffer resetable in
   post_execute.
 * fix compile warnings.

Signed-off-by: Wind Yuan <feng.yuan@intel.com>