### PR TITLE
usbcam: fix rendering failure in 720p mode

### DIFF
--- a/xcore/v4l2_device.cpp
+++ b/xcore/v4l2_device.cpp
@@ -226,6 +226,8 @@ V4l2Device::set_format (struct v4l2_format &format)
     XCAM_FAIL_RETURN (ERROR, is_opened (), XCAM_RETURN_ERROR_FILE,
                       "Cannot set format to v4l2 device while it is closed.");
 
+    struct v4l2_format tmp_format = format;
+
     ret = pre_set_format (format);
     if (ret != XCAM_RETURN_NO_ERROR) {
         XCAM_LOG_WARNING ("device(%s) pre_set_format failed", XCAM_STR (_name));
@@ -242,6 +244,16 @@ V4l2Device::set_format (struct v4l2_format &format)
         }
 
         return XCAM_RETURN_ERROR_IOCTL;
+    }
+
+    if (tmp_format.fmt.pix.width != format.fmt.pix.width || tmp_format.fmt.pix.height != format.fmt.pix.height) {
+        XCAM_LOG_ERROR (
+            "device(%s) set v4l2 format failed, supported format: width:%d, height:%d",
+            XCAM_STR (_name),
+            format.fmt.pix.width,
+            format.fmt.pix.height);
+
+        return XCAM_RETURN_ERROR_PARAM;
     }
 
     while (_fps_n && _fps_d) {


### PR DESCRIPTION
  * check parameters of format after ioctl statement
  * add --resolution option for usbcam in test-device-manager command line
  * test command:
    test-device-manager -m dma -f YUYV -d video -e overlay -p \
        --usb /dev/videoX --resolution 1280x960