### PR TITLE
cl: support swap buffer for image handler

### DIFF
--- a/xcore/Makefile.am
+++ b/xcore/Makefile.am
@@ -65,6 +65,7 @@ xcam_sources =               \
 	isp_image_processor.cpp  \
 	isp_config_translator.cpp \
 	poll_thread.cpp          \
+	swapped_buffer.cpp       \
 	sensor_descriptor.cpp    \
 	uvc_device.cpp           \
 	v4l2_buffer_proxy.cpp    \
@@ -201,6 +202,7 @@ nobase_libxcam_coreinclude_HEADERS =  \
 	image_processor.h          \
 	safe_list.h                \
 	smartptr.h                 \
+	swapped_buffer.h           \
 	v4l2_buffer_proxy.h        \
 	v4l2_device.h              \
 	video_buffer.h             \

--- a/xcore/cl_image_bo_buffer.h
+++ b/xcore/cl_image_bo_buffer.h
@@ -60,6 +60,10 @@ public:
 
 protected:
     CLImageBoBuffer (const VideoBufferInfo &info, const SmartPtr<CLImageBoData> &data);
+
+    //derived from SwappedBuffer
+    virtual SmartPtr<SwappedBuffer> create_new_swap_buffer (
+        const VideoBufferInfo &info, SmartPtr<BufferData> &data);
 };
 
 class CLBoBufferPool

--- a/xcore/cl_image_handler.h
+++ b/xcore/cl_image_handler.h
@@ -87,8 +87,8 @@ class CLImageHandler
 public:
     typedef std::list<SmartPtr<CLImageKernel>> KernelList;
     enum BufferPoolType {
-        CLBoPoolType  = 0,
-        DrmBoPoolType,
+        CLBoPoolType  = 0x0001,
+        DrmBoPoolType = 0x0002,
     };
 
 public:
@@ -111,6 +111,10 @@ public:
     void set_pool_size (uint32_t size) {
         XCAM_ASSERT (size);
         _buf_pool_size = size;
+    }
+
+    void enable_buf_pool_swap_flags (uint32_t flags) {
+        _buf_swap_flags = flags;
     }
 
     bool add_kernel (SmartPtr<CLImageKernel> &kernel);
@@ -141,11 +145,33 @@ private:
     SmartPtr<BufferPool>       _buf_pool;
     BufferPoolType             _buf_pool_type;
     uint32_t                   _buf_pool_size;
+    uint32_t                   _buf_swap_flags;
     X3aResultList              _3a_results;
     int64_t                    _result_timestamp;
 
     XCAM_OBJ_PROFILING_DEFINES;
 };
+
+// never allocate buffer, only swap ouput from input
+class CLCloneImageHandler
+    : public CLImageHandler
+{
+public:
+    explicit CLCloneImageHandler (const char *name);
+    void set_clone_flags (uint32_t flags) {
+        _clone_flags = flags;
+    }
+
+protected:
+    //derived from CLImageHandler
+    virtual XCamReturn prepare_output_buf (SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output);
+
+private:
+    XCAM_DEAD_COPY (CLCloneImageHandler);
+
+    uint32_t                   _clone_flags;
+};
+
 
 };
 

--- a/xcore/cl_memory.cpp
+++ b/xcore/cl_memory.cpp
@@ -670,7 +670,8 @@ bool CLImage2D::init_image_2d (
 CLImage2DArray::CLImage2DArray (
     SmartPtr<CLContext> &context,
     const VideoBufferInfo &video_info,
-    cl_mem_flags  flags)
+    cl_mem_flags  flags,
+    uint32_t extra_array_size)
     : CLImage (context)
 {
     CLImageDesc cl_desc;
@@ -686,6 +687,8 @@ CLImage2DArray::CLImage2DArray (
     //special process for BYT platform for slice-pitch
     //if (video_info.format == V4L2_PIX_FMT_NV12)
     cl_desc.height = XCAM_ALIGN_UP (cl_desc.height, 16);
+
+    cl_desc.array_size += extra_array_size;
 
     init_image_2d_array (context, cl_desc, flags);
 }

--- a/xcore/cl_memory.h
+++ b/xcore/cl_memory.h
@@ -232,7 +232,8 @@ public:
     explicit CLImage2DArray (
         SmartPtr<CLContext> &context,
         const VideoBufferInfo &video_info,
-        cl_mem_flags  flags = CL_MEM_READ_WRITE);
+        cl_mem_flags  flags = CL_MEM_READ_WRITE,
+        uint32_t extra_array_size = 0);
 
     ~CLImage2DArray () {}
 

--- a/xcore/scaled_buffer_pool.cpp
+++ b/xcore/scaled_buffer_pool.cpp
@@ -23,7 +23,8 @@
 namespace XCam {
 
 ScaledVideoBuffer::ScaledVideoBuffer (const VideoBufferInfo &info, const XCamVideoBufferInfo &scaled_info, const SmartPtr<DrmBoData> &data)
-    : DrmBoBuffer (info, data)
+    :  BufferProxy (info, data)
+    , DrmBoBuffer (info, data)
     , _video_info (scaled_info)
 {
 }

--- a/xcore/swapped_buffer.cpp
+++ b/xcore/swapped_buffer.cpp
@@ -1,0 +1,114 @@
+/*
+ * swapped_buffer.cpp - swapped buffer
+ *
+ *  Copyright (c) 2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Wind Yuan <feng.yuan@intel.com>
+ */
+
+#include "xcam_utils.h"
+#include "swapped_buffer.h"
+
+namespace XCam {
+
+SwappedBuffer::SwappedBuffer (
+    const VideoBufferInfo &info, const SmartPtr<BufferData> &data)
+    : BufferProxy (info, data)
+{
+    xcam_mem_clear (_swap_offsets);
+}
+
+SwappedBuffer::~SwappedBuffer ()
+{
+}
+
+void
+SwappedBuffer::set_swap_info (uint32_t flags, uint32_t* offsets)
+{
+    _swap_flags = flags;
+    XCAM_ASSERT (offsets);
+    memcpy(_swap_offsets, offsets, sizeof (_swap_offsets));
+}
+
+bool SwappedBuffer::swap_new_buffer_info(
+    const VideoBufferInfo &in, uint32_t flags, VideoBufferInfo &out)
+{
+    out = in;
+    if (flags & (uint32_t)(SwapY)) {
+        if (in.offsets[0] == _swap_offsets[SwapYOffset0]) {
+            out.offsets[0] = _swap_offsets[SwapYOffset1];
+        } else {
+            XCAM_ASSERT (in.offsets[0] == _swap_offsets[SwapYOffset1]);
+            out.offsets[0] = _swap_offsets[SwapYOffset0];
+        }
+    }
+    if (flags & (uint32_t)(SwapUV)) {
+        if (in.offsets[1] == _swap_offsets[SwapUVOffset0]) {
+            out.offsets[1] = _swap_offsets[SwapUVOffset1];
+        } else {
+            XCAM_ASSERT (in.offsets[1] == _swap_offsets[SwapUVOffset1]);
+            out.offsets[1] = _swap_offsets[SwapUVOffset0];
+        }
+    }
+    return true;
+}
+
+SmartPtr<SwappedBuffer>
+SwappedBuffer::create_new_swap_buffer (
+    const VideoBufferInfo &info, SmartPtr<BufferData> &data)
+{
+    XCAM_ASSERT (false);
+    SmartPtr<SwappedBuffer> out = new SwappedBuffer (info, data);
+    return out;
+}
+
+SmartPtr<SwappedBuffer>
+SwappedBuffer::swap_clone (SmartPtr<SwappedBuffer> self, uint32_t flags)
+{
+    XCAM_ASSERT (self.ptr () && self.ptr () == (SwappedBuffer*)(this));
+    XCAM_FAIL_RETURN(
+        WARNING,
+        flags && (flags & _swap_flags) == flags,
+        NULL,
+        "SwappedBuffer swap_clone failed since flags doens't match");
+
+    const VideoBufferInfo &cur_info = this->get_video_info ();
+    VideoBufferInfo out_info;
+    XCAM_FAIL_RETURN(
+        WARNING,
+        swap_new_buffer_info (cur_info, flags, out_info),
+        NULL,
+        "SwappedBuffer swap_clone failed on out buffer info");
+
+    SmartPtr<BufferData> data = get_buffer_data ();
+    XCAM_FAIL_RETURN(
+        WARNING,
+        data.ptr (),
+        NULL,
+        "SwappedBuffer swap_clone failed to get buffer data");
+
+    SmartPtr<SwappedBuffer> out = create_new_swap_buffer (out_info, data);
+    XCAM_FAIL_RETURN(
+        WARNING,
+        out.ptr (),
+        NULL,
+        "SwappedBuffer swap_clone failed to create new swap buffer");
+    out->_swap_flags = _swap_flags;
+    memcpy (out->_swap_offsets, _swap_offsets, sizeof (_swap_offsets));
+    out->set_parent (self);
+    return out;
+}
+
+};

--- a/xcore/swapped_buffer.h
+++ b/xcore/swapped_buffer.h
@@ -1,0 +1,75 @@
+/*
+ * swapped_buffer.h - swapped buffer
+ *
+ *  Copyright (c) 2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Wind Yuan <feng.yuan@intel.com>
+ */
+
+#ifndef XCAM_SWAPPED_BUFFER_H
+#define XCAM_SWAPPED_BUFFER_H
+
+#include "xcam_utils.h"
+#include "smartptr.h"
+#include "buffer_pool.h"
+
+namespace XCam {
+
+class SwappedBuffer
+    : public virtual BufferProxy
+{
+public:
+    enum SwapFlags {
+        SwapNone = 0,
+        SwapY    = 1,
+        SwapUV   = 2,
+    };
+
+    enum SwapOffsets {
+        SwapYOffset0 = 0,
+        SwapYOffset1 = 1,
+        SwapUVOffset0 = 2,
+        SwapUVOffset1 = 3,
+    };
+
+protected:
+    explicit SwappedBuffer (
+        const VideoBufferInfo &info, const SmartPtr<BufferData> &data);
+
+public:
+    virtual ~SwappedBuffer ();
+    void set_swap_info (uint32_t flags, uint32_t* offsets);
+
+    SmartPtr<SwappedBuffer> swap_clone (
+        SmartPtr<SwappedBuffer> self, uint32_t flags);
+
+protected:
+    virtual SmartPtr<SwappedBuffer> create_new_swap_buffer (
+        const VideoBufferInfo &info, SmartPtr<BufferData> &data);
+
+    bool swap_new_buffer_info (
+        const VideoBufferInfo &in, uint32_t flags, VideoBufferInfo &out);
+
+private:
+    XCAM_DEAD_COPY (SwappedBuffer);
+
+protected:
+    uint32_t                   _swap_flags;
+    uint32_t                   _swap_offsets[XCAM_VIDEO_MAX_COMPONENTS * 2];
+};
+
+}
+
+#endif //XCAM_SWAPPED_BUFFER_H


### PR DESCRIPTION
 * SwappedBuffer can clone a new buffer for Y or UV swap
 * DrmBoBuffer/CLImageBoBuffer derived from SwappedBuffer
 * CLImageHandler can enable buffer pool for swap buffers.
 * CLCloneImageHandler is a pure clone buffer clone handler
 * e.g image with format NV12 with SwapY, the memory plane
   orders are Y0, UV and another Y1; offsets point to Y0 and
   Y1 can swap and keep UV offsets same.

Signed-off-by: Wind Yuan <feng.yuan@intel.com>