### PR TITLE
swap-buffer: auto config init_order in cl processor

### DIFF
--- a/xcore/buffer_pool.cpp
+++ b/xcore/buffer_pool.cpp
@@ -127,8 +127,14 @@ BufferPool::set_video_info (const VideoBufferInfo &info)
         fixate_video_info (new_info),
         false,
         "BufferPool fixate video info failed");
-    _buffer_info = new_info;
+    update_video_info_unsafe (new_info);
     return true;
+}
+
+void
+BufferPool::update_video_info_unsafe (const VideoBufferInfo &info)
+{
+    _buffer_info = info;
 }
 
 bool

--- a/xcore/buffer_pool.h
+++ b/xcore/buffer_pool.h
@@ -111,6 +111,8 @@ protected:
 
     bool add_data_unsafe (SmartPtr<BufferData> data);
 
+    void update_video_info_unsafe (const VideoBufferInfo &info);
+
 private:
     void release (SmartPtr<BufferData> &data);
     XCAM_DEAD_COPY (BufferPool);

--- a/xcore/cl_3a_image_processor.h
+++ b/xcore/cl_3a_image_processor.h
@@ -97,6 +97,8 @@ protected:
 
 private:
     virtual XCamReturn create_handlers ();
+
+    bool post_config ();
     XCAM_DEAD_COPY (CL3aImageProcessor);
 
 private:

--- a/xcore/cl_image_handler.cpp
+++ b/xcore/cl_image_handler.cpp
@@ -161,6 +161,26 @@ CLImageHandler::~CLImageHandler ()
 }
 
 bool
+CLImageHandler::enable_buf_pool_swap_flags (
+    uint32_t flags,
+    uint32_t init_order)
+{
+    _buf_swap_flags = flags;
+    _buf_swap_init_order = init_order;
+
+    SmartPtr<DrmBoBufferPool> pool = _buf_pool.dynamic_cast_ptr<DrmBoBufferPool> ();
+
+    if (pool.ptr () && !pool->update_swap_init_order (init_order)) {
+        XCAM_LOG_ERROR (
+            "Handler(%s) update swap order(0x%04x) to buffer pool failed",
+            XCAM_STR (get_name ()),
+            init_order);
+        return false;
+    }
+    return true;
+}
+
+bool
 CLImageHandler::add_kernel (SmartPtr<CLImageKernel> &kernel)
 {
     _kernels.push_back (kernel);

--- a/xcore/cl_image_handler.h
+++ b/xcore/cl_image_handler.h
@@ -113,13 +113,9 @@ public:
         _buf_pool_size = size;
     }
 
-    void enable_buf_pool_swap_flags (
+    bool enable_buf_pool_swap_flags (
         uint32_t flags,
-        uint32_t init_order = (uint32_t)(SwappedBuffer::OrderY0Y1))
-    {
-        _buf_swap_flags = flags;
-        _buf_swap_init_order = init_order;
-    }
+        uint32_t init_order = (uint32_t)(SwappedBuffer::OrderY0Y1));
 
     bool add_kernel (SmartPtr<CLImageKernel> &kernel);
     bool set_kernels_enable (bool enable);
@@ -165,6 +161,9 @@ public:
     explicit CLCloneImageHandler (const char *name);
     void set_clone_flags (uint32_t flags) {
         _clone_flags = flags;
+    }
+    uint32_t get_clone_flags () const {
+        return _clone_flags;
     }
 
 protected:

--- a/xcore/cl_image_processor.cpp
+++ b/xcore/cl_image_processor.cpp
@@ -79,6 +79,18 @@ CLImageProcessor::add_handler (SmartPtr<CLImageHandler> &handler)
     return true;
 }
 
+CLImageProcessor::ImageHandlerList::iterator
+CLImageProcessor::handlers_begin ()
+{
+    return _handlers.begin ();
+}
+
+CLImageProcessor::ImageHandlerList::iterator
+CLImageProcessor::handlers_end ()
+{
+    return _handlers.end ();
+}
+
 SmartPtr<CLContext>
 CLImageProcessor::get_cl_context ()
 {

--- a/xcore/cl_image_processor.h
+++ b/xcore/cl_image_processor.h
@@ -35,6 +35,7 @@ class CLHandlerThread;
 class CLImageProcessor
     : public ImageProcessor
 {
+public:
     typedef std::list<SmartPtr<CLImageHandler>>  ImageHandlerList;
     friend class CLHandlerThread;
 
@@ -43,6 +44,8 @@ public:
     virtual ~CLImageProcessor ();
 
     bool add_handler (SmartPtr<CLImageHandler> &handler);
+    ImageHandlerList::iterator handlers_begin ();
+    ImageHandlerList::iterator handlers_end ();
 
 protected:
 

--- a/xcore/drm_bo_buffer.cpp
+++ b/xcore/drm_bo_buffer.cpp
@@ -172,6 +172,34 @@ DrmBoBufferPool::~DrmBoBufferPool ()
 }
 
 bool
+DrmBoBufferPool::update_swap_init_order (uint32_t init_order)
+{
+    VideoBufferInfo info = get_video_info ();
+    XCAM_ASSERT (info.format);
+
+    if ((_swap_flags & (uint32_t)(SwappedBuffer::SwapY)) && !(init_order & (uint32_t)(SwappedBuffer::OrderYMask))) {
+        XCAM_LOG_WARNING ("update swap init order failed, need init Y order, error order:0x%04x", init_order);
+        return false;
+    }
+
+    if ((_swap_flags & (uint32_t)(SwappedBuffer::SwapUV)) && !(init_order & (uint32_t)(SwappedBuffer::OrderUVMask))) {
+        XCAM_LOG_WARNING ("update swap init order failed, need init UV order, error order:0x%04x", init_order);
+        return false;
+    }
+    _swap_init_order = init_order;
+
+    XCAM_FAIL_RETURN (
+        WARNING,
+        init_swap_order (info),
+        false,
+        "CL3aImageProcessor post_config failed");
+
+    update_video_info_unsafe (info);
+
+    return true;
+}
+
+bool
 DrmBoBufferPool::fixate_video_info (VideoBufferInfo &info)
 {
     if (info.format != V4L2_PIX_FMT_NV12)

--- a/xcore/drm_bo_buffer.h
+++ b/xcore/drm_bo_buffer.h
@@ -103,6 +103,8 @@ public:
         return _swap_flags;
     }
 
+    bool update_swap_init_order (uint32_t init_order);
+
 protected:
     // derived from BufferPool
     virtual bool fixate_video_info (VideoBufferInfo &info);


### PR DESCRIPTION
 This is a workaround for HW encoder which only support Y plane offset = 0.