### PR TITLE
Add test case for enable Wavelet denoise

### DIFF
--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -316,6 +316,7 @@ void print_help (const char *bin_name)
             "\t --enable-wdr  enable wdr\n"
             "\t --enable-new-wdr  enable new wdr algorithm\n"
             "\t --enable-retinex  enable retinex\n"
+            "\t --enable-wavelet  enable wavelet denoise\n"
             "\t --pipeline    pipe mode\n"
             "\t               select from [basic, advance, extreme], default is [basic]\n"
             "(e.g.: xxxx --hdr=xx --tnr=xx --tnr-level=xx --bilateral --enable-snr --enable-ee --enable-bnr --enable-dpc)\n\n"
@@ -365,6 +366,7 @@ int main (int argc, char *argv[])
     bool newtonemapping_type = false;
     bool wdr_type = false;
     bool retinex_type = false;
+    bool wavelet_type = false;
     int32_t brightness_level = 128;
     bool    have_usbcam = 0;
     char*   usb_device_name = NULL;
@@ -387,6 +389,7 @@ int main (int argc, char *argv[])
         {"enable-wdr", no_argument, NULL, 'W'},
         {"enable-new-wdr", no_argument, NULL, 'N'},
         {"enable-retinex", no_argument, NULL, 'X'},
+        {"enable-wavelet", no_argument, NULL, 'V'},
         {"usb", required_argument, NULL, 'U'},
         {"resolution", required_argument, NULL, 'R'},
         {"sync", no_argument, NULL, 'Y'},
@@ -527,7 +530,10 @@ int main (int argc, char *argv[])
             retinex_type = true;
             break;
         }
-
+        case 'V': {
+            wavelet_type = true;
+            break;
+        }
         case 'D': {
             dpc_type = true;
             break;
@@ -736,6 +742,7 @@ int main (int argc, char *argv[])
         cl_processor->set_newtonemapping(newtonemapping_type);
         cl_processor->set_gamma (!wdr_type); // disable gamma for WDR
         cl_processor->set_retinex (retinex_type);
+        cl_processor->set_wavelet (wavelet_type);
         cl_processor->set_capture_stage (capture_stage);
         if (need_display) {
             cl_processor->set_output_format (V4L2_PIX_FMT_XBGR32);

--- a/wrapper/gstreamer/gstxcamsrc.cpp
+++ b/wrapper/gstreamer/gstxcamsrc.cpp
@@ -67,6 +67,7 @@ using namespace GstXCam;
 #define DEFAULT_PROP_ENABLE_3A          TRUE
 #define DEFAULT_PROP_ENABLE_USB         FALSE
 #define DEFAULT_PROP_ENABLE_WDR         FALSE
+#define DEFAULT_PROP_ENABLE_WAVELET     FALSE
 #define DEFAULT_PROP_BUFFERCOUNT        8
 #define DEFAULT_PROP_PIXELFORMAT        V4L2_PIX_FMT_NV12 //420 instead of 0
 #define DEFAULT_PROP_FIELD              V4L2_FIELD_NONE // 0
@@ -226,6 +227,7 @@ enum {
     PROP_INPUT_FMT,
     PROP_ENABLE_USB,
     PROP_ENABLE_WDR,
+    PROP_ENABLE_WAVELET,
     PROP_FAKE_INPUT
 };
 
@@ -338,6 +340,11 @@ gst_xcam_src_class_init (GstXCamSrcClass * klass)
                               DEFAULT_PROP_ENABLE_WDR, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
     g_object_class_install_property (
+        gobject_class, PROP_ENABLE_WAVELET,
+        g_param_spec_boolean ("enable-wavelet", "enable wavelet denoise", "Enable WAVELET DENOISE",
+                              DEFAULT_PROP_ENABLE_WAVELET, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+    g_object_class_install_property (
         gobject_class, PROP_MEM_MODE,
         g_param_spec_enum ("io-mode", "memory mode", "Memory mode",
                            GST_TYPE_XCAM_SRC_MEM_MODE, DEFAULT_PROP_MEM_MODE,
@@ -433,6 +440,7 @@ gst_xcam_src_init (GstXCamSrc *xcamsrc)
     xcamsrc->enable_3a = DEFAULT_PROP_ENABLE_3A;
     xcamsrc->enable_usb = DEFAULT_PROP_ENABLE_USB;
     xcamsrc->enable_wdr = DEFAULT_PROP_ENABLE_WDR;
+    xcamsrc->enable_wavelet = DEFAULT_PROP_ENABLE_WAVELET;
     xcamsrc->path_to_fake = NULL;
     xcamsrc->time_offset_ready = FALSE;
     xcamsrc->time_offset = -1;
@@ -505,6 +513,10 @@ gst_xcam_src_get_property (
 
     case PROP_ENABLE_WDR:
         g_value_set_boolean (value, src->enable_wdr);
+        break;
+
+    case PROP_ENABLE_WAVELET:
+        g_value_set_boolean (value, src->enable_wavelet);
         break;
 
     case PROP_MEM_MODE:
@@ -582,6 +594,10 @@ gst_xcam_src_set_property (
 
     case PROP_ENABLE_WDR:
         src->enable_wdr = g_value_get_boolean (value);
+        break;
+
+    case PROP_ENABLE_WAVELET:
+        src->enable_wavelet = g_value_get_boolean (value);
         break;
 
     case PROP_MEM_MODE:
@@ -785,6 +801,10 @@ gst_xcam_src_start (GstBaseSrc *src)
             xcamsrc->in_format = V4L2_PIX_FMT_SGRBG12;
             setenv ("AIQ_CPF_PATH", "/etc/atomisp/imx185_wdr.cpf", 1);
         }
+        if(xcamsrc->enable_wavelet)
+        {
+            cl_processor->set_wavelet (true);
+        }
         cl_processor->set_profile ((CL3aImageProcessor::PipelineProfile)xcamsrc->cl_pipe_profile);
         device_manager->add_image_processor (cl_processor);
         device_manager->set_cl_image_processor (cl_processor);
@@ -940,7 +960,7 @@ translate_format_to_xcam (GstVideoFormat format)
     case GST_VIDEO_FORMAT_Y42B:
         return V4L2_PIX_FMT_YUV422P;
 
-        //RGB
+    //RGB
     case GST_VIDEO_FORMAT_RGBx:
         return V4L2_PIX_FMT_RGB32;
     case GST_VIDEO_FORMAT_BGRx:

--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -77,6 +77,7 @@ struct _GstXCamSrc
     gboolean                     enable_3a;
     gboolean                     enable_usb;
     gboolean                     enable_wdr;
+    gboolean                     enable_wavelet;
     char                        *path_to_fake;
 
     gboolean                     time_offset_ready;


### PR DESCRIPTION
- test-device-manager Command:
  ./test-device-manager -f BA10 -m dma -c -d still -p -a dynamic --enable-wavelet

- gst-launch-1.0 Command:
  Command on device:
   gst-launch-1.0 xcamsrc io-mode=4 imageprocessor=1 analyzer=2 pipe-profile=2 enable-wavelet=true ! video/x-raw, format=NV12, width=1920, height=1080, framerate=25/1 ! queue ! vaapiencode_h264 rate-control=cbr ! tcpclientsink host="10.238.145.61" port=3000 blocksize=1024000 sync=false
  Command on Linux server:
   gst-launch-1.0 -v tcpserversrc host=0.0.0.0 port=3000 ! queue max-size-bytes=0 ! h264parse  ! queue ! avdec_h264 ! videoconvert ! video/x-raw, format=BGRx | ximagesink sync=false