### PR TITLE
Create a separate CL buffer for Wavelet denoise kernel to hold approximation image data

### DIFF
--- a/wrapper/gstreamer/gstxcamsrc.cpp
+++ b/wrapper/gstreamer/gstxcamsrc.cpp
@@ -960,7 +960,7 @@ translate_format_to_xcam (GstVideoFormat format)
     case GST_VIDEO_FORMAT_Y42B:
         return V4L2_PIX_FMT_YUV422P;
 
-        //RGB
+    //RGB
     case GST_VIDEO_FORMAT_RGBx:
         return V4L2_PIX_FMT_RGB32;
     case GST_VIDEO_FORMAT_BGRx:

--- a/xcore/cl_wavelet_denoise_handler.h
+++ b/xcore/cl_wavelet_denoise_handler.h
@@ -67,9 +67,10 @@ private:
 
     SmartPtr<CLWaveletDenoiseImageHandler> _handler;
 
-    SmartPtr<CLMemory>  _buffer_in;
-    SmartPtr<CLMemory>  _buffer_out;
+    SmartPtr<CLMemory>  _input_image;
+    SmartPtr<CLMemory>  _approx_image;
     SmartPtr<CLMemory>  _details_image;
+    SmartPtr<CLMemory>  _reconstruct_image;
 };
 
 class CLWaveletDenoiseImageHandler
@@ -87,6 +88,10 @@ public:
         return _details_image;
     };
 
+    SmartPtr<CLMemory> &get_approx_image () {
+        return _approx_image;
+    };
+
 protected:
     virtual XCamReturn prepare_output_buf (SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output);
 
@@ -96,6 +101,7 @@ private:
 private:
     XCam3aResultWaveletNoiseReduction _config;
     SmartPtr<CLMemory> _details_image;
+    SmartPtr<CLMemory> _approx_image;
 };
 
 SmartPtr<CLImageHandler>


### PR DESCRIPTION
To read & write same memory location within work items in CL kernel will have potential data async issue. Allocate a separate CL buffer to hold approximation image data, wavelet CL kernel will access buffer write or read only. .