### PR TITLE
Add option in gstreamer for new tonemapping kernel.

### DIFF
--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -71,12 +71,12 @@ struct _GstXCamSrc
     uint32_t                     buf_count;
     uint32_t                     sensor_id;
     uint32_t                     capture_mode;
+    uint32_t                     enable_wdr;
     char                        *device;
     char                        *path_to_cpf;
     char                        *path_to_3alib;
     gboolean                     enable_3a;
     gboolean                     enable_usb;
-    gboolean                     enable_wdr;
     gboolean                     enable_wavelet;
     char                        *path_to_fake;
 

--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -54,6 +54,12 @@ typedef enum {
 } ImageProcessorType;
 
 typedef enum {
+    NONE = 0,
+    GAUSSIAN,
+    HALEQ,
+} WDRModeType;
+
+typedef enum {
     SIMPLE_ANALYZER = 0,
     AIQ_ANALYZER,
     DYNAMIC_ANALYZER,
@@ -71,7 +77,6 @@ struct _GstXCamSrc
     uint32_t                     buf_count;
     uint32_t                     sensor_id;
     uint32_t                     capture_mode;
-    uint32_t                     enable_wdr;
     char                        *device;
     char                        *path_to_cpf;
     char                        *path_to_3alib;
@@ -92,6 +97,7 @@ struct _GstXCamSrc
     GstVideoInfo                 gst_video_info;
     VideoBufferInfo              xcam_video_info;
     ImageProcessorType           image_processor_type;
+    WDRModeType                  wdr_mode_type;
     AnalyzerType                 analyzer_type;
     int32_t                      cl_pipe_profile;
     SmartPtr<MainDeviceManager>  device_manager;


### PR DESCRIPTION
* Test command:
   gst-launch-1.0 xcamsrc io-mode=4 imageprocessor=1 analyzer=2 pipe-profile=2
   enable-wdr=X ! video/x-raw, format=NV12, width=1920, height=1080,
   framerate=30/1 ! queue ! vaapiencode_h264 rate-control=cbr ! tcpclientsink
   host="(your host id)" port=3000 blocksize=1024000 sync=false

   X = 0: disable wdr.
   X = 1: enable old wdr.
   X = 2: enable new wdr.

   default value is 0.