### PR TITLE
cl: adjust retinex algorithm and add interface to gstreamer.

### DIFF
--- a/cl_kernel/kernel_retinex.cl
+++ b/cl_kernel/kernel_retinex.cl
@@ -8,17 +8,20 @@ typedef struct {
     float  threshold;
     float           log_min;
     float           log_max;
+    float    width;
+    float    height;
 } CLRetinexConfig;
 
-__kernel void kernel_retinex (__read_only image2d_t input, __write_only image2d_t output, uint vertical_offset_in, uint vertical_offset_out, CLRetinexConfig re_config, __global float *table)
+__kernel void kernel_retinex (__read_only image2d_t input, __read_only image2d_t ga_input, __write_only image2d_t output, uint vertical_offset_in, uint vertical_offset_out, CLRetinexConfig re_config)
 {
     int x = get_global_id (0);
     int y = get_global_id (1);
     sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+    sampler_t sampler1 = CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
 
     float4 y_out, uv_in;
-    float4 y_in[25];
-    float y_ga, y_lg;
+    float4 y_in, y_ga;
+    float y_lg;
     int i;
     // cpy UV
     if(y % 2 == 0) {
@@ -26,19 +29,11 @@ __kernel void kernel_retinex (__read_only image2d_t input, __write_only image2d_
         write_imagef(output, (int2)(x, y / 2 + vertical_offset_out), uv_in);
     }
 
-    for(i = 0; i < 25; i++)
-        y_in[i] = read_imagef(input, sampler, (int2)(x - 2 + i % 5, y - 2 + i / 5)) * 255.0;
+    y_in = read_imagef(input, sampler, (int2)(x, y)) * 255.0;
+    y_ga = read_imagef(ga_input, sampler1, (float2)(x/re_config.width, y/(re_config.height/2*3))) * 255.0;
 
-    for(i = 0; i < 25; i++)
-        y_ga += y_in[i].x * table[i];
-    y_lg = log(y_in[12].x) - log(y_ga);
+    y_lg = log(y_in.x) - log(y_ga.x);
 
-    if(y_lg < re_config.log_min)
-        y_out.x = 0.0f;
-    else if(y_lg > re_config.log_max)
-        y_out.x = 1.0;
-    else
-        y_out.x = re_config.gain * (y_lg - re_config.log_min) / 255.0;
+        y_out.x = re_config.gain * y_in.x/128.0 * (y_lg - re_config.log_min) / 255.0;
     write_imagef(output, (int2)(x, y), y_out);
 }
-

--- a/wrapper/gstreamer/gstxcamsrc.cpp
+++ b/wrapper/gstreamer/gstxcamsrc.cpp
@@ -68,6 +68,7 @@ using namespace GstXCam;
 #define DEFAULT_PROP_ENABLE_USB         FALSE
 #define DEFAULT_PROP_ENABLE_WDR         FALSE
 #define DEFAULT_PROP_ENABLE_WAVELET     FALSE
+#define DEFAULT_PROP_ENABLE_RETINEX     FALSE
 #define DEFAULT_PROP_BUFFERCOUNT        8
 #define DEFAULT_PROP_PIXELFORMAT        V4L2_PIX_FMT_NV12 //420 instead of 0
 #define DEFAULT_PROP_FIELD              V4L2_FIELD_NONE // 0
@@ -228,6 +229,7 @@ enum {
     PROP_ENABLE_USB,
     PROP_ENABLE_WDR,
     PROP_ENABLE_WAVELET,
+    PROP_ENABLE_RETINEX,
     PROP_FAKE_INPUT
 };
 
@@ -345,6 +347,11 @@ gst_xcam_src_class_init (GstXCamSrcClass * klass)
                               DEFAULT_PROP_ENABLE_WAVELET, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
     g_object_class_install_property (
+        gobject_class, PROP_ENABLE_RETINEX,
+        g_param_spec_boolean ("enable-retinex", "enable retinex", "Enable RETINEX",
+                              DEFAULT_PROP_ENABLE_RETINEX, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+    g_object_class_install_property (
         gobject_class, PROP_MEM_MODE,
         g_param_spec_enum ("io-mode", "memory mode", "Memory mode",
                            GST_TYPE_XCAM_SRC_MEM_MODE, DEFAULT_PROP_MEM_MODE,
@@ -441,6 +448,7 @@ gst_xcam_src_init (GstXCamSrc *xcamsrc)
     xcamsrc->enable_usb = DEFAULT_PROP_ENABLE_USB;
     xcamsrc->enable_wdr = DEFAULT_PROP_ENABLE_WDR;
     xcamsrc->enable_wavelet = DEFAULT_PROP_ENABLE_WAVELET;
+    xcamsrc->enable_retinex = DEFAULT_PROP_ENABLE_RETINEX;
     xcamsrc->path_to_fake = NULL;
     xcamsrc->time_offset_ready = FALSE;
     xcamsrc->time_offset = -1;
@@ -517,6 +525,10 @@ gst_xcam_src_get_property (
 
     case PROP_ENABLE_WAVELET:
         g_value_set_boolean (value, src->enable_wavelet);
+        break;
+
+    case PROP_ENABLE_RETINEX:
+        g_value_set_boolean (value, src->enable_retinex);
         break;
 
     case PROP_MEM_MODE:
@@ -598,6 +610,10 @@ gst_xcam_src_set_property (
 
     case PROP_ENABLE_WAVELET:
         src->enable_wavelet = g_value_get_boolean (value);
+        break;
+
+    case PROP_ENABLE_RETINEX:
+        src->enable_retinex = g_value_get_boolean (value);
         break;
 
     case PROP_MEM_MODE:
@@ -805,6 +821,12 @@ gst_xcam_src_start (GstBaseSrc *src)
         {
             cl_processor->set_wavelet (true);
         }
+
+        if(xcamsrc->enable_retinex)
+        {
+            cl_processor->set_retinex(true);
+        }
+
         cl_processor->set_profile ((CL3aImageProcessor::PipelineProfile)xcamsrc->cl_pipe_profile);
         device_manager->add_image_processor (cl_processor);
         device_manager->set_cl_image_processor (cl_processor);

--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -78,6 +78,7 @@ struct _GstXCamSrc
     gboolean                     enable_usb;
     gboolean                     enable_wdr;
     gboolean                     enable_wavelet;
+    gboolean                     enable_retinex;
     char                        *path_to_fake;
 
     gboolean                     time_offset_ready;

--- a/wrapper/gstreamer/interface/gstxcaminterface.h
+++ b/wrapper/gstreamer/interface/gstxcaminterface.h
@@ -453,6 +453,17 @@ struct _GstXCam3AInterface {
      * \return           bool          0 on success
      */
     gboolean (* set_tonemapping_mode)           (GstXCam3A *xcam, gboolean enable);
+
+/*!
+ * \brief set retinex mode.
+ *
+ * \param[in,out]	 xcam		   XCam3A handle
+ * \param[in]		 enable 	   true: enable, false: disable
+ * \return			 bool		   0 on success
+ */
+gboolean (* set_retinex_mode)			(GstXCam3A *xcam, gboolean enable);
+
+
 };
 
 /*! \brief Get GST interface type of XCam 3A interface.

--- a/xcore/cl_gauss_handler.h
+++ b/xcore/cl_gauss_handler.h
@@ -44,12 +44,13 @@ protected:
         CLArgument args[], uint32_t &arg_count,
         CLWorkSize &work_size);
 
-private:
-    XCAM_DEAD_COPY (CLGaussImageKernel);
+protected:
     uint32_t _vertical_offset_in;
     uint32_t _vertical_offset_out;
     SmartPtr<CLBuffer>  _g_table_buffer;
     float _g_table[XCAM_GAUSS_TABLE_SIZE*XCAM_GAUSS_TABLE_SIZE];
+private:
+    XCAM_DEAD_COPY (CLGaussImageKernel);
 };
 
 class CLGaussImageHandler

--- a/xcore/cl_image_scaler.cpp
+++ b/xcore/cl_image_scaler.cpp
@@ -23,18 +23,24 @@
 
 namespace XCam {
 
-#define XCAM_CL_IMAGE_SCALER_KERNEL_LOCAL_WORK_SIZE 4
-
-CLImageScalerKernel::CLImageScalerKernel (
+CLScalerKernel::CLScalerKernel (
     SmartPtr<CLContext> &context,
-    CLImageScalerMemoryLayout mem_layout,
-    SmartPtr<CLImageScaler> &scaler
+    CLImageScalerMemoryLayout mem_layout
 )
     : CLImageKernel (context, "kernel_image_scaler")
     , _pixel_format (V4L2_PIX_FMT_NV12)
     , _mem_layout (mem_layout)
     , _output_width (0)
     , _output_height (0)
+{
+}
+
+CLImageScalerKernel::CLImageScalerKernel (
+    SmartPtr<CLContext> &context,
+    CLImageScalerMemoryLayout mem_layout,
+    SmartPtr<CLImageScaler> &scaler
+)
+    : CLScalerKernel (context, mem_layout)
     , _scaler (scaler)
 {
 }
@@ -103,7 +109,7 @@ CLImageScalerKernel::prepare_arguments (
         input_imageDesc.height = input_info.height;
         input_imageDesc.row_pitch = input_info.strides[0];
 
-        _image_in = new CLVaImage (context, input, input_imageDesc, input_info.offsets[0]);
+        _image_in = new CLVaImage (context, input, input_imageDesc, 0);
     }
 
     //set args;

--- a/xcore/cl_image_scaler.h
+++ b/xcore/cl_image_scaler.h
@@ -35,24 +35,18 @@ enum CLImageScalerMemoryLayout {
     CL_IMAGE_SCALER_RGBA = 2,
 };
 
+#define XCAM_CL_IMAGE_SCALER_KERNEL_LOCAL_WORK_SIZE 4
+
 class CLImageScaler;
 
-class CLImageScalerKernel
+class CLScalerKernel
     : public CLImageKernel
 {
 public:
-    explicit CLImageScalerKernel (
-        SmartPtr<CLContext> &context, CLImageScalerMemoryLayout mem_layout, SmartPtr<CLImageScaler> &scaler);
+    explicit CLScalerKernel (
+        SmartPtr<CLContext> &context, CLImageScalerMemoryLayout mem_layout);
 
 public:
-    virtual XCamReturn prepare_arguments (
-        SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
-        CLArgument args[], uint32_t &arg_count,
-        CLWorkSize &work_size);
-
-    virtual XCamReturn post_execute (SmartPtr<DrmBoBuffer> &output);
-
-    virtual void pre_stop ();
     CLImageScalerMemoryLayout get_mem_layout () const {
         return _mem_layout;
     };
@@ -61,15 +55,37 @@ public:
     };
 
 private:
-    XCAM_DEAD_COPY (CLImageScalerKernel);
+    XCAM_DEAD_COPY (CLScalerKernel);
 
-private:
+protected:
     uint32_t _pixel_format;
     CLImageScalerMemoryLayout _mem_layout;
     uint32_t _output_width;
     uint32_t _output_height;
-    SmartPtr<CLImageScaler> _scaler;
     SmartPtr<CLImage> _cl_image_out;
+};
+
+class CLImageScalerKernel
+    : public CLScalerKernel
+{
+public:
+    explicit CLImageScalerKernel (
+        SmartPtr<CLContext> &context, CLImageScalerMemoryLayout mem_layout, SmartPtr<CLImageScaler> &scaler);
+
+    virtual XCamReturn prepare_arguments (
+        SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
+        CLArgument args[], uint32_t &arg_count,
+        CLWorkSize &work_size);
+
+    virtual XCamReturn post_execute (SmartPtr<DrmBoBuffer> &output);
+
+    virtual void pre_stop ();
+
+private:
+    XCAM_DEAD_COPY (CLImageScalerKernel);
+
+private:
+    SmartPtr<CLImageScaler> _scaler;
 };
 
 class CLImageScaler

--- a/xcore/cl_retinex_handler.cpp
+++ b/xcore/cl_retinex_handler.cpp
@@ -23,54 +23,149 @@
 
 namespace XCam {
 
-CLRetinexImageKernel::CLRetinexImageKernel (SmartPtr<CLContext> &context)
-    : CLImageKernel (context, "kernel_retinex")
-    , _vertical_offset_in (0)
-    , _vertical_offset_out (0)
+CLRetinexScalerImageKernel::CLRetinexScalerImageKernel (SmartPtr<CLContext> &context,
+    CLImageScalerMemoryLayout mem_layout,
+    SmartPtr<CLRetinexImageHandler> &scaler)
+    :  CLScalerKernel (context, mem_layout),
+    _scaler(scaler)
 {
-    set_gaussian(5, 2);
 }
-
-bool
-CLRetinexImageKernel::set_gaussian (int size, float sigma)
-{
-    int i, j;
-    float dis = 0, sum = 0;
-    for(i = 0; i < size; i++)  {
-        for(j = 0; j < size; j++)  {
-            {
-                dis = (float)(i - size / 2) * (i - size / 2) + (j - size / 2) * (j - size / 2);
-                _g_table[i * XCAM_RETINEX_TABLE_SIZE + j] = 1 / (2 * 3.14 * sigma * sigma) * exp(-dis / (2 * sigma * sigma));
-                sum += _g_table[i * XCAM_RETINEX_TABLE_SIZE + j];
-            }
-        }
-    }
-
-    for(i = 0; i < XCAM_RETINEX_TABLE_SIZE * XCAM_RETINEX_TABLE_SIZE; i++)
-        _g_table[i] = _g_table[i] / sum;
-
-    return true;
-}
-
 
 XCamReturn
-CLRetinexImageKernel::prepare_arguments (
+CLRetinexScalerImageKernel::prepare_arguments (
     SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
     CLArgument args[], uint32_t &arg_count,
     CLWorkSize &work_size)
 {
-    SmartPtr<CLContext> context = get_context ();
-    const VideoBufferInfo & video_info_in = input->get_video_info ();
-    const VideoBufferInfo & video_info_out = output->get_video_info ();
-    _retinex_config.log_min = -0.192321;
-    _retinex_config.log_max = 0.122745;
-    _retinex_config.gain = 255.0 / (_retinex_config.log_max - _retinex_config.log_min);
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
 
-    _image_in = new CLVaImage (context, input);
-    _image_out = new CLVaImage (context, output);
-    _g_table_buffer = new CLBuffer(
-        context, sizeof(float)*XCAM_RETINEX_TABLE_SIZE * XCAM_RETINEX_TABLE_SIZE,
-        CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR , &_g_table);
+    SmartPtr<CLContext> context = get_context ();
+    const VideoBufferInfo &input_info = input->get_video_info ();
+    _pixel_format = input_info.format;
+
+    XCAM_UNUSED (output);
+    SmartPtr<DrmBoBuffer> scaler_buf = _scaler->get_scaler_buf ();
+    XCAM_ASSERT (scaler_buf.ptr ());
+
+    const VideoBufferInfo & output_info = scaler_buf->get_video_info ();
+    CLImageDesc output_imageDesc;
+    uint32_t channel_bits = XCAM_ALIGN_UP (output_info.color_bits, 8);
+    if (channel_bits == 8)
+        output_imageDesc.format.image_channel_data_type = CL_UNSIGNED_INT8;
+    else if (channel_bits == 16)
+        output_imageDesc.format.image_channel_data_type = CL_UNSIGNED_INT16;
+
+    if ((CL_IMAGE_SCALER_NV12_UV == get_mem_layout ()) && (V4L2_PIX_FMT_NV12 == input_info.format)) {
+        output_imageDesc.format.image_channel_order = CL_RG;
+        output_imageDesc.width = output_info.width / 2;
+        output_imageDesc.height = output_info.height / 2;
+        output_imageDesc.row_pitch = output_info.strides[1];
+
+        _cl_image_out = new CLVaImage (context, scaler_buf, output_imageDesc, output_info.offsets[1]);
+        _output_width = output_info.width / 2;
+        _output_height = output_info.height / 2;
+    } else {
+        output_imageDesc.format.image_channel_order = CL_R;
+        output_imageDesc.width = output_info.width;
+        output_imageDesc.height = output_info.height;
+        output_imageDesc.row_pitch = output_info.strides[0];
+
+        _cl_image_out = new CLVaImage (context, scaler_buf, output_imageDesc, 0);
+        _output_width = output_info.width;
+        _output_height = output_info.height;
+    }
+
+    CLImageDesc input_imageDesc;
+    channel_bits = XCAM_ALIGN_UP (input_info.color_bits, 8);
+    if (channel_bits == 8)
+        input_imageDesc.format.image_channel_data_type = CL_UNSIGNED_INT8;
+    else if (channel_bits == 16)
+        input_imageDesc.format.image_channel_data_type = CL_UNSIGNED_INT16;
+
+    if ((CL_IMAGE_SCALER_NV12_UV == get_mem_layout ()) && (V4L2_PIX_FMT_NV12 == input_info.format)) {
+        input_imageDesc.format.image_channel_order = CL_RG;
+        input_imageDesc.width = input_info.width / 2;
+        input_imageDesc.height = input_info.height / 2;
+        input_imageDesc.row_pitch = input_info.strides[1];
+
+        _image_in = new CLVaImage (context, input, input_imageDesc, input_info.offsets[1]);
+    } else {
+        input_imageDesc.format.image_channel_order = CL_R;
+        input_imageDesc.width = input_info.width;
+        input_imageDesc.height = input_info.height;
+        input_imageDesc.row_pitch = input_info.strides[0];
+
+        _image_in = new CLVaImage (context, input, input_imageDesc, 0);
+    }
+
+    //set args;
+    args[0].arg_adress = &_image_in->get_mem_id ();
+    args[0].arg_size = sizeof (cl_mem);
+    args[1].arg_adress = &_cl_image_out->get_mem_id ();
+    args[1].arg_size = sizeof (cl_mem);
+    args[2].arg_adress = &_output_width;
+    args[2].arg_size = sizeof (_output_width);
+    args[3].arg_adress = &_output_height;
+    args[3].arg_size = sizeof (_output_height);
+    arg_count = 4;
+
+    work_size.dim = XCAM_DEFAULT_IMAGE_DIM;
+    work_size.global[0] = _output_width;
+    work_size.global[1] = _output_height;
+    work_size.local[0] = 4;
+    work_size.local[1] = 4;
+
+    return ret;
+}
+
+XCamReturn
+CLRetinexScalerImageKernel::post_execute (SmartPtr<DrmBoBuffer> &output)
+{
+    XCAM_UNUSED (output);
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+
+    if ((V4L2_PIX_FMT_NV12 != get_pixel_format ()) ||
+            ((CL_IMAGE_SCALER_NV12_UV == get_mem_layout ()) && (V4L2_PIX_FMT_NV12 == get_pixel_format ()))) {
+        get_context ()->finish();
+        _image_in.release ();
+    }
+    return ret;
+}
+
+void
+CLRetinexScalerImageKernel::pre_stop ()
+{
+    if (_scaler.ptr ())
+        _scaler.ptr ()->pre_stop ();
+}
+
+CLRetinexGaussImageKernel::CLRetinexGaussImageKernel (SmartPtr<CLContext> &context,
+    SmartPtr<CLRetinexImageHandler> &scaler)
+    :  CLGaussImageKernel (context),
+    _scaler(scaler)
+{
+}
+
+XCamReturn
+CLRetinexGaussImageKernel::prepare_arguments (
+    SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
+    CLArgument args[], uint32_t &arg_count,
+    CLWorkSize &work_size)
+{
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+
+    XCAM_UNUSED (input);
+    XCAM_UNUSED (output);
+
+    SmartPtr<CLContext> context = get_context ();
+
+    SmartPtr<DrmBoBuffer> scaler_buf = _scaler->get_scaler_buf ();
+    XCAM_ASSERT (scaler_buf.ptr ());
+
+    const VideoBufferInfo & buf_info = scaler_buf->get_video_info ();
+
+    _image_in = new CLVaImage (context, scaler_buf);
+    _image_out = new CLVaImage (context, scaler_buf);
 
     XCAM_ASSERT (_image_in->is_valid () && _image_out->is_valid ());
     XCAM_FAIL_RETURN (
@@ -79,8 +174,12 @@ CLRetinexImageKernel::prepare_arguments (
         XCAM_RETURN_ERROR_MEM,
         "cl image kernel(%s) in/out memory not available", get_kernel_name ());
 
-    _vertical_offset_in = video_info_in.aligned_height;
-    _vertical_offset_out = video_info_out.aligned_height;
+    _vertical_offset_in = buf_info.aligned_height;
+    _vertical_offset_out= buf_info.aligned_height;
+
+    _g_table_buffer = new CLBuffer(
+        context, sizeof(float)*XCAM_GAUSS_TABLE_SIZE*XCAM_GAUSS_TABLE_SIZE,
+        CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR , &_g_table);
 
     //set args;
     args[0].arg_adress = &_image_in->get_mem_id ();
@@ -91,10 +190,71 @@ CLRetinexImageKernel::prepare_arguments (
     args[2].arg_size = sizeof (_vertical_offset_in);
     args[3].arg_adress = &_vertical_offset_out;
     args[3].arg_size = sizeof (_vertical_offset_out);
-    args[4].arg_adress = &_retinex_config;
-    args[4].arg_size = sizeof (CLRetinexConfig);
-    args[5].arg_adress = &_g_table_buffer->get_mem_id();
-    args[5].arg_size = sizeof (cl_mem);
+    args[4].arg_adress = &_g_table_buffer->get_mem_id();
+    args[4].arg_size = sizeof (cl_mem);
+    arg_count = 5;
+
+    work_size.dim = XCAM_DEFAULT_IMAGE_DIM;
+    work_size.global[0] = buf_info.width;
+    work_size.global[1] = buf_info.height;
+    work_size.local[0] = 4;
+    work_size.local[1] = 4;
+
+    return ret;
+}
+
+CLRetinexImageKernel::CLRetinexImageKernel (SmartPtr<CLContext> &context, SmartPtr<CLRetinexImageHandler> &scaler)
+    : CLImageKernel (context, "kernel_retinex"),
+    _scaler(scaler)
+{
+}
+
+XCamReturn
+CLRetinexImageKernel::prepare_arguments (
+    SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
+    CLArgument args[], uint32_t &arg_count,
+    CLWorkSize &work_size)
+{
+    SmartPtr<CLContext> context = get_context ();
+    const VideoBufferInfo & video_info_in = input->get_video_info ();
+    const VideoBufferInfo & video_info_out = output->get_video_info ();
+    _retinex_config.log_min = -0.2;
+    _retinex_config.log_max = 0.4;
+    _retinex_config.gain = 255.0 / (_retinex_config.log_max - _retinex_config.log_min);
+    _retinex_config.width = (float)video_info_in.width;
+    _retinex_config.height = (float)video_info_in.height;
+
+    SmartPtr<DrmBoBuffer> scaler_buf = _scaler->get_scaler_buf ();
+    XCAM_ASSERT (scaler_buf.ptr ());
+
+    _image_in_ga = new CLVaImage (context, scaler_buf);
+    _image_in = new CLVaImage (context, input);
+    _image_out = new CLVaImage (context, output);
+
+    XCAM_ASSERT (_image_in->is_valid () && _image_out->is_valid () && _image_in->is_valid());
+    XCAM_FAIL_RETURN (
+        WARNING,
+        _image_in->is_valid () && _image_out->is_valid () && _image_in->is_valid(),
+        XCAM_RETURN_ERROR_MEM,
+        "cl image kernel(%s) in/out memory not available", get_kernel_name ());
+
+    _vertical_offset_in = video_info_in.aligned_height;
+    _vertical_offset_out = video_info_out.aligned_height;
+
+    //set args;
+    args[0].arg_adress = &_image_in->get_mem_id ();
+    args[0].arg_size = sizeof (cl_mem);
+    args[1].arg_adress = &_image_in_ga->get_mem_id ();
+    args[1].arg_size = sizeof (cl_mem);
+    args[2].arg_adress = &_image_out->get_mem_id ();
+    args[2].arg_size = sizeof (cl_mem);
+    args[3].arg_adress = &_vertical_offset_in;
+    args[3].arg_size = sizeof (_vertical_offset_in);
+    args[4].arg_adress = &_vertical_offset_out;
+    args[4].arg_size = sizeof (_vertical_offset_out);
+    args[5].arg_adress = &_retinex_config;
+    args[5].arg_size = sizeof (CLRetinexConfig);
+
     arg_count = 6;
 
     work_size.dim = XCAM_DEFAULT_IMAGE_DIM;
@@ -108,14 +268,63 @@ CLRetinexImageKernel::prepare_arguments (
 
 CLRetinexImageHandler::CLRetinexImageHandler (const char *name)
     : CLImageHandler (name)
+    ,_scaler_factor(0.5)
 {
 }
 
-bool
-CLRetinexImageHandler::set_gaussian_table (int size, float sigma)
+void
+CLRetinexImageHandler::pre_stop ()
 {
-    _retinex_kernel->set_gaussian (size, sigma);
-    return true;
+    if (_scaler_buf_pool.ptr ())
+        _scaler_buf_pool->stop ();
+}
+
+XCamReturn
+CLRetinexImageHandler::prepare_output_buf (SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output)
+{
+    CLImageHandler::prepare_output_buf(input, output);
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+    ret = prepare_scaler_buf (input->get_video_info (), _scaler_buf);
+    XCAM_FAIL_RETURN(
+        WARNING,
+        ret == XCAM_RETURN_NO_ERROR,
+        ret,
+        "CLImageScalerKernel prepare scaled video buf failed");
+
+    _scaler_buf->set_timestamp (input->get_timestamp ());
+
+    return XCAM_RETURN_NO_ERROR;
+
+}
+
+XCamReturn
+CLRetinexImageHandler::prepare_scaler_buf (const VideoBufferInfo &video_info, SmartPtr<DrmBoBuffer> &output)
+{
+    SmartPtr<BufferProxy> buffer;
+    SmartPtr<DrmDisplay> display;
+
+    if (!_scaler_buf_pool.ptr ()) {
+        VideoBufferInfo scaler_video_info;
+        uint32_t new_width = XCAM_ALIGN_UP ((uint32_t)(video_info.width * _scaler_factor),
+                                            2 * XCAM_CL_IMAGE_SCALER_KERNEL_LOCAL_WORK_SIZE);
+        uint32_t new_height = XCAM_ALIGN_UP ((uint32_t)(video_info.height * _scaler_factor),
+                                             2 * XCAM_CL_IMAGE_SCALER_KERNEL_LOCAL_WORK_SIZE);
+
+        scaler_video_info.init (video_info.format, new_width, new_height);
+
+        display = DrmDisplay::instance ();
+        XCAM_ASSERT (display.ptr ());
+        _scaler_buf_pool = new ScaledVideoBufferPool (display);
+        _scaler_buf_pool->set_video_info (scaler_video_info);
+        _scaler_buf_pool->reserve (6);
+    }
+
+    buffer = _scaler_buf_pool->get_buffer (_scaler_buf_pool);
+    XCAM_ASSERT (buffer.ptr ());
+
+    output = buffer.dynamic_cast_ptr<DrmBoBuffer> ();
+    XCAM_ASSERT (output.ptr ());
+    return XCAM_RETURN_NO_ERROR;
 }
 
 bool
@@ -127,14 +336,68 @@ CLRetinexImageHandler::set_retinex_kernel(SmartPtr<CLRetinexImageKernel> &kernel
     return true;
 }
 
+bool
+CLRetinexImageHandler::set_retinex_scaler_kernel(SmartPtr<CLRetinexScalerImageKernel> &kernel)
+{
+    SmartPtr<CLImageKernel> image_kernel = kernel;
+    add_kernel (image_kernel);
+    _retinex_scaler_kernel = kernel;
+    return true;
+}
+
+bool
+CLRetinexImageHandler::set_retinex_gauss_kernel(SmartPtr<CLRetinexGaussImageKernel> &kernel)
+{
+    SmartPtr<CLImageKernel> image_kernel = kernel;
+    add_kernel (image_kernel);
+    _retinex_gauss_kernel = kernel;
+    return true;
+}
+
 SmartPtr<CLImageHandler>
 create_cl_retinex_image_handler (SmartPtr<CLContext> &context)
 {
     SmartPtr<CLRetinexImageHandler> retinex_handler;
+
+    SmartPtr<CLRetinexScalerImageKernel> retinex_scaler_kernel;
+    SmartPtr<CLRetinexGaussImageKernel> retinex_gauss_kernel;
     SmartPtr<CLRetinexImageKernel> retinex_kernel;
+
     XCamReturn ret = XCAM_RETURN_NO_ERROR;
 
-    retinex_kernel = new CLRetinexImageKernel (context);
+    retinex_handler = new CLRetinexImageHandler ("cl_handler_retinex");
+
+    retinex_scaler_kernel = new CLRetinexScalerImageKernel (context, CL_IMAGE_SCALER_NV12_Y, retinex_handler);
+    {
+        XCAM_CL_KERNEL_FUNC_SOURCE_BEGIN(kernel_image_scaler)
+#include "kernel_image_scaler.clx"
+        XCAM_CL_KERNEL_FUNC_END;
+        ret = retinex_scaler_kernel->load_from_source (kernel_image_scaler_body, strlen (kernel_image_scaler_body));
+        XCAM_FAIL_RETURN (
+            WARNING,
+             ret == XCAM_RETURN_NO_ERROR,
+             NULL,
+             "CL image handler(%s) load source failed", retinex_scaler_kernel->get_kernel_name());
+    }
+    XCAM_ASSERT (retinex_scaler_kernel->is_valid ());
+    retinex_handler->set_retinex_scaler_kernel (retinex_scaler_kernel);
+
+    retinex_gauss_kernel = new CLRetinexGaussImageKernel (context, retinex_handler);
+    {
+        XCAM_CL_KERNEL_FUNC_SOURCE_BEGIN(kernel_gauss)
+#include "kernel_gauss.clx"
+        XCAM_CL_KERNEL_FUNC_END;
+        ret = retinex_gauss_kernel->load_from_source (kernel_gauss_body, strlen (kernel_gauss_body));
+        XCAM_FAIL_RETURN (
+            WARNING,
+            ret == XCAM_RETURN_NO_ERROR,
+            NULL,
+            "CL image handler(%s) load source failed", retinex_gauss_kernel->get_kernel_name());
+    }
+    XCAM_ASSERT (retinex_gauss_kernel->is_valid ());
+    retinex_handler->set_retinex_gauss_kernel (retinex_gauss_kernel);
+
+    retinex_kernel = new CLRetinexImageKernel (context, retinex_handler);
     {
         XCAM_CL_KERNEL_FUNC_SOURCE_BEGIN(kernel_retinex)
 #include "kernel_retinex.clx"
@@ -147,7 +410,6 @@ create_cl_retinex_image_handler (SmartPtr<CLContext> &context)
             "CL image handler(%s) load source failed", retinex_kernel->get_kernel_name());
     }
     XCAM_ASSERT (retinex_kernel->is_valid ());
-    retinex_handler = new CLRetinexImageHandler ("cl_handler_retinex");
     retinex_handler->set_retinex_kernel (retinex_kernel);
 
     return retinex_handler;

--- a/xcore/cl_retinex_handler.h
+++ b/xcore/cl_retinex_handler.h
@@ -25,7 +25,8 @@
 #include "cl_image_handler.h"
 #include "base/xcam_3a_result.h"
 #include "x3a_stats_pool.h"
-
+#include "cl_image_scaler.h"
+#include "cl_gauss_handler.h"
 
 #define XCAM_RETINEX_TABLE_SIZE 5
 #define XCAM_RETINEX_SCALE 3
@@ -36,15 +37,53 @@ typedef struct {
     float           threshold;
     float           log_min;
     float           log_max;
+    float           width;
+    float           height;
 } CLRetinexConfig;
+
+class CLRetinexImageHandler;
+
+class CLRetinexScalerImageKernel
+    : public CLScalerKernel
+{
+public:
+    explicit CLRetinexScalerImageKernel (SmartPtr<CLContext> &context, CLImageScalerMemoryLayout mem_layout, SmartPtr<CLRetinexImageHandler> &scaler);
+    virtual XCamReturn prepare_arguments (
+        SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
+        CLArgument args[], uint32_t &arg_count,
+        CLWorkSize &work_size);
+    virtual XCamReturn post_execute (SmartPtr<DrmBoBuffer> &output);
+    virtual void pre_stop ();
+
+private:
+    XCAM_DEAD_COPY (CLRetinexScalerImageKernel);
+    SmartPtr<CLRetinexImageHandler> _scaler;
+
+};
+
+class CLRetinexGaussImageKernel
+    : public CLGaussImageKernel
+{
+public:
+    explicit CLRetinexGaussImageKernel (SmartPtr<CLContext> &context, SmartPtr<CLRetinexImageHandler> &scaler);
+    virtual XCamReturn prepare_arguments (
+        SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
+        CLArgument args[], uint32_t &arg_count,
+        CLWorkSize &work_size);
+//    virtual XCamReturn post_execute (SmartPtr<DrmBoBuffer> &output);
+//    virtual void pre_stop ();
+
+private:
+    XCAM_DEAD_COPY (CLRetinexGaussImageKernel);
+    SmartPtr<CLRetinexImageHandler> _scaler;
+
+};
 
 class CLRetinexImageKernel
     : public CLImageKernel
 {
 public:
-    explicit CLRetinexImageKernel (SmartPtr<CLContext> &context);
-    bool set_gaussian(int size, float sigma);
-    bool get_retinex_log_value (XCam3AStats * stats);
+    explicit CLRetinexImageKernel (SmartPtr<CLContext> &context, SmartPtr<CLRetinexImageHandler> &scaler);
 
 protected:
     virtual XCamReturn prepare_arguments (
@@ -54,11 +93,11 @@ protected:
 
 private:
     XCAM_DEAD_COPY (CLRetinexImageKernel);
+    CLRetinexConfig _retinex_config;
+    SmartPtr<CLImage>   _image_in_ga;
     uint32_t _vertical_offset_in;
     uint32_t _vertical_offset_out;
-    CLRetinexConfig _retinex_config;
-    SmartPtr<CLBuffer>  _g_table_buffer;
-    float _g_table[XCAM_RETINEX_TABLE_SIZE*XCAM_RETINEX_TABLE_SIZE];
+    SmartPtr<CLRetinexImageHandler> _scaler;
 };
 
 class CLRetinexImageHandler
@@ -67,11 +106,25 @@ class CLRetinexImageHandler
 public:
     explicit CLRetinexImageHandler (const char *name);
     bool set_retinex_kernel(SmartPtr<CLRetinexImageKernel> &kernel);
-    bool set_gaussian_table(int size, float sigma);
+    bool set_retinex_scaler_kernel(SmartPtr<CLRetinexScalerImageKernel> &kernel);
+    bool set_retinex_gauss_kernel(SmartPtr<CLRetinexGaussImageKernel> &kernel);
+    SmartPtr<DrmBoBuffer> &get_scaler_buf () {
+        return _scaler_buf;
+    };
+    void pre_stop ();
+
+protected:
+    virtual XCamReturn prepare_output_buf (SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output);
+    XCamReturn prepare_scaler_buf (const VideoBufferInfo &video_info, SmartPtr<DrmBoBuffer> &output);
 
 private:
     XCAM_DEAD_COPY (CLRetinexImageHandler);
     SmartPtr<CLRetinexImageKernel> _retinex_kernel;
+    SmartPtr<CLRetinexScalerImageKernel> _retinex_scaler_kernel;
+    SmartPtr<CLRetinexGaussImageKernel> _retinex_gauss_kernel;
+    SmartPtr<ScaledVideoBufferPool> _scaler_buf_pool;
+    SmartPtr<DrmBoBuffer>   _scaler_buf;
+    double _scaler_factor;
 };
 
 SmartPtr<CLImageHandler>


### PR DESCRIPTION
  * gst-launch-1.0 test cmdline:
     Command on device:
      $ gst-launch-1.0 xcamsrc io-mode=4 imageprocessor=1 analyzer=2\
        pipe-profile=2 enable-retinex=true ! video/x-raw,format=NV12,\
        width=1920, height=1080, framerate=25/1 ! queue ! \
        vaapiencode_h264 rate-control=cbr ! tcpclientsink host="$IP"\
        port=3000 sync=false
     Command on Linux server:
      $ gst-launch-1.0 -v tcpserversrc host=0.0.0.0 port=3000 ! \
        queue max-size-bytes=0 ! h264parse  ! queue ! avdec_h264 \
        ! videoconvert ! video/x-raw, format=BGRx | ximagesinksync=false