### PR TITLE
tests: fix capture-raw-data failure issue

### DIFF
--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -320,6 +320,7 @@ void print_help (const char *bin_name)
             "\t --wavelet-mode  specify wavelet mode\n"
             "\t --pipeline    pipe mode\n"
             "\t               select from [basic, advance, extreme], default is [basic]\n"
+            "\t --disable-post disable cl post image processor\n"
             "(e.g.: xxxx --hdr=xx --tnr=xx --tnr-level=xx --bilateral --enable-snr --enable-ee --enable-bnr --enable-dpc)\n\n"
 #endif
             , bin_name
@@ -355,6 +356,7 @@ int main (int argc, char *argv[])
     CL3aImageProcessor::CaptureStage capture_stage = CL3aImageProcessor::TonemappingStage;
 #endif
     bool have_cl_processor = false;
+    bool have_cl_post_processor = true;
     bool need_display = false;
     enum v4l2_memory v4l2_mem_type = V4L2_MEMORY_MMAP;
     const char *bin_name = argv[0];
@@ -394,6 +396,7 @@ int main (int argc, char *argv[])
         {"sync", no_argument, NULL, 'Y'},
         {"capture", required_argument, NULL, 'C'},
         {"pipeline", required_argument, NULL, 'P'},
+        {"disable-post", no_argument, NULL, 'O'},
         {0, 0, 0, 0},
     };
 
@@ -607,6 +610,10 @@ int main (int argc, char *argv[])
                 capture_stage = CL3aImageProcessor::BasicbayerStage;
             break;
         }
+        case 'O': {
+            have_cl_post_processor = false;
+            break;
+        }
 #endif
         case 'r': {
             if (optarg) {
@@ -757,14 +764,16 @@ int main (int argc, char *argv[])
         device_manager->add_image_processor (cl_processor);
     }
 
-    cl_post_processor = new CLPostImageProcessor ();
+    if (have_cl_post_processor) {
+        cl_post_processor = new CLPostImageProcessor ();
 
-    cl_post_processor->set_retinex (retinex_type);
+        cl_post_processor->set_retinex (retinex_type);
 
-    if ((display_mode == DRM_DISPLAY_MODE_PRIMARY) && need_display) {
-        cl_post_processor->set_output_format (V4L2_PIX_FMT_XBGR32);
+        if ((display_mode == DRM_DISPLAY_MODE_PRIMARY) && need_display) {
+            cl_post_processor->set_output_format (V4L2_PIX_FMT_XBGR32);
+        }
+        device_manager->add_image_processor (cl_post_processor);
     }
-    device_manager->add_image_processor (cl_post_processor);
 #endif
 
     SmartPtr<PollThread> poll_thread;


### PR DESCRIPTION
  * add --disable-post to disable cl post image processor
  * test cmdline:
    # test-device-manager -f BA12 -m mmap -d still -s -i 1000 \
      -n 100 --disable-post
    # test-device-manager -f BA10 -m mmap -d still -s -i 1000 \
      -n 100 --disable-post