### PR TITLE
tests: fix overlay mode display failed issue

### DIFF
--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -761,7 +761,7 @@ int main (int argc, char *argv[])
 
         cl_post_processor->set_retinex (retinex_type);
 
-        if ((display_mode == DRM_DISPLAY_MODE_PRIMARY) && need_display) {
+        if (need_display) {
             cl_post_processor->set_output_format (V4L2_PIX_FMT_XBGR32);
         }
         device_manager->add_image_processor (cl_post_processor);

--- a/xcore/cl_csc_handler.cpp
+++ b/xcore/cl_csc_handler.cpp
@@ -180,6 +180,20 @@ CLCscImageHandler::set_rgbtoyuv_matrix (const XCam3aResultColorMatrix &matrix)
     return true;
 }
 
+bool
+CLCscImageHandler::set_output_format (uint32_t fourcc)
+{
+    XCAM_FAIL_RETURN (
+        WARNING,
+        V4L2_PIX_FMT_XBGR32 == fourcc || V4L2_PIX_FMT_NV12 == fourcc,
+        false,
+        "CL csc handler doesn't support format: (%s)",
+        xcam_fourcc_to_string (fourcc));
+
+    _output_format = fourcc;
+    return true;
+}
+
 XCamReturn
 CLCscImageHandler::prepare_buffer_pool_video_info (
     const VideoBufferInfo &input,

--- a/xcore/cl_csc_handler.h
+++ b/xcore/cl_csc_handler.h
@@ -67,6 +67,7 @@ public:
     explicit CLCscImageHandler (const char *name, CLCscType type);
     bool set_csc_kernel(SmartPtr<CLCscImageKernel> &kernel);
     bool set_rgbtoyuv_matrix (const XCam3aResultColorMatrix &matrix);
+    bool set_output_format (uint32_t fourcc);
 
 protected:
     virtual XCamReturn prepare_buffer_pool_video_info (

--- a/xcore/cl_post_image_processor.cpp
+++ b/xcore/cl_post_image_processor.cpp
@@ -100,6 +100,7 @@ CLPostImageProcessor::create_handlers ()
         XCAM_RETURN_ERROR_CL,
         "CLPostImageProcessor create csc handler failed");
     _csc->set_kernels_enable (_out_sample_type == OutSampleRGB);
+    _csc->set_output_format (_output_fourcc);
     image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
     image_handler->set_pool_size (XCAM_CL_POST_IMAGE_DEFAULT_POOL_SIZE);
     add_handler (image_handler);


### PR DESCRIPTION
  * specify output format in csc handler for preview
  * test command line:
    # test-device-manager -m dma -c -f BA10 -d still -p -a dynamic \
      --pipeline=extreme -e overlay
    # test-device-manager -m dma -f NV12 -d video -p -a aiq -e overlay
  * usbcam test command line:
    # test-device-manager -m dma -f NV12 -d video -e overlay -p \
      --disable-post --usb /dev/videoX --resolution 1920x1080
    # test-device-manager -m dma -f YUYV -d video -e overlay -p \
      --disable-post --usb /dev/videoX --resolution 1920x1080