### PR TITLE
cl-retinex: enable tnr for retinex to reduce noise

### DIFF
--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -70,7 +70,7 @@ typedef enum {
 
 typedef enum {
     SIMPLE_ANALYZER = 0,
-    AIQ_ANALYZER,
+    AIQ_TUNER_ANALYZER,
     DYNAMIC_ANALYZER,
     HYBRID_ANALYZER,
 } AnalyzerType;

--- a/xcore/cl_post_image_processor.cpp
+++ b/xcore/cl_post_image_processor.cpp
@@ -22,6 +22,7 @@
 #include "cl_post_image_processor.h"
 #include "cl_context.h"
 
+#include "cl_tnr_handler.h"
 #include "cl_retinex_handler.h"
 #include "cl_csc_handler.h"
 
@@ -34,6 +35,7 @@ CLPostImageProcessor::CLPostImageProcessor ()
     : CLImageProcessor ("CLPostImageProcessor")
     , _output_fourcc (V4L2_PIX_FMT_NV12)
     , _out_sample_type (OutSampleYuv)
+    , _tnr_mode (TnrYuv)
     , _enable_retinex (false)
 {
     XCAM_LOG_DEBUG ("CLPostImageProcessor constructed");
@@ -71,6 +73,75 @@ CLPostImageProcessor::set_output_format (uint32_t fourcc)
     return true;
 }
 
+bool
+CLPostImageProcessor::can_process_result (SmartPtr < X3aResult > & result)
+{
+    if (!result.ptr ())
+        return false;
+
+    switch (result->get_type ()) {
+    case XCAM_3A_RESULT_TEMPORAL_NOISE_REDUCTION_YUV:
+        return true;
+    default:
+        return false;
+    }
+
+    return false;
+}
+
+XCamReturn
+CLPostImageProcessor::apply_3a_results (X3aResultList &results)
+{
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+
+    for (X3aResultList::iterator iter = results.begin (); iter != results.end (); ++iter)
+    {
+        SmartPtr<X3aResult> &result = *iter;
+        ret = apply_3a_result (result);
+        if (ret != XCAM_RETURN_NO_ERROR)
+            break;
+    }
+
+    return ret;
+}
+
+XCamReturn
+CLPostImageProcessor::apply_3a_result (SmartPtr<X3aResult> &result)
+{
+    STREAM_LOCK;
+
+    if (!result.ptr ())
+        return XCAM_RETURN_BYPASS;
+
+    uint32_t res_type = result->get_type ();
+
+    switch (res_type) {
+    case XCAM_3A_RESULT_TEMPORAL_NOISE_REDUCTION_YUV: {
+        SmartPtr<X3aTemporalNoiseReduction> tnr_res = result.dynamic_cast_ptr<X3aTemporalNoiseReduction> ();
+        XCAM_ASSERT (tnr_res.ptr ());
+        if (_tnr.ptr ()) {
+            if (_enable_retinex) {
+                XCam3aResultTemporalNoiseReduction config;
+                xcam_mem_clear (config);
+                config.gain = 0.22;
+                config.threshold [0] = 0.00081;
+                config.threshold [1] = 0.00072;
+                _tnr->set_yuv_config (config);
+            } else {
+                _tnr->set_yuv_config (tnr_res->get_standard_result ());
+            }
+        }
+        break;
+    }
+    default:
+        XCAM_LOG_WARNING ("CLPostImageProcessor unknow 3a result: %d", res_type);
+        break;
+    }
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+
 XCamReturn
 CLPostImageProcessor::create_handlers ()
 {
@@ -79,7 +150,7 @@ CLPostImageProcessor::create_handlers ()
 
     XCAM_ASSERT (context.ptr ());
 
-    /* retinex*/
+    /* retinex */
     image_handler = create_cl_retinex_image_handler (context);
     _retinex = image_handler.dynamic_cast_ptr<CLRetinexImageHandler> ();
     XCAM_FAIL_RETURN (
@@ -92,6 +163,33 @@ CLPostImageProcessor::create_handlers ()
     image_handler->set_pool_size (XCAM_CL_POST_IMAGE_MAX_POOL_SIZE);
     add_handler (image_handler);
 
+    /* Temporal Noise Reduction */
+    if (_enable_retinex) {
+        switch (_tnr_mode) {
+        case TnrYuv: {
+            image_handler = create_cl_tnr_image_handler (context, CL_TNR_TYPE_YUV);
+            _tnr = image_handler.dynamic_cast_ptr<CLTnrImageHandler> ();
+            XCAM_FAIL_RETURN (
+                WARNING,
+                _tnr.ptr (),
+                XCAM_RETURN_ERROR_CL,
+                "CLPostImageProcessor create tnr handler failed");
+            _tnr->set_mode (CL_TNR_TYPE_YUV);
+            image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+            image_handler->set_pool_size (XCAM_CL_POST_IMAGE_DEFAULT_POOL_SIZE);
+            add_handler (image_handler);
+            break;
+        }
+        case TnrDisable:
+            XCAM_LOG_DEBUG ("CLPostImageProcessor disable tnr");
+            break;
+        default:
+            XCAM_LOG_WARNING ("CLPostImageProcessor unknown tnr mode (%d)", _tnr_mode);
+            break;
+        }
+    }
+
+    /* csc (nv12torgba) */
     image_handler = create_cl_csc_image_handler (context, CL_CSC_TYPE_NV12TORGBA);
     _csc = image_handler.dynamic_cast_ptr<CLCscImageHandler> ();
     XCAM_FAIL_RETURN (
@@ -106,6 +204,16 @@ CLPostImageProcessor::create_handlers ()
     add_handler (image_handler);
 
     return XCAM_RETURN_NO_ERROR;
+}
+
+bool
+CLPostImageProcessor::set_tnr (CLTnrMode mode)
+{
+    _tnr_mode = mode;
+
+    STREAM_LOCK;
+
+    return true;
 }
 
 bool

--- a/xcore/cl_post_image_processor.h
+++ b/xcore/cl_post_image_processor.h
@@ -23,10 +23,12 @@
 #define XCAM_CL_POST_IMAGE_PROCESSOR_H
 
 #include "xcam_utils.h"
+#include <base/xcam_3a_types.h>
 #include "cl_image_processor.h"
 
 namespace XCam {
 
+class CLTnrImageHandler;
 class CLRetinexImageHandler;
 class CLCscImageHandler;
 
@@ -40,13 +42,24 @@ public:
         OutSampleBayer,
     };
 
+    enum CLTnrMode {
+        TnrDisable = 0,
+        TnrYuv,
+    };
+
 public:
     explicit CLPostImageProcessor ();
     virtual ~CLPostImageProcessor ();
 
     bool set_output_format (uint32_t fourcc);
 
+    virtual bool set_tnr (CLTnrMode mode);
     virtual bool set_retinex (bool enable);
+
+protected:
+    virtual bool can_process_result (SmartPtr<X3aResult> &result);
+    virtual XCamReturn apply_3a_results (X3aResultList &results);
+    virtual XCamReturn apply_3a_result (SmartPtr<X3aResult> &result);
 
 private:
     virtual XCamReturn create_handlers ();
@@ -56,9 +69,12 @@ private:
 private:
     uint32_t                               _output_fourcc;
     OutSampleType                          _out_sample_type;
+
+    SmartPtr<CLTnrImageHandler>            _tnr;
     SmartPtr<CLRetinexImageHandler>        _retinex;
     SmartPtr<CLCscImageHandler>            _csc;
 
+    CLTnrMode                              _tnr_mode;
     bool                                   _enable_retinex;
 };
 

--- a/xcore/cl_tnr_handler.cpp
+++ b/xcore/cl_tnr_handler.cpp
@@ -17,8 +17,7 @@
  *
  * Author: Wei Zong <wei.zong@intel.com>
  */
-#include "xcam_utils.h"
-#include "x3a_stats_pool.h"
+
 #include "cl_tnr_handler.h"
 
 namespace XCam {

--- a/xcore/cl_tnr_handler.h
+++ b/xcore/cl_tnr_handler.h
@@ -22,8 +22,9 @@
 #define XCAM_CL_TNR_HANLDER_H
 
 #include "xcam_utils.h"
-#include "cl_image_handler.h"
 #include "base/xcam_3a_result.h"
+#include "x3a_stats_pool.h"
+#include "cl_image_handler.h"
 
 namespace XCam {
 


### PR DESCRIPTION
  * add AnalyzeTuner for ISP to get 3a parameters
  * test-dev-manager cmdline:
    # test-device-manager -m dma -c -f BA10 -d still -p -a dynamic \
      --pipeline=advance --enable-retinex
    # test-device-manager -m dma -f NV12 -d video -p -a aiq \
      --enable-retinex
  * gst-launch-1.0 cmdline:
    # gst-launch-1.0 xcamsrc io-mode=4 imageprocessor=1 analyzer=2 \
      pipe-profile=1 enable-retinex=true ! video/x-raw, format=NV12, \
      width=1920, height=1080, framerate=25/1 ! queue ! vaapiencode_h264 \
      rate-control=cbr ! tcpclientsink host="<host_ip>" port=3000 \
      blocksize=1024000 sync=false
    # gst-launch-1.0 xcamsrc sensor-id=3 io-mode=4 analyzer=1 \
      enable-retinex=true ! video/x-raw, format=NV12, width=1920, \
      height=1080, framerate=25/1 ! queue ! vaapiencode_h264 rate-control=cbr \
      ! tcpclientsink host="<host_ip>" port=3000 blocksize=1024000 sync=false