### PR TITLE
smart-lib/compile: fix sample undefined issue

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,7 +106,8 @@ if test "$enable_libcl" = "yes" && test "$HAVE_LIBCL" -eq 0; then
     PKG_CHECK_MODULES(LIBCL, [OpenCL], [HAVE_LIBCL=1], [HAVE_LIBCL=0])
 
     if test "$HAVE_LIBCL" -eq 1; then
-        LIBCL_LIBS="$LIBCL_LIBS  -I/usr/local/lib/beignet -lcl"
+        LIBCL_LIBS="$LIBCL_LIBS -lcl"
+        LDFLAGS="$LDFLAGS -L/usr/local/lib/beignet"
     fi
 fi
 

--- a/smartlib/sample_smart_analysis.cpp
+++ b/smartlib/sample_smart_analysis.cpp
@@ -74,6 +74,11 @@ FrameSaver::FrameSaver (bool save, uint32_t interval, uint32_t count)
 {
 }
 
+FrameSaver::~FrameSaver ()
+{
+    close_file ();
+}
+
 void
 FrameSaver::save_frame (XCamVideoBuffer *buffer)
 {


### PR DESCRIPTION
 * fix bug of FrameSaver destruction undefined
 * use LDFLAGS to hard-link beignet libcl support on Linux