### PR TITLE
cl-retinex: support 3 scale gaussian

### DIFF
--- a/cl_kernel/kernel_retinex.cl
+++ b/cl_kernel/kernel_retinex.cl
@@ -55,7 +55,8 @@ __kernel void kernel_retinex (
     __read_only image2d_t ga_input0,
 #if RETINEX_SCALE_SIZE > 1
     __read_only image2d_t ga_input1,
-#elif RETINEX_SCALE_SIZE > 2
+#endif
+#if RETINEX_SCALE_SIZE > 2
     __read_only image2d_t ga_input2,
 #endif
     __write_only image2d_t output_y, __write_only image2d_t output_uv,
@@ -101,6 +102,17 @@ __kernel void kernel_retinex (
     pos_ga.x += ga_x_step;
     y_ga[1].w = read_imagef(ga_input1, sampler_ga, pos_ga).x * 255.0f;
 #endif
+
+#if RETINEX_SCALE_SIZE > 2
+    y_ga[2].x = read_imagef(ga_input2, sampler_ga, pos_ga).x * 255.0f;
+    pos_ga.x += ga_x_step;
+    y_ga[2].y = read_imagef(ga_input2, sampler_ga, pos_ga).x * 255.0f;
+    pos_ga.x += ga_x_step;
+    y_ga[2].z = read_imagef(ga_input2, sampler_ga, pos_ga).x * 255.0f;
+    pos_ga.x += ga_x_step;
+    y_ga[2].w = read_imagef(ga_input2, sampler_ga, pos_ga).x * 255.0f;
+#endif
+
 
     y_lg = (float4) (0.0f, 0.0f, 0.0f, 0.0f);
 #pragma unroll

--- a/xcore/cl_retinex_handler.cpp
+++ b/xcore/cl_retinex_handler.cpp
@@ -376,8 +376,8 @@ create_cl_retinex_image_handler (SmartPtr<CLContext> &context)
         "Retinex handler create scaler kernel failed");
     retinex_handler->set_retinex_scaler_kernel (retinex_scaler_kernel);
 
-    uint32_t scale [2] = {2, 8};
-    float sigma [2] = {2.0f, 8.0f};
+    uint32_t scale [3] = {2, 8, 20};
+    float sigma [3] = {2.0f, 8.0f, 20.0f};
 
     for (uint32_t i = 0; i < XCAM_RETINEX_MAX_SCALE; ++i) {
         SmartPtr<CLImageKernel> retinex_gauss_kernel;


### PR DESCRIPTION
 * default is still 2-scale retinex
 * if want 3 scale, need #define XCAM_RETINEX_MAX_SCALE 3