### PR TITLE
cl_mem: support conversion from buffer to image2d

### DIFF
--- a/xcore/cl_memory.h
+++ b/xcore/cl_memory.h
@@ -226,7 +226,8 @@ public:
     explicit CLImage2D (
         SmartPtr<CLContext> &context,
         const CLImageDesc &cl_desc,
-        cl_mem_flags  flags = CL_MEM_READ_WRITE);
+        cl_mem_flags  flags = CL_MEM_READ_WRITE,
+        SmartPtr<CLBuffer> bind_buf = NULL);
 
     ~CLImage2D () {}
 
@@ -237,6 +238,9 @@ private:
         cl_mem_flags  flags);
 
     XCAM_DEAD_COPY (CLImage2D);
+
+private:
+    SmartPtr<CLBuffer> _bind_buf;
 };
 
 class CLImage2DArray


### PR DESCRIPTION
 * Usage:
    SmartPtr<CLBuffer> cl_buffer = new CLBuffer (
        context, sizeof(uint8_t) * width * height,
        CL_MEM_READ_WRITE, NULL);
    CLImageDesc cl_desc = {
        {CL_R, CL_UNSIGNED_INT8},
        width, height,
        sizeof(uint8_t) * width,
        0, 0, 0 };
    SmartPtr<CLImage2D> cl_image = new CLImage2D (
        context, cl_desc, 0, cl_buffer);