### PR TITLE
cl-wavelet: wavelet bayes shrink cl kernel performance improvement

### DIFF
--- a/cl_kernel/kernel_wavelet_coeff_thresholding.cl
+++ b/cl_kernel/kernel_wavelet_coeff_thresholding.cl
@@ -11,7 +11,7 @@ __kernel void kernel_wavelet_coeff_thresholding (float noise_var1, float noise_v
         __read_only image2d_t in_lh, __read_only image2d_t var_lh, __write_only image2d_t out_lh,
         __read_only image2d_t in_hh, __read_only image2d_t var_hh, __write_only image2d_t out_hh,
         int layer, int decomLevels,
-        float hardThresh, float softThresh)
+        float hardThresh, float softThresh, float ag_weight)
 {
     int x = get_global_id (0);
     int y = get_global_id (1);
@@ -56,9 +56,9 @@ __kernel void kernel_wavelet_coeff_thresholding (float noise_var1, float noise_v
     stddev_hh = coeff_var_hh - noise_var;
     stddev_hh = (stddev_hh > 0) ? sqrt(stddev_hh) : 0.000001;
 
-    thresh_hl = (noise_var / stddev_hl) / (255 * (1 << layer));
-    thresh_lh = (noise_var / stddev_lh) / (255 * (1 << layer));
-    thresh_hh = (noise_var / stddev_hh) / (255 * (1 << layer));
+    thresh_hl = (ag_weight * noise_var / stddev_hl) / (255 * (1 << layer));
+    thresh_lh = (ag_weight * noise_var / stddev_lh) / (255 * (1 << layer));
+    thresh_hh = (ag_weight * noise_var / stddev_hh) / (255 * (1 << layer));
 
     // Soft thresholding
     output_hl = (fabs(input_hl) < thresh_hl) ? 0 : ((input_hl > 0) ? fabs(input_hl) - thresh_hl : thresh_hl - fabs(input_hl));

--- a/cl_kernel/kernel_wavelet_coeff_variance.cl
+++ b/cl_kernel/kernel_wavelet_coeff_variance.cl
@@ -5,202 +5,158 @@
  * output: Wavelet coefficients variance
  */
 
+#define WG_CELL_X_SIZE 8
+#define WG_CELL_Y_SIZE 8
+
+#define SLM_CELL_X_OFFSET 1
+#define SLM_CELL_Y_OFFSET 2
+
+// 10x12
+#define SLM_CELL_X_SIZE (WG_CELL_X_SIZE + SLM_CELL_X_OFFSET * 2)
+#define SLM_CELL_Y_SIZE (WG_CELL_Y_SIZE + SLM_CELL_Y_OFFSET * 2)
+
 __kernel void kernel_wavelet_coeff_variance (__read_only image2d_t input, __write_only image2d_t output, int layer)
 {
-    int x = get_global_id (0);
-    int y = get_global_id (1);
     sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
 
-    float4 line0[3];
-    float4 line1[3];
-    float4 line2[3];
-    float4 line3[3];
-    float4 line4[3];
-    float4 line5[3];
-    float4 line6[3];
-    float4 line7[3];
+    int g_id_x = get_global_id (0);
+    int g_id_y = get_global_id (1);
 
-    float4 line_sum[8];
-    float4 line_var[4];
+    int group_id_x = get_group_id(0);
+    int group_id_y = get_group_id(1);
 
-    float offset = 0.5;
+    int local_id_x = get_local_id(0);
+    int local_id_y = get_local_id(1);
 
-    line0[0] = (read_imagef(input, sampler, (int2)(x - 1, 4 * y - 2)) - offset);
-    line0[1] = (read_imagef(input, sampler, (int2)(x, 4 * y - 2)) - offset);
-    line0[2] = (read_imagef(input, sampler, (int2)(x + 1, 4 * y - 2)) - offset);
+    int g_size_x = get_global_size (0);
+    int g_size_y = get_global_size (1);
 
-    line1[0] = (read_imagef(input, sampler, (int2)(x - 1, 4 * y - 1)) - offset);
-    line1[1] = (read_imagef(input, sampler, (int2)(x, 4 * y - 1)) - offset);
-    line1[2] = (read_imagef(input, sampler, (int2)(x + 1, 4 * y - 1)) - offset);
+    int l_size_x = get_local_size (0);
+    int l_size_y = get_local_size (1);
 
-    line2[0] = (read_imagef(input, sampler, (int2)(x - 1, 4 * y)) - offset);
-    line2[1] = (read_imagef(input, sampler, (int2)(x, 4 * y)) - offset);
-    line2[2] = (read_imagef(input, sampler, (int2)(x + 1, 4 * y)) - offset);
+    int local_index = local_id_y * WG_CELL_X_SIZE + local_id_x;
 
-    line3[0] = (read_imagef(input, sampler, (int2)(x - 1, 4 * y + 1)) - offset);
-    line3[1] = (read_imagef(input, sampler, (int2)(x, 2 * 4 * y + 1)) - offset);
-    line3[2] = (read_imagef(input, sampler, (int2)(x + 1, 4 * y + 1)) - offset);
+    float offset = 0.5f;
+    float4 line_sum[5] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    float4 line_var = 0.0f;
 
-    line4[0] = (read_imagef(input, sampler, (int2)(x - 1, 4 * y + 2)) - offset);
-    line4[1] = (read_imagef(input, sampler, (int2)(x, 4 * y + 2)) - offset);
-    line4[2] = (read_imagef(input, sampler, (int2)(x + 1, 4 * y + 2)) - offset);
+    __local float4 local_src_data[SLM_CELL_X_SIZE * SLM_CELL_Y_SIZE];
 
-    line5[0] = (read_imagef(input, sampler, (int2)(x - 1, 4 * y + 3)) - offset);
-    line5[1] = (read_imagef(input, sampler, (int2)(x, 4 * y + 3)) - offset);
-    line5[2] = (read_imagef(input, sampler, (int2)(x + 1, 4 * y + 3)) - offset);
+    int i = local_id_x + local_id_y * WG_CELL_X_SIZE;
+    int start_x = mad24(group_id_x, WG_CELL_X_SIZE, -SLM_CELL_X_OFFSET);
+    int start_y = mad24(group_id_y, WG_CELL_Y_SIZE, -SLM_CELL_Y_OFFSET);
 
-    line6[0] = (read_imagef(input, sampler, (int2)(x - 1, 4 * y + 4)) - offset);
-    line6[1] = (read_imagef(input, sampler, (int2)(x, 4 * y + 4)) - offset);
-    line6[2] = (read_imagef(input, sampler, (int2)(x + 1, 4 * y + 4)) - offset);
+    for (int j = i;  j < SLM_CELL_X_SIZE * SLM_CELL_Y_SIZE; j += WG_CELL_X_SIZE * WG_CELL_Y_SIZE)
+    {
+        int x = start_x - SLM_CELL_X_OFFSET + (j % SLM_CELL_X_SIZE);
+        int y = start_y - SLM_CELL_Y_OFFSET + (j / SLM_CELL_Y_SIZE);
+        local_src_data[j] = read_imagef (input, sampler, (int2)(x, y)) - offset;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
 
-    line7[0] = (read_imagef(input, sampler, (int2)(x - 1, 4 * y + 5)) - offset);
-    line7[1] = (read_imagef(input, sampler, (int2)(x, 4 * y + 5)) - offset);
-    line7[2] = (read_imagef(input, sampler, (int2)(x + 1, 4 * y + 5)) - offset);
+    float16 line0 = *((__local float16 *)(local_src_data + local_id_y * SLM_CELL_X_SIZE + local_id_x));
+    float16 line1 = *((__local float16 *)(local_src_data + (local_id_y + 1) * SLM_CELL_X_SIZE + local_id_x));
+    float16 line2 = *((__local float16 *)(local_src_data + (local_id_y + 2) * SLM_CELL_X_SIZE + local_id_x));
+    float16 line3 = *((__local float16 *)(local_src_data + (local_id_y + 3) * SLM_CELL_X_SIZE + local_id_x));
+    float16 line4 = *((__local float16 *)(local_src_data + (local_id_y + 4) * SLM_CELL_X_SIZE + local_id_x));
 
 #if WAVELET_DENOISE_Y
+    line_sum[0] = mad(line0.s0123, line0.s0123, line_sum[0]);
+    line_sum[0] = mad(line0.s1234, line0.s1234, line_sum[0]);
+    line_sum[0] = mad(line0.s2345, line0.s2345, line_sum[0]);
+    line_sum[0] = mad(line0.s3456, line0.s3456, line_sum[0]);
+    line_sum[0] = mad(line0.s4567, line0.s4567, line_sum[0]);
+    line_sum[0] = mad(line0.s5678, line0.s5678, line_sum[0]);
+    line_sum[0] = mad(line0.s6789, line0.s6789, line_sum[0]);
+    line_sum[0] = mad(line0.s789a, line0.s789a, line_sum[0]);
+    line_sum[0] = mad(line0.s89ab, line0.s89ab, line_sum[0]);
 
-    line_sum[0] = line0[0] * line0[0]
-                  + (float4)(line0[0].s123, line0[1].s0) * (float4)(line0[0].s123, line0[1].s0)
-                  + (float4)(line0[0].s23, line0[1].s01) * (float4)(line0[0].s23, line0[1].s01)
-                  + (float4)(line0[0].s3, line0[1].s012) * (float4)(line0[0].s3, line0[1].s012)
-                  + line0[1] * line0[1]
-                  + (float4)(line0[1].s123, line0[2].s0) * (float4)(line0[1].s123, line0[2].s0)
-                  + (float4)(line0[1].s23, line0[2].s01) * (float4)(line0[1].s23, line0[2].s01)
-                  + (float4)(line0[1].s3, line0[2].s012) * (float4)(line0[1].s3, line0[2].s012)
-                  + line0[2] * line0[2];
+    line_sum[1] = mad(line1.s0123, line1.s0123, line_sum[1]);
+    line_sum[1] = mad(line1.s1234, line1.s1234, line_sum[1]);
+    line_sum[1] = mad(line1.s2345, line1.s2345, line_sum[1]);
+    line_sum[1] = mad(line1.s3456, line1.s3456, line_sum[1]);
+    line_sum[1] = mad(line1.s4567, line1.s4567, line_sum[1]);
+    line_sum[1] = mad(line1.s5678, line1.s5678, line_sum[1]);
+    line_sum[1] = mad(line1.s6789, line1.s6789, line_sum[1]);
+    line_sum[1] = mad(line1.s789a, line1.s789a, line_sum[1]);
+    line_sum[1] = mad(line1.s89ab, line1.s89ab, line_sum[1]);
 
-    line_sum[1] = line1[0] * line1[0]
-                  + (float4)(line1[0].s123, line1[1].s0) * (float4)(line1[0].s123, line1[1].s0)
-                  + (float4)(line1[0].s23, line1[1].s01) * (float4)(line1[0].s23, line1[1].s01)
-                  + (float4)(line1[0].s3, line1[1].s012) * (float4)(line1[0].s3, line1[1].s012)
-                  + line1[1] * line1[1]
-                  + (float4)(line1[1].s123, line1[2].s0) * (float4)(line1[1].s123, line1[2].s0)
-                  + (float4)(line1[1].s23, line1[2].s01) * (float4)(line1[1].s23, line1[2].s01)
-                  + (float4)(line1[1].s3, line1[2].s012) * (float4)(line1[1].s3, line1[2].s012)
-                  + line1[2] * line1[2];
+    line_sum[2] = mad(line2.s0123, line2.s0123, line_sum[2]);
+    line_sum[2] = mad(line2.s1234, line2.s1234, line_sum[2]);
+    line_sum[2] = mad(line2.s2345, line2.s2345, line_sum[2]);
+    line_sum[2] = mad(line2.s3456, line2.s3456, line_sum[2]);
+    line_sum[2] = mad(line2.s4567, line2.s4567, line_sum[2]);
+    line_sum[2] = mad(line2.s5678, line2.s5678, line_sum[2]);
+    line_sum[2] = mad(line2.s6789, line2.s6789, line_sum[2]);
+    line_sum[2] = mad(line2.s789a, line2.s789a, line_sum[2]);
+    line_sum[2] = mad(line2.s89ab, line2.s89ab, line_sum[2]);
 
-    line_sum[2] = line2[0] * line2[0]
-                  + (float4)(line2[0].s123, line2[1].s0) * (float4)(line2[0].s123, line2[1].s0)
-                  + (float4)(line2[0].s23, line2[1].s01) * (float4)(line2[0].s23, line2[1].s01)
-                  + (float4)(line2[0].s3, line2[1].s012) * (float4)(line2[0].s3, line2[1].s012)
-                  + line2[1] * line2[1]
-                  + (float4)(line2[1].s123, line2[2].s0) * (float4)(line2[1].s123, line2[2].s0)
-                  + (float4)(line2[1].s23, line2[2].s01) * (float4)(line2[1].s23, line2[2].s01)
-                  + (float4)(line2[1].s3, line2[2].s012) * (float4)(line2[1].s3, line2[2].s012)
-                  + line2[2] * line2[2];
+    line_sum[3] = mad(line3.s0123, line3.s0123, line_sum[3]);
+    line_sum[3] = mad(line3.s1234, line3.s1234, line_sum[3]);
+    line_sum[3] = mad(line3.s2345, line3.s2345, line_sum[3]);
+    line_sum[3] = mad(line3.s3456, line3.s3456, line_sum[3]);
+    line_sum[3] = mad(line3.s4567, line3.s4567, line_sum[3]);
+    line_sum[3] = mad(line3.s5678, line3.s5678, line_sum[3]);
+    line_sum[3] = mad(line3.s6789, line3.s6789, line_sum[3]);
+    line_sum[3] = mad(line3.s789a, line3.s789a, line_sum[3]);
+    line_sum[3] = mad(line3.s89ab, line3.s89ab, line_sum[3]);
 
-    line_sum[3] = line3[0] * line3[0]
-                  + (float4)(line3[0].s123, line3[1].s0) * (float4)(line3[0].s123, line3[1].s0)
-                  + (float4)(line3[0].s23, line3[1].s01) * (float4)(line3[0].s23, line3[1].s01)
-                  + (float4)(line3[0].s3, line3[1].s012) * (float4)(line3[0].s3, line3[1].s012)
-                  + line3[1] * line3[1]
-                  + (float4)(line3[1].s123, line3[2].s0) * (float4)(line3[1].s123, line3[2].s0)
-                  + (float4)(line3[1].s23, line3[2].s01) * (float4)(line3[1].s23, line3[2].s01)
-                  + (float4)(line3[1].s3, line3[2].s012) * (float4)(line3[1].s3, line3[2].s012)
-                  + line3[2] * line3[2];
+    line_sum[4] = mad(line4.s0123, line4.s0123, line_sum[4]);
+    line_sum[4] = mad(line4.s1234, line4.s1234, line_sum[4]);
+    line_sum[4] = mad(line4.s2345, line4.s2345, line_sum[4]);
+    line_sum[4] = mad(line4.s3456, line4.s3456, line_sum[4]);
+    line_sum[4] = mad(line4.s4567, line4.s4567, line_sum[4]);
+    line_sum[4] = mad(line4.s5678, line4.s5678, line_sum[4]);
+    line_sum[4] = mad(line4.s6789, line4.s6789, line_sum[4]);
+    line_sum[4] = mad(line4.s789a, line4.s789a, line_sum[4]);
+    line_sum[4] = mad(line4.s89ab, line4.s89ab, line_sum[4]);
 
-    line_sum[4] = line4[0] * line4[0]
-                  + (float4)(line4[0].s123, line4[1].s0) * (float4)(line4[0].s123, line4[1].s0)
-                  + (float4)(line4[0].s23, line4[1].s01) * (float4)(line4[0].s23, line4[1].s01)
-                  + (float4)(line4[0].s3, line4[1].s012) * (float4)(line4[0].s3, line4[1].s012)
-                  + line4[1] * line4[1]
-                  + (float4)(line4[1].s123, line4[2].s0) * (float4)(line4[1].s123, line4[2].s0)
-                  + (float4)(line4[1].s23, line4[2].s01) * (float4)(line4[1].s23, line4[2].s01)
-                  + (float4)(line4[1].s3, line4[2].s012) * (float4)(line4[1].s3, line4[2].s012)
-                  + line4[2] * line4[2];
-
-    line_sum[5] = line5[0] * line5[0]
-                  + (float4)(line5[0].s123, line5[1].s0) * (float4)(line5[0].s123, line5[1].s0)
-                  + (float4)(line5[0].s23, line5[1].s01) * (float4)(line5[0].s23, line5[1].s01)
-                  + (float4)(line5[0].s3, line5[1].s012) * (float4)(line5[0].s3, line5[1].s012)
-                  + line5[1] * line5[1]
-                  + (float4)(line5[1].s123, line5[2].s0) * (float4)(line5[1].s123, line5[2].s0)
-                  + (float4)(line5[1].s23, line5[2].s01) * (float4)(line5[1].s23, line5[2].s01)
-                  + (float4)(line5[1].s3, line5[2].s012) * (float4)(line5[1].s3, line5[2].s012)
-                  + line5[2] * line5[2];
-
-    line_sum[6] = line6[0] * line6[0]
-                  + (float4)(line6[0].s123, line6[1].s0) * (float4)(line6[0].s123, line6[1].s0)
-                  + (float4)(line6[0].s23, line6[1].s01) * (float4)(line6[0].s23, line6[1].s01)
-                  + (float4)(line6[0].s3, line6[1].s012) * (float4)(line6[0].s3, line6[1].s012)
-                  + line6[1] * line6[1]
-                  + (float4)(line6[1].s123, line6[2].s0) * (float4)(line6[1].s123, line6[2].s0)
-                  + (float4)(line6[1].s23, line6[2].s01) * (float4)(line6[1].s23, line6[2].s01)
-                  + (float4)(line6[1].s3, line6[2].s012) * (float4)(line6[1].s3, line6[2].s012)
-                  + line6[2] * line6[2];
-
-    line_sum[7] = line7[0] * line7[0]
-                  + (float4)(line7[0].s123, line7[1].s0) * (float4)(line7[0].s123, line7[1].s0)
-                  + (float4)(line7[0].s23, line7[1].s01) * (float4)(line7[0].s23, line7[1].s01)
-                  + (float4)(line7[0].s3, line7[1].s012) * (float4)(line7[0].s3, line7[1].s012)
-                  + line7[1] * line7[1]
-                  + (float4)(line7[1].s123, line7[2].s0) * (float4)(line7[1].s123, line7[2].s0)
-                  + (float4)(line7[1].s23, line7[2].s01) * (float4)(line7[1].s23, line7[2].s01)
-                  + (float4)(line7[1].s3, line7[2].s012) * (float4)(line7[1].s3, line7[2].s012)
-                  + line7[2] * line7[2];
-
-    line_var[0] = (line_sum[0] + line_sum[1] + line_sum[2] + line_sum[3] + line_sum[4]) / 45;
-    line_var[1] = (line_sum[1] + line_sum[2] + line_sum[3] + line_sum[4] + line_sum[5]) / 45;
-    line_var[2] = (line_sum[2] + line_sum[3] + line_sum[4] + line_sum[5] + line_sum[6]) / 45;
-    line_var[3] = (line_sum[3] + line_sum[4] + line_sum[5] + line_sum[6] + line_sum[7]) / 45;
+    line_var = (line_sum[0] + line_sum[1] + line_sum[2] + line_sum[3] + line_sum[4]) / 45;
 #endif
 
 #if WAVELET_DENOISE_UV
-    line_sum[0] = line0[0] * line0[0]
-                  + (float4)(line0[0].s23, line0[1].s01) * (float4)(line0[0].s23, line0[1].s01)
-                  + line0[1] * line0[1]
-                  + (float4)(line0[1].s23, line0[2].s01) * (float4)(line0[1].s23, line0[2].s01)
-                  + line0[2] * line0[2];
+    line_sum[0] = mad(line0.s0123, line0.s0123, line_sum[0]);
+    line_sum[0] = mad(line0.s2345, line0.s2345, line_sum[0]);
+    line_sum[0] = mad(line0.s4567, line0.s4567, line_sum[0]);
+    line_sum[0] = mad(line0.s6789, line0.s6789, line_sum[0]);
+    line_sum[0] = mad(line0.s89ab, line0.s89ab, line_sum[0]);
+    line_sum[0] = mad(line0.sabcd, line0.sabcd, line_sum[0]);
+    line_sum[0] = mad(line0.scdef, line0.scdef, line_sum[0]);
 
-    line_sum[1] = line1[0] * line1[0]
-                  + (float4)(line1[0].s23, line1[1].s01) * (float4)(line1[0].s23, line1[1].s01)
-                  + line1[1] * line1[1]
-                  + (float4)(line1[1].s23, line1[2].s01) * (float4)(line1[1].s23, line1[2].s01)
-                  + line1[2] * line1[2];
+    line_sum[1] = mad(line1.s0123, line1.s0123, line_sum[1]);
+    line_sum[1] = mad(line1.s2345, line1.s2345, line_sum[1]);
+    line_sum[1] = mad(line1.s4567, line1.s4567, line_sum[1]);
+    line_sum[1] = mad(line1.s6789, line1.s6789, line_sum[1]);
+    line_sum[1] = mad(line1.s89ab, line1.s89ab, line_sum[1]);
+    line_sum[1] = mad(line1.sabcd, line1.sabcd, line_sum[1]);
+    line_sum[1] = mad(line1.scdef, line1.scdef, line_sum[1]);
 
-    line_sum[2] = line2[0] * line2[0]
-                  + (float4)(line2[0].s23, line2[1].s01) * (float4)(line2[0].s23, line2[1].s01)
-                  + line2[1] * line2[1]
-                  + (float4)(line2[1].s23, line2[2].s01) * (float4)(line2[1].s23, line2[2].s01)
-                  + line2[2] * line2[2];
+    line_sum[2] = mad(line2.s0123, line2.s0123, line_sum[2]);
+    line_sum[2] = mad(line2.s2345, line2.s2345, line_sum[2]);
+    line_sum[2] = mad(line2.s4567, line2.s4567, line_sum[2]);
+    line_sum[2] = mad(line2.s6789, line2.s6789, line_sum[2]);
+    line_sum[2] = mad(line2.s89ab, line2.s89ab, line_sum[2]);
+    line_sum[2] = mad(line2.sabcd, line2.sabcd, line_sum[2]);
+    line_sum[2] = mad(line2.scdef, line2.scdef, line_sum[2]);
 
-    line_sum[3] = line3[0] * line3[0]
-                  + (float4)(line3[0].s23, line3[1].s01) * (float4)(line3[0].s23, line3[1].s01)
-                  + line3[1] * line3[1]
-                  + (float4)(line3[1].s23, line3[2].s01) * (float4)(line3[1].s23, line3[2].s01)
-                  + line3[2] * line3[2];
+    line_sum[3] = mad(line3.s0123, line3.s0123, line_sum[3]);
+    line_sum[3] = mad(line3.s2345, line3.s2345, line_sum[3]);
+    line_sum[3] = mad(line3.s4567, line3.s4567, line_sum[3]);
+    line_sum[3] = mad(line3.s6789, line3.s6789, line_sum[3]);
+    line_sum[3] = mad(line3.s89ab, line3.s89ab, line_sum[3]);
+    line_sum[3] = mad(line3.sabcd, line3.sabcd, line_sum[3]);
+    line_sum[3] = mad(line3.scdef, line3.scdef, line_sum[3]);
 
-    line_sum[4] = line4[0] * line4[0]
-                  + (float4)(line4[0].s23, line4[1].s01) * (float4)(line4[0].s23, line4[1].s01)
-                  + line4[1] * line4[1]
-                  + (float4)(line4[1].s23, line4[2].s01) * (float4)(line4[1].s23, line4[2].s01)
-                  + line4[2] * line4[2];
+    line_sum[4] = mad(line4.s0123, line4.s0123, line_sum[4]);
+    line_sum[4] = mad(line4.s2345, line4.s2345, line_sum[4]);
+    line_sum[4] = mad(line4.s4567, line4.s4567, line_sum[4]);
+    line_sum[4] = mad(line4.s6789, line4.s6789, line_sum[4]);
+    line_sum[4] = mad(line4.s89ab, line4.s89ab, line_sum[4]);
+    line_sum[4] = mad(line4.sabcd, line4.sabcd, line_sum[4]);
+    line_sum[4] = mad(line4.scdef, line4.scdef, line_sum[4]);
 
-    line_sum[5] = line5[0] * line5[0]
-                  + (float4)(line5[0].s23, line5[1].s01) * (float4)(line5[0].s23, line5[1].s01)
-                  + line5[1] * line5[1]
-                  + (float4)(line5[1].s23, line5[2].s01) * (float4)(line5[1].s23, line5[2].s01)
-                  + line5[2] * line5[2];
-
-    line_sum[6] = line6[0] * line6[0]
-                  + (float4)(line6[0].s23, line6[1].s01) * (float4)(line6[0].s23, line6[1].s01)
-                  + line6[1] * line6[1]
-                  + (float4)(line6[1].s23, line6[2].s01) * (float4)(line6[1].s23, line6[2].s01)
-                  + line6[2] * line6[2];
-
-    line_sum[7] = line7[0] * line7[0]
-                  + (float4)(line7[0].s23, line7[1].s01) * (float4)(line7[0].s23, line7[1].s01)
-                  + line7[1] * line7[1]
-                  + (float4)(line7[1].s23, line7[2].s01) * (float4)(line7[1].s23, line7[2].s01)
-                  + line7[2] * line7[2];
-    line_var[0] = (line_sum[0] + line_sum[1] + line_sum[2] + line_sum[3] + line_sum[4]) / 25;
-    line_var[1] = (line_sum[1] + line_sum[2] + line_sum[3] + line_sum[4] + line_sum[5]) / 25;
-    line_var[2] = (line_sum[2] + line_sum[3] + line_sum[4] + line_sum[5] + line_sum[6]) / 25;
-    line_var[3] = (line_sum[3] + line_sum[4] + line_sum[5] + line_sum[6] + line_sum[7]) / 25;
+    line_var = ((line_sum[0] + line_sum[1] + line_sum[2] + line_sum[3] + line_sum[4]) / 35);
 #endif
 
-    write_imagef(output, (int2)(x, 4 * y), line_var[0]);
-    write_imagef(output, (int2)(x, 4 * y + 1), line_var[1]);
-    write_imagef(output, (int2)(x, 4 * y + 2), line_var[2]);
-    write_imagef(output, (int2)(x, 4 * y + 3), line_var[3]);
+    write_imagef(output, (int2)(g_id_x, g_id_y), line_var);
 }

--- a/tests/test-cl-image.cpp
+++ b/tests/test-cl-image.cpp
@@ -569,7 +569,7 @@ int main (int argc, char *argv[])
         wavelet_config.threshold[0] = 0.2;
         wavelet_config.threshold[1] = 0.5;
         wavelet_config.decomposition_levels = 4;
-        wavelet_config.analog_gain = 10;
+        wavelet_config.analog_gain = 0.001;
         wavelet->set_denoise_config (wavelet_config);
         break;
     }
@@ -581,7 +581,7 @@ int main (int argc, char *argv[])
         wavelet_config.threshold[0] = 0.2;
         wavelet_config.threshold[1] = 0.5;
         wavelet_config.decomposition_levels = 4;
-        wavelet_config.analog_gain = 10;
+        wavelet_config.analog_gain = 0.001;
         wavelet->set_denoise_config (wavelet_config);
         break;
     }

--- a/xcore/cl_newwavelet_denoise_handler.h
+++ b/xcore/cl_newwavelet_denoise_handler.h
@@ -129,6 +129,7 @@ private:
     uint32_t  _current_layer;
     float     _hard_threshold;
     float     _soft_threshold;
+    float     _anolog_gain_weight;
     SmartPtr<CLNewWaveletDenoiseImageHandler> _handler;
     float     _noise_variance[2];
 };


### PR DESCRIPTION
Use shared local memory in CL kernel to store surrounding image pixels to do wavelet coefficient mean square convolution.