### PR TITLE
cl-wavelet: Add interface to enable bayes shrink for wavelet denoise

### DIFF
--- a/modules/ocl/cl_3a_image_processor.cpp
+++ b/modules/ocl/cl_3a_image_processor.cpp
@@ -55,7 +55,8 @@ CL3aImageProcessor::CL3aImageProcessor ()
     , _enable_scaler (false)
     , _enable_wireframe (false)
     , _wavelet_basis (CL_WAVELET_DISABLED)
-    , _wavelet_channel (CL_WAVELET_CHANNEL_UV)
+    , _wavelet_channel (CL_IMAGE_CHANNEL_UV)
+    , _wavelet_bayes_shrink (false)
     , _snr_mode (0)
 {
     keep_attached_buf (true);
@@ -433,7 +434,7 @@ CL3aImageProcessor::create_handlers ()
         break;
     }
     case CL_WAVELET_HAAR: {
-        image_handler = create_cl_newwavelet_denoise_image_handler (context, _wavelet_channel);
+        image_handler = create_cl_newwavelet_denoise_image_handler (context, _wavelet_channel, _wavelet_bayes_shrink);
         _newwavelet = image_handler.dynamic_cast_ptr<CLNewWaveletDenoiseImageHandler> ();
         XCAM_FAIL_RETURN (
             WARNING,
@@ -561,10 +562,11 @@ CL3aImageProcessor::set_gamma (bool enable)
 }
 
 bool
-CL3aImageProcessor::set_wavelet (CLWaveletBasis basis, uint32_t channel)
+CL3aImageProcessor::set_wavelet (CLWaveletBasis basis, uint32_t channel, bool bayes_shrink)
 {
     _wavelet_basis = basis;
-    _wavelet_channel = (CLWaveletChannel)channel;
+    _wavelet_channel = (CLImageChannel)channel;
+    _wavelet_bayes_shrink = bayes_shrink;
 
     STREAM_LOCK;
 

--- a/modules/ocl/cl_3a_image_processor.h
+++ b/modules/ocl/cl_3a_image_processor.h
@@ -92,7 +92,7 @@ public:
     virtual bool set_scaler (bool enable);
     virtual bool set_wireframe (bool enable);
     virtual bool set_tnr (uint32_t mode, uint8_t level);
-    virtual bool set_wavelet (CLWaveletBasis basis, uint32_t channel);
+    virtual bool set_wavelet (CLWaveletBasis basis, uint32_t channel, bool bayes_shrink);
     virtual bool set_tonemapping (CLTonemappingMode wdr_mode);
 
     PipelineProfile get_profile () const {
@@ -145,6 +145,7 @@ private:
     bool                                _enable_wireframe;
     CLWaveletBasis                      _wavelet_basis;
     uint32_t                            _wavelet_channel;
+    bool                                _wavelet_bayes_shrink;
     uint32_t                            _snr_mode; // spatial nr mode
 };
 

--- a/modules/ocl/cl_newwavelet_denoise_handler.h
+++ b/modules/ocl/cl_newwavelet_denoise_handler.h
@@ -144,7 +144,8 @@ public:
                                        SmartPtr<CLNewWaveletDenoiseImageHandler> &handler,
                                        CLWaveletFilterBank fb,
                                        uint32_t channel,
-                                       uint32_t layer);
+                                       uint32_t layer,
+                                       bool bayes_shrink);
 
     SmartPtr<CLWaveletDecompBuffer> get_decomp_buffer (uint32_t channel, int layer);
 
@@ -164,6 +165,7 @@ private:
     uint32_t  _decomposition_levels;
     uint32_t  _channel;
     uint32_t  _current_layer;
+    bool      _bayes_shrink;
     float     _hard_threshold;
     float     _soft_threshold;
 
@@ -204,7 +206,7 @@ private:
 };
 
 SmartPtr<CLImageHandler>
-create_cl_newwavelet_denoise_image_handler (SmartPtr<CLContext> &context, uint32_t channel);
+create_cl_newwavelet_denoise_image_handler (SmartPtr<CLContext> &context, uint32_t channel, bool bayes_shrink);
 
 };
 

--- a/modules/ocl/cl_wavelet_denoise_handler.cpp
+++ b/modules/ocl/cl_wavelet_denoise_handler.cpp
@@ -126,7 +126,7 @@ CLWaveletDenoiseImageKernel::prepare_arguments (
     args[11].arg_adress = &_soft_threshold;
     args[11].arg_size = sizeof (_soft_threshold);
 
-    if (_channel & CL_WAVELET_CHANNEL_UV) {
+    if (_channel & CL_IMAGE_CHANNEL_UV) {
         work_size.global[0] = video_info_in.width / 16;
         work_size.global[1] = video_info_in.height / 2;
     } else {
@@ -208,7 +208,7 @@ create_cl_wavelet_denoise_image_handler (SmartPtr<CLContext> &context, uint32_t 
         ret = wavelet_kernel->load_from_source (
                   kernel_wavelet_denoise_body, strlen (kernel_wavelet_denoise_body),
                   NULL, NULL,
-                  (channel & CL_WAVELET_CHANNEL_UV) ? "-DWAVELET_DENOISE_UV=1" : "-DWAVELET_DENOISE_UV=0");
+                  (channel & CL_IMAGE_CHANNEL_UV) ? "-DWAVELET_DENOISE_UV=1" : "-DWAVELET_DENOISE_UV=0");
         XCAM_FAIL_RETURN (
             WARNING,
             ret == XCAM_RETURN_NO_ERROR,

--- a/tests/test-cl-image.cpp
+++ b/tests/test-cl-image.cpp
@@ -561,7 +561,7 @@ int main (int argc, char *argv[])
         break;
     }
     case TestHandlerHatWavelet: {
-        image_handler = create_cl_wavelet_denoise_image_handler (context, CL_WAVELET_CHANNEL_UV);
+        image_handler = create_cl_wavelet_denoise_image_handler (context, CL_IMAGE_CHANNEL_UV);
         SmartPtr<CLWaveletDenoiseImageHandler> wavelet = image_handler.dynamic_cast_ptr<CLWaveletDenoiseImageHandler> ();
         XCAM_ASSERT (wavelet.ptr ());
         XCam3aResultWaveletNoiseReduction wavelet_config;
@@ -574,7 +574,7 @@ int main (int argc, char *argv[])
         break;
     }
     case TestHandlerHaarWavelet: {
-        image_handler = create_cl_newwavelet_denoise_image_handler (context, CL_WAVELET_CHANNEL_UV | CL_WAVELET_CHANNEL_Y);
+        image_handler = create_cl_newwavelet_denoise_image_handler (context, CL_IMAGE_CHANNEL_UV | CL_IMAGE_CHANNEL_Y, false);
         SmartPtr<CLNewWaveletDenoiseImageHandler> wavelet = image_handler.dynamic_cast_ptr<CLNewWaveletDenoiseImageHandler> ();
         XCAM_ASSERT (wavelet.ptr ());
         XCam3aResultWaveletNoiseReduction wavelet_config;

--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -321,7 +321,7 @@ void print_help (const char *bin_name)
             "\t               select from [disabled, retinex, dcp], default is [disabled]\n"
             "\t --enable-retinex  enable retinex\n"
             "\t --wavelet-mode specify wavelet denoise mode, default is off\n"
-            "\t                select from [0:disable, 1:Hat Y, 2:Hat UV, 3:Haar Y, 4:Haar UV, 5:Haar YUV]\n"
+            "\t                select from [0:disable, 1:Hat Y, 2:Hat UV, 3:Haar Y, 4:Haar UV, 5:Haar YUV, 6:Haar Bayes Shrink]\n"
             "\t --enable-wireframe  enable wire frame\n"
             "\t --pipeline    pipe mode\n"
             "\t               select from [basic, advance, extreme], default is [basic]\n"
@@ -373,7 +373,8 @@ int main (int argc, char *argv[])
     bool wdr_type = false;
     uint32_t defog_type = 0;
     CLWaveletBasis wavelet_mode = CL_WAVELET_DISABLED;
-    uint32_t wavelet_channel = CL_WAVELET_CHANNEL_UV;
+    uint32_t wavelet_channel = CL_IMAGE_CHANNEL_UV;
+    bool wavelet_bayes_shrink = false;
     bool wireframe_type = false;
 
     int32_t brightness_level = 128;
@@ -564,19 +565,23 @@ int main (int argc, char *argv[])
             }
             if (atoi(optarg) == 1) {
                 wavelet_mode = CL_WAVELET_HAT;
-                wavelet_channel = CL_WAVELET_CHANNEL_Y;
+                wavelet_channel = CL_IMAGE_CHANNEL_Y;
             } else if (atoi(optarg) == 2) {
                 wavelet_mode = CL_WAVELET_HAT;
-                wavelet_channel = CL_WAVELET_CHANNEL_UV;
+                wavelet_channel = CL_IMAGE_CHANNEL_UV;
             } else if (atoi(optarg) == 3) {
                 wavelet_mode = CL_WAVELET_HAAR;
-                wavelet_channel = CL_WAVELET_CHANNEL_Y;
+                wavelet_channel = CL_IMAGE_CHANNEL_Y;
             } else if (atoi(optarg) == 4) {
                 wavelet_mode = CL_WAVELET_HAAR;
-                wavelet_channel = CL_WAVELET_CHANNEL_UV;
+                wavelet_channel = CL_IMAGE_CHANNEL_UV;
             } else if (atoi(optarg) == 5) {
                 wavelet_mode = CL_WAVELET_HAAR;
-                wavelet_channel = CL_WAVELET_CHANNEL_UV | CL_WAVELET_CHANNEL_Y;
+                wavelet_channel = CL_IMAGE_CHANNEL_UV | CL_IMAGE_CHANNEL_Y;
+            } else if (atoi(optarg) == 6) {
+                wavelet_mode = CL_WAVELET_HAAR;
+                wavelet_channel = CL_IMAGE_CHANNEL_UV | CL_IMAGE_CHANNEL_Y;
+                wavelet_bayes_shrink = true;
             } else {
                 wavelet_mode = CL_WAVELET_DISABLED;
             }
@@ -812,7 +817,7 @@ int main (int argc, char *argv[])
         cl_processor->set_denoise (denoise_type);
         cl_processor->set_tonemapping(wdr_mode);
         cl_processor->set_gamma (!wdr_type); // disable gamma for WDR
-        cl_processor->set_wavelet (wavelet_mode, wavelet_channel);
+        cl_processor->set_wavelet (wavelet_mode, wavelet_channel, wavelet_bayes_shrink);
         cl_processor->set_wireframe (wireframe_type);
         cl_processor->set_capture_stage (capture_stage);
 

--- a/wrapper/gstreamer/gstxcamsrc.cpp
+++ b/wrapper/gstreamer/gstxcamsrc.cpp
@@ -201,6 +201,7 @@ gst_xcam_src_wavelet_mode_get_type (void)
         {HARR_WAVELET_Y, "Haar wavelet Y", "haar Y"},
         {HARR_WAVELET_UV, "Haar wavelet UV", "haar UV"},
         {HARR_WAVELET_YUV, "Haar wavelet YUV", "haar YUV"},
+        {HARR_WAVELET_BAYES, "Haar wavelet bayes shrink", "haar Bayes"},
         {0, NULL, NULL},
     };
 
@@ -888,17 +889,19 @@ gst_xcam_src_start (GstBaseSrc *src)
 
         if (NONE_WAVELET != xcamsrc->wavelet_mode) {
             if (HAT_WAVELET_Y == xcamsrc->wavelet_mode) {
-                cl_processor->set_wavelet (CL_WAVELET_HAT, CL_WAVELET_CHANNEL_Y);
+                cl_processor->set_wavelet (CL_WAVELET_HAT, CL_IMAGE_CHANNEL_Y, false);
             } else if (HAT_WAVELET_UV == xcamsrc->wavelet_mode) {
-                cl_processor->set_wavelet (CL_WAVELET_HAT, CL_WAVELET_CHANNEL_UV);
+                cl_processor->set_wavelet (CL_WAVELET_HAT, CL_IMAGE_CHANNEL_UV, false);
             } else if (HARR_WAVELET_Y == xcamsrc->wavelet_mode) {
-                cl_processor->set_wavelet (CL_WAVELET_HAAR, CL_WAVELET_CHANNEL_Y);
+                cl_processor->set_wavelet (CL_WAVELET_HAAR, CL_IMAGE_CHANNEL_Y, false);
             } else if (HARR_WAVELET_UV == xcamsrc->wavelet_mode) {
-                cl_processor->set_wavelet (CL_WAVELET_HAAR, CL_WAVELET_CHANNEL_UV);
+                cl_processor->set_wavelet (CL_WAVELET_HAAR, CL_IMAGE_CHANNEL_UV, false);
             } else if (HARR_WAVELET_YUV == xcamsrc->wavelet_mode) {
-                cl_processor->set_wavelet (CL_WAVELET_HAAR, CL_WAVELET_CHANNEL_UV | CL_WAVELET_CHANNEL_Y);
+                cl_processor->set_wavelet (CL_WAVELET_HAAR, CL_IMAGE_CHANNEL_UV | CL_IMAGE_CHANNEL_Y, false);
+            } else if (HARR_WAVELET_BAYES == xcamsrc->wavelet_mode) {
+                cl_processor->set_wavelet (CL_WAVELET_HAAR, CL_IMAGE_CHANNEL_UV | CL_IMAGE_CHANNEL_Y, true);
             } else {
-                cl_processor->set_wavelet (CL_WAVELET_DISABLED, CL_WAVELET_CHANNEL_UV);
+                cl_processor->set_wavelet (CL_WAVELET_DISABLED, CL_IMAGE_CHANNEL_UV, false);
             }
         }
 
@@ -1078,7 +1081,7 @@ translate_format_to_xcam (GstVideoFormat format)
     case GST_VIDEO_FORMAT_Y42B:
         return V4L2_PIX_FMT_YUV422P;
 
-        //RGB
+    //RGB
     case GST_VIDEO_FORMAT_RGBx:
         return V4L2_PIX_FMT_RGB32;
     case GST_VIDEO_FORMAT_BGRx:

--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -66,6 +66,7 @@ typedef enum {
     HARR_WAVELET_Y,
     HARR_WAVELET_UV,
     HARR_WAVELET_YUV,
+    HARR_WAVELET_BAYES,
 } WaveletModeType;
 
 typedef enum {

--- a/xcore/xcam_utils.h
+++ b/xcore/xcam_utils.h
@@ -40,9 +40,9 @@ enum CLWaveletBasis {
     CL_WAVELET_HAAR,
 };
 
-enum CLWaveletChannel {
-    CL_WAVELET_CHANNEL_Y = 1,
-    CL_WAVELET_CHANNEL_UV = 1 << 1,
+enum CLImageChannel {
+    CL_IMAGE_CHANNEL_Y = 1,
+    CL_IMAGE_CHANNEL_UV = 1 << 1,
 };
 
 inline double


### PR DESCRIPTION
            "\t --wavelet-mode specify wavelet denoise mode, default is off\n"
            "\t     select from [0:disable, 1:Hat Y, 2:Hat UV,\n"
            "\t     3:Haar Y, 4:Haar UV, 5:Haar YUV, 6:Haar Bayes Shrink]\n"