### PR TITLE
move wavelet, wireframe and scaler to post image processor

### DIFF
--- a/modules/ocl/cl_3a_image_processor.cpp
+++ b/modules/ocl/cl_3a_image_processor.cpp
@@ -29,11 +29,9 @@
 #include "cl_tnr_handler.h"
 #include "cl_tonemapping_handler.h"
 #include "cl_newtonemapping_handler.h"
-#include "cl_image_scaler.h"
 #include "cl_bayer_basic_handler.h"
 #include "cl_wavelet_denoise_handler.h"
 #include "cl_newwavelet_denoise_handler.h"
-#include "cl_wire_frame_handler.h"
 
 #define XCAM_CL_3A_IMAGE_MAX_POOL_SIZE 6
 
@@ -43,7 +41,6 @@ CL3aImageProcessor::CL3aImageProcessor ()
     : CLImageProcessor ("CL3aImageProcessor")
     , _output_fourcc (V4L2_PIX_FMT_NV12)
     , _3a_stats_bits (8)
-    , _scaler_factor (1.0)
     , _pipeline_profile (BasicPipelineProfile)
     , _capture_stage (TonemappingStage)
     , _wdr_mode (WDRdisabled)
@@ -52,8 +49,6 @@ CL3aImageProcessor::CL3aImageProcessor ()
     , _enable_gamma (true)
     , _enable_macc (true)
     , _enable_dpc (false)
-    , _enable_scaler (false)
-    , _enable_wireframe (false)
     , _wavelet_basis (CL_WAVELET_DISABLED)
     , _wavelet_channel (CL_IMAGE_CHANNEL_UV)
     , _wavelet_bayes_shrink (false)
@@ -112,14 +107,6 @@ CL3aImageProcessor::set_3a_stats_bits (uint32_t bits)
 }
 
 bool
-CL3aImageProcessor::set_scaler_factor (const double factor)
-{
-    _scaler_factor = factor;
-
-    return true;
-}
-
-bool
 CL3aImageProcessor::can_process_result (SmartPtr<X3aResult> &result)
 {
     if (result.ptr() == NULL)
@@ -139,7 +126,6 @@ CL3aImageProcessor::can_process_result (SmartPtr<X3aResult> &result)
     case XCAM_3A_RESULT_TEMPORAL_NOISE_REDUCTION_YUV:
     case XCAM_3A_RESULT_EDGE_ENHANCEMENT:
     case XCAM_3A_RESULT_WAVELET_NOISE_REDUCTION:
-    case XCAM_3A_RESULT_FACE_DETECTION:
         return true;
 
     default:
@@ -305,15 +291,6 @@ CL3aImageProcessor::apply_3a_result (SmartPtr<X3aResult> &result)
         break;
     }
 
-    case XCAM_3A_RESULT_FACE_DETECTION: {
-        SmartPtr<X3aFaceDetectionResult> fd_res = result.dynamic_cast_ptr<X3aFaceDetectionResult> ();
-        XCAM_ASSERT (fd_res.ptr ());
-        if (_wire_frame.ptr ()) {
-            _wire_frame->set_wire_frame_config (fd_res->get_standard_result_ptr (), get_scaler_factor ());
-        }
-        break;
-    }
-
     default:
         XCAM_LOG_WARNING ("CL3aImageProcessor unknow 3a result:%d", res_type);
         break;
@@ -453,33 +430,6 @@ CL3aImageProcessor::create_handlers ()
         break;
     }
 
-    /* image scaler */
-    image_handler = create_cl_image_scaler_handler (context, V4L2_PIX_FMT_NV12);
-    _scaler = image_handler.dynamic_cast_ptr<CLImageScaler> ();
-    XCAM_FAIL_RETURN (
-        WARNING,
-        _scaler.ptr (),
-        XCAM_RETURN_ERROR_CL,
-        "CL3aImageProcessor create scaler handler failed");
-    _scaler->set_scaler_factor (_scaler_factor);
-    _scaler->set_buffer_callback (_stats_callback);
-    image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
-    image_handler->set_kernels_enable (_enable_scaler);
-    add_handler (image_handler);
-
-    /* wire frame */
-    image_handler = create_cl_wire_frame_image_handler (context);
-    _wire_frame = image_handler.dynamic_cast_ptr<CLWireFrameImageHandler> ();
-    XCAM_FAIL_RETURN (
-        WARNING,
-        _wire_frame.ptr (),
-        XCAM_RETURN_ERROR_CL,
-        "CL3aImageProcessor create wire frame handler failed");
-    _wire_frame->set_kernels_enable (_enable_wireframe);
-    image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
-    image_handler->set_pool_size (XCAM_CL_3A_IMAGE_MAX_POOL_SIZE);
-    add_handler (image_handler);
-
     XCAM_FAIL_RETURN (
         WARNING,
         post_config (),
@@ -608,26 +558,6 @@ bool
 CL3aImageProcessor::set_tonemapping (CLTonemappingMode wdr_mode)
 {
     _wdr_mode = wdr_mode;
-
-    STREAM_LOCK;
-
-    return true;
-}
-
-bool
-CL3aImageProcessor::set_scaler (bool enable)
-{
-    _enable_scaler = enable;
-
-    STREAM_LOCK;
-
-    return true;
-}
-
-bool
-CL3aImageProcessor::set_wireframe (bool enable)
-{
-    _enable_wireframe = enable;
 
     STREAM_LOCK;
 

--- a/modules/ocl/cl_3a_image_processor.h
+++ b/modules/ocl/cl_3a_image_processor.h
@@ -35,8 +35,6 @@ class CLBayerPipeImageHandler;
 class CLYuvPipeImageHandler;
 class CLTonemappingImageHandler;
 class CLNewTonemappingImageHandler;
-class CLWaveletDenoiseImageHandler;
-class CLNewWaveletDenoiseImageHandler;
 
 #define ENABLE_YEENR_HANDLER 0
 
@@ -84,7 +82,6 @@ public:
     virtual bool set_macc (bool enable);
     virtual bool set_dpc (bool enable);
     virtual bool set_tnr (uint32_t mode, uint8_t level);
-    virtual bool set_wavelet (CLWaveletBasis basis, uint32_t channel, bool bayes_shrink);
     virtual bool set_tonemapping (CLTonemappingMode wdr_mode);
 
     PipelineProfile get_profile () const {
@@ -117,8 +114,6 @@ private:
 #if ENABLE_YEENR_HANDLER
     SmartPtr<CLEeImageHandler>          _ee;
 #endif
-    SmartPtr<CLWaveletDenoiseImageHandler>   _wavelet;
-    SmartPtr<CLNewWaveletDenoiseImageHandler>   _newwavelet;
 
     // simple 3a bayer pipeline
     SmartPtr<CLBayerBasicImageHandler>  _bayer_basic_pipe;
@@ -130,9 +125,6 @@ private:
     bool                                _enable_gamma;
     bool                                _enable_macc;
     bool                                _enable_dpc;
-    CLWaveletBasis                      _wavelet_basis;
-    uint32_t                            _wavelet_channel;
-    bool                                _wavelet_bayes_shrink;
     uint32_t                            _snr_mode; // spatial nr mode
 };
 

--- a/modules/ocl/cl_3a_image_processor.h
+++ b/modules/ocl/cl_3a_image_processor.h
@@ -35,10 +35,8 @@ class CLBayerPipeImageHandler;
 class CLYuvPipeImageHandler;
 class CLTonemappingImageHandler;
 class CLNewTonemappingImageHandler;
-class CLImageScaler;
 class CLWaveletDenoiseImageHandler;
 class CLNewWaveletDenoiseImageHandler;
-class CLWireFrameImageHandler;
 
 #define ENABLE_YEENR_HANDLER 0
 
@@ -79,18 +77,12 @@ public:
     bool set_output_format (uint32_t fourcc);
     bool set_capture_stage (CaptureStage capture_stage);
     bool set_3a_stats_bits (uint32_t bits);
-    bool set_scaler_factor (const double factor);
-    double get_scaler_factor () const {
-        return _scaler_factor;
-    }
 
     virtual bool set_hdr (uint32_t mode);
     virtual bool set_denoise (uint32_t mode);
     virtual bool set_gamma (bool enable);
     virtual bool set_macc (bool enable);
     virtual bool set_dpc (bool enable);
-    virtual bool set_scaler (bool enable);
-    virtual bool set_wireframe (bool enable);
     virtual bool set_tnr (uint32_t mode, uint8_t level);
     virtual bool set_wavelet (CLWaveletBasis basis, uint32_t channel, bool bayes_shrink);
     virtual bool set_tonemapping (CLTonemappingMode wdr_mode);
@@ -115,7 +107,6 @@ private:
 private:
     uint32_t                            _output_fourcc;
     uint32_t                            _3a_stats_bits;
-    double                              _scaler_factor;
     PipelineProfile                     _pipeline_profile;
     CaptureStage                        _capture_stage;
     CLTonemappingMode                   _wdr_mode;
@@ -123,13 +114,11 @@ private:
     SmartPtr<CLCscImageHandler>         _csc;
     SmartPtr<CLTonemappingImageHandler> _tonemapping;
     SmartPtr<CLNewTonemappingImageHandler> _newtonemapping;
-    SmartPtr<CLImageScaler>             _scaler;
 #if ENABLE_YEENR_HANDLER
     SmartPtr<CLEeImageHandler>          _ee;
 #endif
     SmartPtr<CLWaveletDenoiseImageHandler>   _wavelet;
     SmartPtr<CLNewWaveletDenoiseImageHandler>   _newwavelet;
-    SmartPtr<CLWireFrameImageHandler>   _wire_frame;
 
     // simple 3a bayer pipeline
     SmartPtr<CLBayerBasicImageHandler>  _bayer_basic_pipe;
@@ -141,8 +130,6 @@ private:
     bool                                _enable_gamma;
     bool                                _enable_macc;
     bool                                _enable_dpc;
-    bool                                _enable_scaler;
-    bool                                _enable_wireframe;
     CLWaveletBasis                      _wavelet_basis;
     uint32_t                            _wavelet_channel;
     bool                                _wavelet_bayes_shrink;

--- a/modules/ocl/cl_post_image_processor.h
+++ b/modules/ocl/cl_post_image_processor.h
@@ -33,6 +33,8 @@ class CLTnrImageHandler;
 class CLRetinexImageHandler;
 class CLCscImageHandler;
 class CLDefogDcpImageHandler;
+class CLWaveletDenoiseImageHandler;
+class CLNewWaveletDenoiseImageHandler;
 class CL3DDenoiseImageHandler;
 class CLImageScaler;
 class CLWireFrameImageHandler;
@@ -81,6 +83,7 @@ public:
 
     virtual bool set_tnr (CLTnrMode mode);
     virtual bool set_defog_mode (CLDefogMode mode);
+    virtual bool set_wavelet (CLWaveletBasis basis, uint32_t channel, bool bayes_shrink);
     virtual bool set_3ddenoise_mode (CL3DDenoiseMode mode, uint8_t ref_frame_count);
     virtual bool set_scaler (bool enable);
     virtual bool set_wireframe (bool enable);
@@ -103,6 +106,8 @@ private:
     SmartPtr<CLTnrImageHandler>               _tnr;
     SmartPtr<CLRetinexImageHandler>           _retinex;
     SmartPtr<CLDefogDcpImageHandler>          _defog_dcp;
+    SmartPtr<CLWaveletDenoiseImageHandler>    _wavelet;
+    SmartPtr<CLNewWaveletDenoiseImageHandler> _newwavelet;
     SmartPtr<CL3DDenoiseImageHandler>         _3d_denoise;
     SmartPtr<CLImageScaler>                   _scaler;
     SmartPtr<CLWireFrameImageHandler>         _wireframe;
@@ -112,6 +117,9 @@ private:
 
     CLTnrMode                                 _tnr_mode;
     CLDefogMode                               _defog_mode;
+    CLWaveletBasis                            _wavelet_basis;
+    uint32_t                                  _wavelet_channel;
+    bool                                      _wavelet_bayes_shrink;
     CL3DDenoiseMode                           _3d_denoise_mode;
     uint8_t                                   _3d_denoise_ref_count;
     bool                                      _enable_scaler;

--- a/modules/ocl/cl_post_image_processor.h
+++ b/modules/ocl/cl_post_image_processor.h
@@ -25,6 +25,7 @@
 #include "xcam_utils.h"
 #include <base/xcam_3a_types.h>
 #include "cl_image_processor.h"
+#include "stats_callback_interface.h"
 
 namespace XCam {
 
@@ -33,6 +34,8 @@ class CLRetinexImageHandler;
 class CLCscImageHandler;
 class CLDefogDcpImageHandler;
 class CL3DDenoiseImageHandler;
+class CLImageScaler;
+class CLWireFrameImageHandler;
 
 class CLPostImageProcessor
     : public CLImageProcessor
@@ -66,10 +69,21 @@ public:
     virtual ~CLPostImageProcessor ();
 
     bool set_output_format (uint32_t fourcc);
+    void set_stats_callback (const SmartPtr<StatsCallback> &callback);
+
+    bool set_scaler_factor (const double factor);
+    double get_scaler_factor () const {
+        return _scaler_factor;
+    }
+    bool is_scaled () {
+        return _enable_scaler;
+    }
 
     virtual bool set_tnr (CLTnrMode mode);
     virtual bool set_defog_mode (CLDefogMode mode);
     virtual bool set_3ddenoise_mode (CL3DDenoiseMode mode, uint8_t ref_frame_count);
+    virtual bool set_scaler (bool enable);
+    virtual bool set_wireframe (bool enable);
 
 protected:
     virtual bool can_process_result (SmartPtr<X3aResult> &result);
@@ -82,19 +96,26 @@ private:
     XCAM_DEAD_COPY (CLPostImageProcessor);
 
 private:
-    uint32_t                               _output_fourcc;
-    OutSampleType                          _out_sample_type;
+    uint32_t                                  _output_fourcc;
+    OutSampleType                             _out_sample_type;
+    SmartPtr<StatsCallback>                   _stats_callback;
 
-    SmartPtr<CLTnrImageHandler>            _tnr;
-    SmartPtr<CLRetinexImageHandler>        _retinex;
-    SmartPtr<CLDefogDcpImageHandler>       _defog_dcp;
-    SmartPtr<CLCscImageHandler>            _csc;
-    SmartPtr<CL3DDenoiseImageHandler>      _3d_denoise;
+    SmartPtr<CLTnrImageHandler>               _tnr;
+    SmartPtr<CLRetinexImageHandler>           _retinex;
+    SmartPtr<CLDefogDcpImageHandler>          _defog_dcp;
+    SmartPtr<CL3DDenoiseImageHandler>         _3d_denoise;
+    SmartPtr<CLImageScaler>                   _scaler;
+    SmartPtr<CLWireFrameImageHandler>         _wireframe;
+    SmartPtr<CLCscImageHandler>               _csc;
 
-    CLTnrMode                              _tnr_mode;
-    CLDefogMode                            _defog_mode;
-    CL3DDenoiseMode                        _3d_denoise_mode;
-    uint8_t                                _3d_denoise_ref_count;
+    double                                    _scaler_factor;
+
+    CLTnrMode                                 _tnr_mode;
+    CLDefogMode                               _defog_mode;
+    CL3DDenoiseMode                           _3d_denoise_mode;
+    uint8_t                                   _3d_denoise_ref_count;
+    bool                                      _enable_scaler;
+    bool                                      _enable_wireframe;
 };
 
 };

--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -378,11 +378,11 @@ int main (int argc, char *argv[])
 #if HAVE_LIBCL
     bool wdr_type = false;
     uint32_t defog_type = 0;
-    uint32_t denoise_3d_mode = 0;
-    uint8_t denoise_3d_ref_count = 3;
     CLWaveletBasis wavelet_mode = CL_WAVELET_DISABLED;
     uint32_t wavelet_channel = CL_IMAGE_CHANNEL_UV;
     bool wavelet_bayes_shrink = false;
+    uint32_t denoise_3d_mode = 0;
+    uint8_t denoise_3d_ref_count = 3;
     bool wireframe_type = false;
 #endif
 
@@ -847,7 +847,6 @@ int main (int argc, char *argv[])
         cl_processor->set_denoise (denoise_type);
         cl_processor->set_tonemapping(wdr_mode);
         cl_processor->set_gamma (!wdr_type); // disable gamma for WDR
-        cl_processor->set_wavelet (wavelet_mode, wavelet_channel, wavelet_bayes_shrink);
         cl_processor->set_capture_stage (capture_stage);
 
         if (wdr_type) {
@@ -864,6 +863,7 @@ int main (int argc, char *argv[])
 
         cl_post_processor->set_stats_callback (device_manager);
         cl_post_processor->set_defog_mode ((CLPostImageProcessor::CLDefogMode)defog_type);
+        cl_post_processor->set_wavelet (wavelet_mode, wavelet_channel, wavelet_bayes_shrink);
         cl_post_processor->set_3ddenoise_mode ((CLPostImageProcessor::CL3DDenoiseMode) denoise_3d_mode, denoise_3d_ref_count);
 
         cl_post_processor->set_wireframe (wireframe_type);

--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -751,21 +751,6 @@ int main (int argc, char *argv[])
         loader = dynamic_loader.dynamic_cast_ptr<AnalyzerLoader> ();
         analyzer = dynamic_loader->load_analyzer (loader);
         CHECK_EXP (analyzer.ptr (), "load dynamic 3a lib(%s) failed", path_of_3a);
-
-        // Create smart analyzer from dynamic libraries
-        SmartHandlerList smart_handlers = SmartAnalyzerLoader::load_smart_handlers (DEFAULT_SMART_ANALYSIS_LIB_DIR);
-        if (!smart_handlers.empty () ) {
-            smart_analyzer = new SmartAnalyzer ();
-            if (!smart_analyzer.ptr ()) {
-                XCAM_LOG_INFO ("load smart analyzer(%s) failed", DEFAULT_SMART_ANALYSIS_LIB_DIR);
-                break;
-            }
-            SmartHandlerList::iterator i_handler = smart_handlers.begin ();
-            for (; i_handler != smart_handlers.end (); ++i_handler) {
-                XCAM_ASSERT ((*i_handler).ptr ());
-                smart_analyzer->add_handler (*i_handler);
-            }
-        }
         break;
     }
     default:
@@ -774,6 +759,23 @@ int main (int argc, char *argv[])
     }
     XCAM_ASSERT (analyzer.ptr ());
     analyzer->set_sync_mode (sync_mode);
+
+#if HAVE_LIBCL
+    SmartHandlerList smart_handlers = SmartAnalyzerLoader::load_smart_handlers (DEFAULT_SMART_ANALYSIS_LIB_DIR);
+    if (!smart_handlers.empty ()) {
+        smart_analyzer = new SmartAnalyzer ();
+        if (smart_analyzer.ptr ()) {
+            SmartHandlerList::iterator i_handler = smart_handlers.begin ();
+            for (; i_handler != smart_handlers.end ();	++i_handler)
+            {
+                XCAM_ASSERT ((*i_handler).ptr ());
+                smart_analyzer->add_handler (*i_handler);
+            }
+        } else {
+            XCAM_LOG_WARNING ("load smart analyzer(%s) failed, please check.", DEFAULT_SMART_ANALYSIS_LIB_DIR);
+        }
+    }
+#endif
 
     signal(SIGINT, dev_stop_handler);
 

--- a/wrapper/gstreamer/gstxcamfilter.cpp
+++ b/wrapper/gstreamer/gstxcamfilter.cpp
@@ -474,7 +474,6 @@ copy_xcambuf_to_gstbuf (GstVideoInfo gstinfo, SmartPtr<VideoBuffer> xcambuf, Gst
     gst_buffer_unmap (tmpbuf, &mapinfo);
     xcambuf->unmap ();
 
-    GST_BUFFER_TIMESTAMP (tmpbuf) = xcambuf->get_timestamp () * 1000;
     *gstbuf = tmpbuf;
 
     return GST_FLOW_OK;
@@ -510,7 +509,6 @@ append_xcambuf_to_gstbuf (GstAllocator *allocator, SmartPtr<VideoBuffer> xcambuf
         offsets,
         (gint *) (xcaminfo.strides));
 
-    GST_BUFFER_TIMESTAMP (tmpbuf) = xcambuf->get_timestamp () * 1000;
     *gstbuf = tmpbuf;
 
     return GST_FLOW_OK;
@@ -544,7 +542,6 @@ static GstFlowReturn
 gst_xcam_filter_prepare_output_buffer (GstBaseTransform *trans, GstBuffer *input, GstBuffer **outbuf)
 {
     GstXCamFilter *xcamfilter = GST_XCAM_FILTER (trans);
-    XCAM_UNUSED (input);
 
     GstFlowReturn ret = GST_FLOW_OK;
     SmartPtr<MainPipeManager> pipe_manager = xcamfilter->pipe_manager;
@@ -560,6 +557,8 @@ gst_xcam_filter_prepare_output_buffer (GstBaseTransform *trans, GstBuffer *input
         GstAllocator *allocator = xcamfilter->allocator;
         ret = append_xcambuf_to_gstbuf (allocator, video_buf, outbuf);
     }
+
+    GST_BUFFER_TIMESTAMP (*outbuf) = GST_BUFFER_TIMESTAMP (input);
 
     return ret;
 }

--- a/wrapper/gstreamer/gstxcamfilter.h
+++ b/wrapper/gstreamer/gstxcamfilter.h
@@ -68,6 +68,7 @@ struct _GstXCamFilter
     DefogModeType                defog_mode;
     Denoise3DModeType            denoise_3d_mode;
     uint8_t                      denoise_3d_ref_count;
+    gboolean                     enable_wireframe;
 
     GstAllocator                 *allocator;
     GstVideoInfo                 gst_video_info;

--- a/wrapper/gstreamer/gstxcamfilter.h
+++ b/wrapper/gstreamer/gstxcamfilter.h
@@ -51,6 +51,16 @@ typedef enum {
 } DefogModeType;
 
 typedef enum {
+    NONE_WAVELET = 0,
+    HAT_WAVELET_Y,
+    HAT_WAVELET_UV,
+    HARR_WAVELET_Y,
+    HARR_WAVELET_UV,
+    HARR_WAVELET_YUV,
+    HARR_WAVELET_BAYES
+} WaveletModeType;
+
+typedef enum {
     DENOISE_3D_NONE = 0,
     DENOISE_3D_YUV,
     DENOISE_3D_UV
@@ -66,6 +76,7 @@ struct _GstXCamFilter
     uint32_t                     buf_count;
     CopyMode                     copy_mode;
     DefogModeType                defog_mode;
+    WaveletModeType              wavelet_mode;
     Denoise3DModeType            denoise_3d_mode;
     uint8_t                      denoise_3d_ref_count;
     gboolean                     enable_wireframe;

--- a/wrapper/gstreamer/gstxcamsrc.cpp
+++ b/wrapper/gstreamer/gstxcamsrc.cpp
@@ -905,8 +905,6 @@ gst_xcam_src_start (GstBaseSrc *src)
             }
         }
 
-        cl_processor->set_wireframe (xcamsrc->enable_wireframe);
-
         cl_processor->set_profile ((CL3aImageProcessor::PipelineProfile)xcamsrc->cl_pipe_profile);
         device_manager->add_image_processor (cl_processor);
         device_manager->set_cl_image_processor (cl_processor);
@@ -920,10 +918,12 @@ gst_xcam_src_start (GstBaseSrc *src)
 #if HAVE_LIBCL
     cl_post_processor = new CLPostImageProcessor ();
 
+    cl_post_processor->set_stats_callback (device_manager);
     if(xcamsrc->enable_retinex)
     {
         cl_post_processor->set_defog_mode (CLPostImageProcessor::DefogRetinex);
     }
+    cl_post_processor->set_wireframe (xcamsrc->enable_wireframe);
 
     device_manager->add_image_processor (cl_post_processor);
     device_manager->set_cl_post_image_processor (cl_post_processor);
@@ -966,9 +966,9 @@ gst_xcam_src_start (GstBaseSrc *src)
                 smart_analyzer->add_handler (*i_handler);
             }
 #if HAVE_LIBCL
-            if (cl_processor.ptr ()) {
-                cl_processor->set_scaler (true);
-                cl_processor->set_scaler_factor (640.0 / DEFAULT_VIDEO_WIDTH);
+            if (cl_post_processor.ptr () && xcamsrc->enable_wireframe) {
+                cl_post_processor->set_scaler (true);
+                cl_post_processor->set_scaler_factor (640.0 / DEFAULT_VIDEO_WIDTH);
             }
 #endif
         }

--- a/wrapper/gstreamer/gstxcamsrc.cpp
+++ b/wrapper/gstreamer/gstxcamsrc.cpp
@@ -887,24 +887,6 @@ gst_xcam_src_start (GstBaseSrc *src)
             }
         }
 
-        if (NONE_WAVELET != xcamsrc->wavelet_mode) {
-            if (HAT_WAVELET_Y == xcamsrc->wavelet_mode) {
-                cl_processor->set_wavelet (CL_WAVELET_HAT, CL_IMAGE_CHANNEL_Y, false);
-            } else if (HAT_WAVELET_UV == xcamsrc->wavelet_mode) {
-                cl_processor->set_wavelet (CL_WAVELET_HAT, CL_IMAGE_CHANNEL_UV, false);
-            } else if (HARR_WAVELET_Y == xcamsrc->wavelet_mode) {
-                cl_processor->set_wavelet (CL_WAVELET_HAAR, CL_IMAGE_CHANNEL_Y, false);
-            } else if (HARR_WAVELET_UV == xcamsrc->wavelet_mode) {
-                cl_processor->set_wavelet (CL_WAVELET_HAAR, CL_IMAGE_CHANNEL_UV, false);
-            } else if (HARR_WAVELET_YUV == xcamsrc->wavelet_mode) {
-                cl_processor->set_wavelet (CL_WAVELET_HAAR, CL_IMAGE_CHANNEL_UV | CL_IMAGE_CHANNEL_Y, false);
-            } else if (HARR_WAVELET_BAYES == xcamsrc->wavelet_mode) {
-                cl_processor->set_wavelet (CL_WAVELET_HAAR, CL_IMAGE_CHANNEL_UV | CL_IMAGE_CHANNEL_Y, true);
-            } else {
-                cl_processor->set_wavelet (CL_WAVELET_DISABLED, CL_IMAGE_CHANNEL_UV, false);
-            }
-        }
-
         cl_processor->set_profile ((CL3aImageProcessor::PipelineProfile)xcamsrc->cl_pipe_profile);
         device_manager->add_image_processor (cl_processor);
         device_manager->set_cl_image_processor (cl_processor);
@@ -923,6 +905,25 @@ gst_xcam_src_start (GstBaseSrc *src)
     {
         cl_post_processor->set_defog_mode (CLPostImageProcessor::DefogRetinex);
     }
+
+    if (NONE_WAVELET != xcamsrc->wavelet_mode) {
+        if (HAT_WAVELET_Y == xcamsrc->wavelet_mode) {
+            cl_post_processor->set_wavelet (CL_WAVELET_HAT, CL_IMAGE_CHANNEL_Y, false);
+        } else if (HAT_WAVELET_UV == xcamsrc->wavelet_mode) {
+            cl_post_processor->set_wavelet (CL_WAVELET_HAT, CL_IMAGE_CHANNEL_UV, false);
+        } else if (HARR_WAVELET_Y == xcamsrc->wavelet_mode) {
+            cl_post_processor->set_wavelet (CL_WAVELET_HAAR, CL_IMAGE_CHANNEL_Y, false);
+        } else if (HARR_WAVELET_UV == xcamsrc->wavelet_mode) {
+            cl_post_processor->set_wavelet (CL_WAVELET_HAAR, CL_IMAGE_CHANNEL_UV, false);
+        } else if (HARR_WAVELET_YUV == xcamsrc->wavelet_mode) {
+            cl_post_processor->set_wavelet (CL_WAVELET_HAAR, CL_IMAGE_CHANNEL_UV | CL_IMAGE_CHANNEL_Y, false);
+        } else if (HARR_WAVELET_BAYES == xcamsrc->wavelet_mode) {
+            cl_post_processor->set_wavelet (CL_WAVELET_HAAR, CL_IMAGE_CHANNEL_UV | CL_IMAGE_CHANNEL_Y, true);
+        } else {
+            cl_post_processor->set_wavelet (CL_WAVELET_DISABLED, CL_IMAGE_CHANNEL_UV, false);
+        }
+    }
+
     cl_post_processor->set_wireframe (xcamsrc->enable_wireframe);
 
     device_manager->add_image_processor (cl_post_processor);

--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -70,6 +70,12 @@ typedef enum {
 } WaveletModeType;
 
 typedef enum {
+    DENOISE_3D_NONE = 0,
+    DENOISE_3D_YUV,
+    DENOISE_3D_UV
+} Denoise3DModeType;
+
+typedef enum {
     SIMPLE_ANALYZER = 0,
     AIQ_TUNER_ANALYZER,
     DYNAMIC_ANALYZER,
@@ -93,6 +99,8 @@ struct _GstXCamSrc
     gboolean                     enable_3a;
     gboolean                     enable_usb;
     gboolean                     enable_retinex;
+    Denoise3DModeType            denoise_3d_mode;
+    uint8_t                      denoise_3d_ref_count;
     gboolean                     enable_wireframe;
     char                        *path_to_fake;
 


### PR DESCRIPTION
  * xcamfilter:  fix timestamp issue
  * cl-wireframe: move wireframe and scaler to post image processor
  * cl-wavelet: move wavelet to post image processor
  * smart-analysis: enable smart-analysis for isp mode
  * xcamsrc: support 3D denoise
