### PR TITLE
cl-3d-denoise: fix gradient calculate normalization error

### DIFF
--- a/cl_kernel/kernel_3d_denoise.cl
+++ b/cl_kernel/kernel_3d_denoise.cl
@@ -64,8 +64,8 @@ inline void average_slice(float8 ref,
     }
     gradient = (float8)(grad.s1, grad.s1, grad.s1, grad.s1, grad.s5, grad.s5, grad.s5, grad.s5);
 
-    grad = ((gradient - ref) + (gradient - grad)) * 0.00392157f;
-    //grad = mad(-2, gradient, (ref + grad)) * 0.00392157f;
+    grad = (gradient - ref) * 0.00098039f;
+    //grad = mad(-2, gradient, (ref + grad)) * 0.0004902f;
     grad.s0 = (grad.s0 + grad.s1 + grad.s2 + grad.s3);
     grad.s4 = (grad.s4 + grad.s5 + grad.s6 + grad.s7);
 

--- a/cl_kernel/kernel_wavelet_coeff_variance.cl
+++ b/cl_kernel/kernel_wavelet_coeff_variance.cl
@@ -48,8 +48,8 @@ __kernel void kernel_wavelet_coeff_variance (__read_only image2d_t input, __writ
 
     for (int j = i;  j < SLM_CELL_X_SIZE * SLM_CELL_Y_SIZE; j += WG_CELL_X_SIZE * WG_CELL_Y_SIZE)
     {
-        int x = start_x - SLM_CELL_X_OFFSET + (j % SLM_CELL_X_SIZE);
-        int y = start_y - SLM_CELL_Y_OFFSET + (j / SLM_CELL_Y_SIZE);
+        int x = start_x + (j % SLM_CELL_X_SIZE);
+        int y = start_y + (j / SLM_CELL_X_SIZE);
         local_src_data[j] = read_imagef (input, sampler, (int2)(x, y)) - offset;
     }
     barrier(CLK_LOCAL_MEM_FENCE);


### PR DESCRIPTION
Fix gradient calculate normalization error, and simplify the calculation to improve performance.