### PR TITLE
cl-3d-denoise: optimize read reference image data from shared local m…

### DIFF
--- a/modules/ocl/cl_3d_denoise_handler.cpp
+++ b/modules/ocl/cl_3d_denoise_handler.cpp
@@ -92,7 +92,7 @@ CL3DDenoiseImageKernel::prepare_arguments (
     cl_desc_out.row_pitch = video_info_out.strides[info_index];
 
     _ref_count = _handler->get_ref_framecount ();
-    _gain = -6.0 / _handler->get_denoise_config ().gain;
+    _gain = 6.0 / _handler->get_denoise_config ().gain;
     _thr_y = _handler->get_denoise_config ().threshold[0];
     _thr_uv = _handler->get_denoise_config ().threshold[1];
 


### PR DESCRIPTION
use read uchar8 instead of read uchar4 twice to optimize shared local memory read