### PR TITLE
cl-defog-dcp: add bilateral filter to remove halo

### DIFF
--- a/cl_kernel/kernel_bi_filter.cl
+++ b/cl_kernel/kernel_bi_filter.cl
@@ -1,0 +1,74 @@
+/*
+ * function:     kernel_bi_filter
+ *               bilateral filter
+ * input_y:      Y channel image2d_t as read only
+ * input_dark:   dark channel image2d_t as read only
+ * output_dark:  dark channel image2d_t as write only
+ *
+ * data_type      CL_UNSIGNED_INT16
+ * channel_order  CL_RGBA
+ */
+
+#define PATCH_RADIUS 7
+#define PATCH_DIAMETER (2 * PATCH_RADIUS + 1)
+
+#define CALC_SUM(y1,y2,dark1,dark2) \
+    cur_y = (float8)(y1, y2); \
+    cur_dark = (float8)(dark1, dark2); \
+    calc_sum (cur_y, cur_dark, center_y, &weight_sum, &data_sum);
+
+__inline void calc_sum (float8 cur_y, float8 cur_dark, float8 center_y, float8 *weight_sum, float8 *data_sum)
+{
+    float8 delta = (cur_y - center_y) / 28.0f;
+    delta = -0.5f * delta * delta;
+
+    float8 weight = native_exp(delta);
+    float8 data = cur_dark * weight;
+    (*weight_sum) += weight;
+    (*data_sum) += data;
+}
+
+__kernel void kernel_bi_filter (
+    __read_only image2d_t input_y,
+    __read_only image2d_t input_dark,
+    __write_only image2d_t output_dark)
+{
+    int pos_x = get_global_id (0);
+    int pos_y = get_global_id (1);
+    sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+    float8 y1, y2, dark1, dark2;
+    float8 cur_y, cur_dark;
+
+    float8 weight_sum = 0.0f;
+    float8 data_sum = 0.0f;
+    float8 center_y = convert_float8(as_uchar8(convert_ushort4(read_imageui(input_y, sampler, (int2)(pos_x, pos_y)))));
+    for (int i = 0; i < PATCH_DIAMETER; i++) {
+        y1 = convert_float8(as_uchar8(convert_ushort4(read_imageui(input_y, sampler, (int2)(pos_x - 1, pos_y - PATCH_RADIUS + i)))));
+        y2 = convert_float8(as_uchar8(convert_ushort4(read_imageui(input_y, sampler, (int2)(pos_x, pos_y - PATCH_RADIUS + i)))));
+        dark1 = convert_float8(as_uchar8(convert_ushort4(read_imageui(input_dark, sampler, (int2)(pos_x - 1, pos_y - PATCH_RADIUS + i)))));
+        dark2 = convert_float8(as_uchar8(convert_ushort4(read_imageui(input_dark, sampler, (int2)(pos_x, pos_y - PATCH_RADIUS + i)))));
+        CALC_SUM (y1.s1234567, y2.s0, dark1.s1234567, dark2.s0);
+        CALC_SUM (y1.s234567, y2.s01, dark1.s234567, dark2.s01);
+        CALC_SUM (y1.s34567, y2.s012, dark1.s34567, dark2.s012);
+        CALC_SUM (y1.s4567, y2.s0123, dark1.s4567, dark2.s0123);
+        CALC_SUM (y1.s567, y2.s01234, dark1.s567, dark2.s01234);
+        CALC_SUM (y1.s67, y2.s012345, dark1.s67, dark2.s012345);
+        CALC_SUM (y1.s7, y2.s0123456, dark1.s7, dark2.s0123456);
+        CALC_SUM (y2.s0123, y2.s4567, dark2.s0123, dark2.s4567);
+
+        y1 = convert_float8(as_uchar8(convert_ushort4(read_imageui(input_y, sampler, (int2)(pos_x + 1, pos_y - PATCH_RADIUS + i)))));
+        dark1 = convert_float8(as_uchar8(convert_ushort4(read_imageui(input_dark, sampler, (int2)(pos_x + 1, pos_y - PATCH_RADIUS + i)))));
+        CALC_SUM (y2.s1234567, y1.s0, dark2.s1234567, dark1.s0);
+        CALC_SUM (y2.s234567, y1.s01, dark2.s234567, dark1.s01);
+        CALC_SUM (y2.s34567, y1.s012, dark2.s34567, dark1.s012);
+        CALC_SUM (y2.s4567, y1.s0123, dark2.s4567, dark1.s0123);
+        CALC_SUM (y2.s567, y1.s01234, dark2.s567, dark1.s01234);
+        CALC_SUM (y2.s67, y1.s012345, dark2.s67, dark1.s012345);
+        CALC_SUM (y2.s7, y1.s0123456, dark2.s7, dark1.s0123456);
+    }
+
+    float8 out_data = data_sum / weight_sum;
+    write_imageui(output_dark, (int2)(pos_x, pos_y), convert_uint4(as_ushort4(convert_uchar8(out_data))));
+}
+

--- a/cl_kernel/kernel_defog_dcp.cl
+++ b/cl_kernel/kernel_defog_dcp.cl
@@ -108,18 +108,19 @@ __kernel void kernel_defog_recover (
     transmit_map[0] = max (transmit_map[0], 0.1f);
     transmit_map[1] = max (transmit_map[1], 0.1f);
 
-    in_r[0] = max_r + (in_r[0] - max_r) / transmit_map[0];
-    in_r[1] = max_r + (in_r[1] - max_r) / transmit_map[1];
-    in_g[0] = max_g + (in_g[0] - max_g) / transmit_map[0];
-    in_g[1] = max_g + (in_g[1] - max_g) / transmit_map[1];
-    in_b[0] = max_b + (in_b[0] - max_b) / transmit_map[0];
-    in_b[1] = max_b + (in_b[1] - max_b) / transmit_map[1];
+    float8 gain = 2.0f;  // adjust the brightness temporarily
+    in_r[0] = (max_r + (in_r[0] - max_r) / transmit_map[0]) * gain;
+    in_r[1] = (max_r + (in_r[1] - max_r) / transmit_map[1]) * gain;
+    in_g[0] = (max_g + (in_g[0] - max_g) / transmit_map[0]) * gain;
+    in_g[1] = (max_g + (in_g[1] - max_g) / transmit_map[1]) * gain;
+    in_b[0] = (max_b + (in_b[0] - max_b) / transmit_map[0]) * gain;
+    in_b[1] = (max_b + (in_b[1] - max_b) / transmit_map[1]) * gain;
 
     out_data = 0.299f * in_r[0] + 0.587f * in_g[0] + 0.114f * in_b[0];
     out_data = clamp (out_data, 0.0f, 255.0f);
     write_imageui(out_y, (int2)(pos_x, pos_y), convert_uint4(as_ushort4(convert_uchar8(out_data))));
-    out_data = clamp (out_data, 0.0f, 255.0f);
     out_data = 0.299f * in_r[1] + 0.587f * in_g[1] + 0.114f * in_b[1];
+    out_data = clamp (out_data, 0.0f, 255.0f);
     write_imageui(out_y, (int2)(pos_x, pos_y + 1), convert_uint4(as_ushort4(convert_uchar8(out_data))));
 
     float4 r, g, b;

--- a/clx_kernel/Makefile.am
+++ b/clx_kernel/Makefile.am
@@ -15,6 +15,7 @@ clx_kernel_sources = \
 	kernel_hdr_rgb.clx            \
 	kernel_macc.clx               \
 	kernel_min_filter.clx         \
+	kernel_bi_filter.clx          \
 	kernel_snr.clx                \
 	kernel_tnr_rgb.clx            \
 	kernel_tnr_yuv.clx            \

--- a/modules/ocl/cl_defog_dcp_handler.cpp
+++ b/modules/ocl/cl_defog_dcp_handler.cpp
@@ -26,8 +26,9 @@
 #include "cl_utils.h"
 
 enum {
-    KernelDarkChannel   = 0,
+    KernelDarkChannel = 0,
     KernelMinFilter,
+    KernelBiFilter,
     KernelDefogRecover,
 };
 
@@ -40,6 +41,11 @@ const static XCamKernelInfo kernels_info [] = {
     {
         "kernel_min_filter",
 #include "kernel_min_filter.clx"
+        , 0,
+    },
+    {
+        "kernel_bi_filter",
+#include "kernel_bi_filter.clx"
         , 0,
     },
     {
@@ -171,6 +177,57 @@ CLMinFilterKernel::prepare_arguments (
     return XCAM_RETURN_NO_ERROR;
 }
 
+CLBiFilterKernel::CLBiFilterKernel (
+    SmartPtr<CLContext> &context,
+    SmartPtr<CLDefogDcpImageHandler> &defog_handler)
+    : CLImageKernel (context)
+    , _defog_handler (defog_handler)
+{
+}
+
+XCamReturn
+CLBiFilterKernel::prepare_arguments (
+    SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
+    CLArgument args[], uint32_t &arg_count,
+    CLWorkSize &work_size)
+{
+    XCAM_UNUSED (output);
+    SmartPtr<CLContext> context = get_context ();
+    const VideoBufferInfo & video_info_in = input->get_video_info ();
+
+    CLImageDesc cl_desc_in;
+    cl_desc_in.format.image_channel_data_type = CL_UNSIGNED_INT16;
+    cl_desc_in.format.image_channel_order = CL_RGBA;
+    cl_desc_in.width = video_info_in.width / 8;
+    cl_desc_in.height = video_info_in.height;
+    cl_desc_in.row_pitch = video_info_in.strides[0];
+    _image_in_y = new CLVaImage (context, input, cl_desc_in, video_info_in.offsets[0]);
+
+    SmartPtr<CLImage> &dark_channel_in = _defog_handler->get_dark_map (XCAM_DEFOG_DC_ORIGINAL);
+    SmartPtr<CLImage> &dark_channel_out = _defog_handler->get_dark_map (XCAM_DEFOG_DC_BI_FILTER);
+
+    arg_count = 0;
+    args[arg_count].arg_adress = &_image_in_y->get_mem_id ();
+    args[arg_count].arg_size = sizeof (cl_mem);
+    ++arg_count;
+
+    args[arg_count].arg_adress = &dark_channel_in->get_mem_id ();
+    args[arg_count].arg_size = sizeof (cl_mem);
+    ++arg_count;
+
+    args[arg_count].arg_adress = &dark_channel_out->get_mem_id ();
+    args[arg_count].arg_size = sizeof (cl_mem);
+    ++arg_count;
+
+    work_size.dim = XCAM_DEFAULT_IMAGE_DIM;
+    work_size.local[0] = 16;
+    work_size.local[1] = 2;
+    work_size.global[0] = XCAM_ALIGN_UP (cl_desc_in.width, work_size.local[0]);
+    work_size.global[1] = XCAM_ALIGN_UP (cl_desc_in.height, work_size.local[1]);
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
 CLDefogRecoverKernel::CLDefogRecoverKernel (
     SmartPtr<CLContext> &context, SmartPtr<CLDefogDcpImageHandler> &defog_handler)
     : CLImageKernel (context)
@@ -189,9 +246,9 @@ CLDefogRecoverKernel::get_max_value (SmartPtr<DrmBoBuffer> &buf)
     const float max_percent = 1.0f;
     SmartPtr<X3aStats> stats = buf->find_3a_stats ();
 
-    _max_r = 255.0f;
-    _max_g = 255.0f;
-    _max_b = 255.0f;
+    _max_r = 230.0f;
+    _max_g = 230.0f;
+    _max_b = 230.0f;
     _max_i = XCAM_MAX (_max_r, _max_g);
     _max_i = XCAM_MAX (_max_i, _max_b);
     if (!stats.ptr ())
@@ -226,9 +283,9 @@ CLDefogRecoverKernel::prepare_arguments (
     XCAM_UNUSED (input);
     SmartPtr<CLContext> context = get_context ();
 
-    arg_count = 0;
+    SmartPtr<CLImage> &dark_map = _defog_handler->get_dark_map (XCAM_DEFOG_DC_BI_FILTER);
 
-    SmartPtr<CLImage> &dark_map = _defog_handler->get_dark_map (XCAM_DEFOG_DC_MIN_FILTER_H);
+    arg_count = 0;
     args[arg_count].arg_adress = &dark_map->get_mem_id ();
     args[arg_count].arg_size = sizeof (cl_mem);
     ++arg_count;
@@ -247,7 +304,7 @@ CLDefogRecoverKernel::prepare_arguments (
     args[arg_count].arg_size = sizeof (_max_b);
     ++arg_count;
 
-    for (int i = 0; i < XCAM_DEFOG_MAX_CHANNELS ; ++i) {
+    for (int i = 0; i < XCAM_DEFOG_MAX_CHANNELS; ++i) {
         SmartPtr<CLImage> &input_color = _defog_handler->get_rgb_channel (i);
 
         args[arg_count].arg_adress = &input_color->get_mem_id ();
@@ -371,8 +428,8 @@ CLDefogDcpImageHandler::dump_buffer ()
     uint32_t width, height;
     char file_name[1024];
 
-    // dump dark channel min-filtered map
-    image = _dark_channel_buf[XCAM_DEFOG_DC_MIN_FILTER_H];
+    // dump dark channel bi-filtered map
+    image = _dark_channel_buf[XCAM_DEFOG_DC_BI_FILTER];
     desc = image->get_image_desc ();
     width = image->get_pixel_bytes () * desc.width;
     height = desc.height;
@@ -419,6 +476,21 @@ create_kernel_min_filter (
     return kernel;
 }
 
+SmartPtr<CLBiFilterKernel>
+create_kernel_bi_filter (SmartPtr<CLContext> &context, SmartPtr<CLDefogDcpImageHandler> handler)
+{
+    SmartPtr<CLBiFilterKernel> kernel;
+
+    kernel = new CLBiFilterKernel (context, handler);
+    XCAM_FAIL_RETURN (
+        WARNING,
+        kernel->build_kernel (kernels_info[KernelBiFilter], NULL) == XCAM_RETURN_NO_ERROR,
+        NULL,
+        "Defog build kernel(%s) failed", kernels_info[KernelBiFilter].kernel_name);
+
+    return kernel;
+}
+
 SmartPtr<CLDefogRecoverKernel>
 create_kernel_defog_recover (SmartPtr<CLContext> &context, SmartPtr<CLDefogDcpImageHandler> handler)
 {
@@ -445,12 +517,18 @@ create_cl_defog_dcp_image_handler (SmartPtr<CLContext> &context)
     XCAM_FAIL_RETURN (ERROR, kernel.ptr (), NULL, "defog handler create dark channel kernel failed");
     defog_handler->add_kernel (kernel);
 
+#if 0
     for (int i = XCAM_DEFOG_DC_MIN_FILTER_V; i <= XCAM_DEFOG_DC_MIN_FILTER_H; ++i) {
         SmartPtr<CLImageKernel> min_kernel;
         min_kernel = create_kernel_min_filter (context, defog_handler, i);
         XCAM_FAIL_RETURN (ERROR, min_kernel.ptr (), NULL, "defog handler create min filter kernel failed");
         defog_handler->add_kernel (min_kernel);
     }
+#endif
+
+    kernel = create_kernel_bi_filter (context, defog_handler);
+    XCAM_FAIL_RETURN (ERROR, kernel.ptr (), NULL, "defog handler create bilateral filter kernel failed");
+    defog_handler->add_kernel (kernel);
 
     kernel = create_kernel_defog_recover (context, defog_handler);
     XCAM_FAIL_RETURN (ERROR, kernel.ptr (), NULL, "defog handler create defog recover kernel failed");

--- a/modules/ocl/cl_defog_dcp_handler.h
+++ b/modules/ocl/cl_defog_dcp_handler.h
@@ -26,11 +26,12 @@
 #include "base/xcam_3a_result.h"
 #include "x3a_stats_pool.h"
 
-#define XCAM_DEFOG_DC_ORIGINAL     0
-#define XCAM_DEFOG_DC_MIN_FILTER_V   1
-#define XCAM_DEFOG_DC_MIN_FILTER_H   2
-#define XCAM_DEFOG_DC_REFINED      3
-#define XCAM_DEFOG_DC_MAX_BUF      4
+#define XCAM_DEFOG_DC_ORIGINAL      0
+#define XCAM_DEFOG_DC_MIN_FILTER_V  1
+#define XCAM_DEFOG_DC_MIN_FILTER_H  2
+#define XCAM_DEFOG_DC_BI_FILTER     3
+#define XCAM_DEFOG_DC_REFINED       4
+#define XCAM_DEFOG_DC_MAX_BUF       5
 
 #define XCAM_DEFOG_R_CHANNEL    0
 #define XCAM_DEFOG_G_CHANNEL    1
@@ -82,6 +83,27 @@ private:
 
     SmartPtr<CLDefogDcpImageHandler>   _defog_handler;
     uint32_t                           _buf_index;
+};
+
+class CLBiFilterKernel
+    : public CLImageKernel
+{
+public:
+    explicit CLBiFilterKernel (
+        SmartPtr<CLContext> &context, SmartPtr<CLDefogDcpImageHandler> &defog_handler);
+
+protected:
+    virtual XCamReturn prepare_arguments (
+        SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
+        CLArgument args[], uint32_t &arg_count,
+        CLWorkSize &work_size);
+
+private:
+    XCAM_DEAD_COPY (CLBiFilterKernel);
+
+private:
+    SmartPtr<CLImage>                  _image_in_y;
+    SmartPtr<CLDefogDcpImageHandler>   _defog_handler;
 };
 
 class CLDefogRecoverKernel

--- a/wrapper/gstreamer/gstxcamsrc.h
+++ b/wrapper/gstreamer/gstxcamsrc.h
@@ -70,6 +70,12 @@ typedef enum {
 } WaveletModeType;
 
 typedef enum {
+    DEFOG_NONE = 0,
+    DEFOG_RETINEX,
+    DEFOG_DCP
+} DefogModeType;
+
+typedef enum {
     DENOISE_3D_NONE = 0,
     DENOISE_3D_YUV,
     DENOISE_3D_UV
@@ -98,7 +104,7 @@ struct _GstXCamSrc
     char                        *path_to_3alib;
     gboolean                     enable_3a;
     gboolean                     enable_usb;
-    gboolean                     enable_retinex;
+    DefogModeType                defog_mode;
     Denoise3DModeType            denoise_3d_mode;
     uint8_t                      denoise_3d_ref_count;
     gboolean                     enable_wireframe;


### PR DESCRIPTION
* 	cl-defog-dcp: add bilateral filter to remove halo
* 	xcamsrc: support defog-mode option, merge enable-retinex into defog-mode