### PR TITLE
cl-warp: prformance optimaztion

### DIFF
--- a/cl_kernel/kernel_image_warp.cl
+++ b/cl_kernel/kernel_image_warp.cl
@@ -50,13 +50,14 @@ __kernel void kernel_image_warp (__read_only image2d_t input,
     float* output_pixel = (float*)(&pixel);
     int i = 0;
 
-    t_y = (1.0f - 2.0f * warp_config.trim_ratio) * (float)d_y +
-          warp_config.trim_ratio * (float)height;
-
+    //t_y = (1.0f - 2.0f * warp_config.trim_ratio) * (float)d_y +
+    //      warp_config.trim_ratio * (float)height;
+    t_y = d_y;
 #pragma unroll
     for (i = 0; i < PIXEL_X_STEP; i++) {
-        t_x = (1.0f - 2.0f * warp_config.trim_ratio) * (float)(PIXEL_X_STEP * d_x + i)
-              + warp_config.trim_ratio * (float)(PIXEL_X_STEP * width);
+        //t_x = (1.0f - 2.0f * warp_config.trim_ratio) * (float)(PIXEL_X_STEP * d_x + i)
+        //      + warp_config.trim_ratio * (float)(PIXEL_X_STEP * width);
+        t_x = (float)(PIXEL_X_STEP * d_x + i);
 
         s_x = warp_config.proj_mat[0] * t_x +
               warp_config.proj_mat[1] * t_y +
@@ -104,10 +105,12 @@ __kernel void kernel_image_warp (__read_only image2d_t input,
     const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
 
     // trim coordinate
-    float t_x = (1.0f - 2.0f * warp_config.trim_ratio) * (float)d_x +
-                warp_config.trim_ratio * (float)width;
-    float t_y = (1.0f - 2.0f * warp_config.trim_ratio) * (float)d_y +
-                warp_config.trim_ratio * (float)height;
+    //float t_x = (1.0f - 2.0f * warp_config.trim_ratio) * (float)d_x +
+    //            warp_config.trim_ratio * (float)width;
+    //float t_y = (1.0f - 2.0f * warp_config.trim_ratio) * (float)d_y +
+    //            warp_config.trim_ratio * (float)height;
+    t_x = d_x;
+    t_y = d_y;
 
     // source coordinate
     float s_x = warp_config.proj_mat[0] * t_x +

--- a/cl_kernel/kernel_image_warp.cl
+++ b/cl_kernel/kernel_image_warp.cl
@@ -5,6 +5,9 @@
 * \param[in] warp_config: image warping parameters
 */
 
+// 8 bytes for each pixel
+#define PIXEL_X_STEP   8
+
 typedef struct {
     int frame_id;
     int valid;
@@ -14,62 +17,131 @@ typedef struct {
     float proj_mat[9];
 } CLWarpConfig;
 
+#if WRITE_UINT
 __kernel void kernel_image_warp (__read_only image2d_t input,
                                  __write_only image2d_t output,
                                  CLWarpConfig warp_config)
 {
-#if WARP_Y
-
-#endif
-
-#if WARP_UV
-
-#endif
-
-    int dx = get_global_id(0);
-    int dy = get_global_id(1);
+    // dest coordinate
+    int d_x = get_global_id(0);
+    int d_y = get_global_id(1);
 
     size_t width = get_global_size(0);
     size_t height = get_global_size(1);
 
     const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
 
-    float sx = warp_config.proj_mat[0] * (float)dx + warp_config.proj_mat[1] * (float)dy + warp_config.proj_mat[2];
-    float sy = warp_config.proj_mat[3] * (float)dx + warp_config.proj_mat[4] * (float)dy + warp_config.proj_mat[5];
-    float w = warp_config.proj_mat[6] * (float)dx + warp_config.proj_mat[7] * (float)dy + warp_config.proj_mat[8];
-    w = w != 0.0f ? 1.f / w : 0.0f;
-    float warp_x = (sx * w) / (float)width;
-    float warp_y = (sy * w) / (float)height;
+    // source coordinate
+    float s_x = 0.0f;
+    float s_y = 0.0f;
+    float w = 0.0f;
+    float warp_x = 0.0f;
+    float warp_y = 0.0f;
+
+    // trim coordinate
+    float t_x = 0.0f;
+    float t_y = 0.0f;
+
+    float8 pixel = 0.0f;
+    float* output_pixel = (float*)(&pixel);
+    int i = 0;
+
+#if WARP_Y
+    t_y = (1.0f - 2.0f * warp_config.trim_ratio) * (float)d_y +
+          warp_config.trim_ratio * (float)height;
+
+    for (i = 0; i < PIXEL_X_STEP; i++) {
+        t_x = (1.0f - 2.0f * warp_config.trim_ratio) * (float)(PIXEL_X_STEP * d_x + i)
+              + warp_config.trim_ratio * (float)(PIXEL_X_STEP * width);
+
+        s_x = warp_config.proj_mat[0] * t_x +
+              warp_config.proj_mat[1] * t_y +
+              warp_config.proj_mat[2];
+        s_y = warp_config.proj_mat[3] * t_x +
+              warp_config.proj_mat[4] * t_y +
+              warp_config.proj_mat[5];
+        w = warp_config.proj_mat[6] * t_x +
+            warp_config.proj_mat[7] * t_y +
+            warp_config.proj_mat[8];
+        w = w != 0.0f ? 1.0f / w : 0.0f;
+
+        warp_x = (s_x * w) / (float)(PIXEL_X_STEP * width);
+        warp_y = (s_y * w) / (float)height;
+
+        output_pixel[i] = read_imagef(input, sampler, (float2)(warp_x, warp_y)).x;
+    }
+    write_imageui(output, (int2)(d_x, d_y), convert_uint4(as_ushort4(convert_uchar8(pixel * 255.0f))));
+#endif
+
+#if WARP_UV
+    t_y = (1.0f - 2.0f * warp_config.trim_ratio) * (float)d_y + warp_config.trim_ratio * (float)height;
+
+    for (i = 0; i < (PIXEL_X_STEP >> 1); i++) {
+        t_x = (1.0f - 2.0f * warp_config.trim_ratio) * (float)(PIXEL_X_STEP * d_x + 2 * i)
+              + warp_config.trim_ratio * (float)(PIXEL_X_STEP * width);
+
+        s_x = warp_config.proj_mat[0] * t_x +
+              warp_config.proj_mat[1] * t_y +
+              warp_config.proj_mat[2];
+        s_y = warp_config.proj_mat[3] * t_x +
+              warp_config.proj_mat[4] * t_y +
+              warp_config.proj_mat[5];
+        w = warp_config.proj_mat[6] * t_x +
+            warp_config.proj_mat[7] * t_y +
+            warp_config.proj_mat[8];
+        w = w != 0.0f ? 1.0f / w : 0.0f;
+        warp_x = (s_x * w) / (float)(PIXEL_X_STEP * width);
+
+        warp_y = (s_y * w) / (float)height;
+
+        float2 temp = read_imagef(input, sampler, (float2)(warp_x, warp_y)).xy;
+        output_pixel[2 * i] = temp.x;
+        output_pixel[2 * i + 1] = temp.y;
+    }
+    write_imageui(output, (int2)(d_x, d_y), convert_uint4(as_ushort4(convert_uchar8(pixel * 255.0f))));
+#endif
+
+}
+
+#else
+__kernel void kernel_image_warp (__read_only image2d_t input,
+                                 __write_only image2d_t output,
+                                 CLWarpConfig warp_config)
+{
+    // dest coordinate
+    int d_x = get_global_id(0);
+    int d_y = get_global_id(1);
+
+    size_t width = get_global_size(0);
+    size_t height = get_global_size(1);
+
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
+
+    // trim coordinate
+    float t_x = (1.0f - 2.0f * warp_config.trim_ratio) * (float)d_x +
+                warp_config.trim_ratio * (float)width;
+    float t_y = (1.0f - 2.0f * warp_config.trim_ratio) * (float)d_y +
+                warp_config.trim_ratio * (float)height;
+
+    // source coordinate
+    float s_x = warp_config.proj_mat[0] * t_x +
+                warp_config.proj_mat[1] * t_y +
+                warp_config.proj_mat[2];
+    float s_y = warp_config.proj_mat[3] * t_x +
+                warp_config.proj_mat[4] * t_y +
+                warp_config.proj_mat[5];
+    float w = warp_config.proj_mat[6] * t_x +
+              warp_config.proj_mat[7] * t_y +
+              warp_config.proj_mat[8];
+    w = w != 0.0f ? 1.0f / w : 0.0f;
+
+    float warp_x = (s_x * w) / (float)width;
+    float warp_y = (s_y * w) / (float)height;
 
     float4 pixel = read_imagef(input, sampler, (float2)(warp_x, warp_y));
-    write_imagef(output, (int2)(dx, dy), pixel);
+
+    write_imagef(output, (int2)(d_x, d_y), pixel);
 }
-
-
-__kernel void kernel_image_trim (__read_only image2d_t input,
-                                 __write_only image2d_t output,
-                                 float trim_ratio)
-{
-#if WARP_Y
-
 #endif
-
-#if WARP_UV
-
-#endif
-
-    int dx = get_global_id(0);
-    int dy = get_global_id(1);
-
-    size_t width = get_global_size(0);
-    size_t height = get_global_size(1);
-
-    const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
-    float sx = (1.0f - 2.0f * trim_ratio) * ((float)dx / (float)width) + trim_ratio;
-    float sy = (1.0f - 2.0f * trim_ratio) * ((float)dy / (float)height) + trim_ratio;
-
-    float4 pixel = read_imagef(input, sampler, (float2)(sx, sy));
-    write_imagef(output, (int2)(dx, dy), pixel);
-}
 
 

--- a/modules/ocl/cl_image_warp_handler.cpp
+++ b/modules/ocl/cl_image_warp_handler.cpp
@@ -26,7 +26,8 @@ namespace XCam {
 #define CL_IMAGE_WARP_WG_WIDTH   8
 #define CL_IMAGE_WARP_WG_HEIGHT  4
 
-#define CL_BUFFER_POOL_SIZE     32
+#define CL_BUFFER_POOL_SIZE      20
+#define CL_IMAGE_WARP_WRITE_UINT 1
 
 enum {
     KernelImageWarp   = 0,
@@ -38,12 +39,7 @@ const XCamKernelInfo kernel_image_warp_info [] = {
         "kernel_image_warp",
 #include "kernel_image_warp.clx"
         , 0,
-    },
-    {
-        "kernel_image_trim",
-#include "kernel_image_warp.clx"
-        , 0,
-    },
+    }
 };
 
 CLImageWarpKernel::CLImageWarpKernel (SmartPtr<CLContext> &context,
@@ -78,31 +74,55 @@ CLImageWarpKernel::prepare_arguments (
     }
 
     CLImageDesc cl_desc_in, cl_desc_out;
-    cl_desc_in.format.image_channel_order = CL_RGBA;
+    cl_desc_in.format.image_channel_order = info_index == 0 ? CL_R : CL_RG;
     cl_desc_in.format.image_channel_data_type = CL_UNORM_INT8;
-    cl_desc_in.width = XCAM_ALIGN_UP (video_info_in.width, 4) / 4;
+    cl_desc_in.width = video_info_in.width >> info_index;
     cl_desc_in.height = video_info_in.height >> info_index;
     cl_desc_in.row_pitch = video_info_in.strides[info_index];
 
+#if CL_IMAGE_WARP_WRITE_UINT
+    cl_desc_out.format.image_channel_data_type = CL_UNSIGNED_INT16;
     cl_desc_out.format.image_channel_order = CL_RGBA;
-    cl_desc_out.format.image_channel_data_type = CL_UNORM_INT8;
-    cl_desc_out.width = XCAM_ALIGN_UP (video_info_out.width, 4) / 4;
+    cl_desc_out.width = XCAM_ALIGN_DOWN (video_info_out.width, 4) / 8;
     cl_desc_out.height = video_info_out.height >> info_index;
-    cl_desc_out.row_pitch = video_info_out.strides[info_index];
+#else
+    cl_desc_out.format.image_channel_order = info_index == 0 ? CL_R : CL_RG;
+    cl_desc_out.format.image_channel_data_type = CL_UNORM_INT8;
+    cl_desc_out.width = video_info_out.width >> info_index;
+    cl_desc_out.height = video_info_out.height >> info_index;
+#endif
 
+    cl_desc_out.row_pitch = video_info_out.strides[info_index];
     _image_in = new CLVaImage (context, input, cl_desc_in, video_info_in.offsets[info_index]);
     _input_frame_id ++;
 
     _warp_config = _handler->get_warp_config ();
 
+    if ((_warp_config.trim_ratio > 0.5f) || (_warp_config.trim_ratio < 0.0f)) {
+        _warp_config.trim_ratio = 0.0f;
+    }
+
     /*
-         H(uv) = [1, 0, 0; 0, 0.5, 0; 0, 0, 1] * H(y) * [1, 0, 0; 0, 2, 0; 0, 0, 1]
+       UV plane set same horizontal coordinate as Y plane &
+       set half vertical coordinate of Y plane, need to adjust the projection matrix
+       H(uv) = [1.0, 0, 0; 0, 0.5, 0; 0, 0, 1] * H(y) * [1, 0, 0; 0, 2, 0; 0, 0, 1]
+
+       UV plane set half horizontal coordinate of Y plane &
+       set half vertical coordinate of Y plane, need to adjust the projection matrix
+       H(uv) = [0.5, 0, 0; 0, 0.5, 0; 0, 0, 1] * H(y) * [2, 0, 0; 0, 2, 0; 0, 0, 1]
     */
     if (_channel == CL_IMAGE_CHANNEL_UV) {
+#if CL_IMAGE_WARP_WRITE_UINT
         _warp_config.proj_mat[1] = 2.0 * _warp_config.proj_mat[1];
         _warp_config.proj_mat[3] = 0.5 * _warp_config.proj_mat[3];
         _warp_config.proj_mat[5] = 0.5 * _warp_config.proj_mat[5];
         _warp_config.proj_mat[7] = 2.0 * _warp_config.proj_mat[7];
+#else
+        _warp_config.proj_mat[2] = 0.5 * _warp_config.proj_mat[2];
+        _warp_config.proj_mat[5] = 0.5 * _warp_config.proj_mat[5];
+        _warp_config.proj_mat[6] = 2.0 * _warp_config.proj_mat[6];
+        _warp_config.proj_mat[7] = 2.0 * _warp_config.proj_mat[7];
+#endif
     }
 
     if (_image_in_list.size () >= CL_BUFFER_POOL_SIZE) {
@@ -113,7 +133,8 @@ CLImageWarpKernel::prepare_arguments (
         _image_in_list.push_back (_image_in);
     }
 
-    XCAM_LOG_DEBUG ("@DEBUG image channel(%d), image list size(%d)", _channel, _image_in_list.size());
+    XCAM_LOG_DEBUG ("@DEBUG image channel(%lu), image list size(%u)", _channel, _image_in_list.size());
+    XCAM_LOG_DEBUG ("@DEBUG warp config image size(%dx%d)", _warp_config.width, _warp_config.height);
     XCAM_LOG_DEBUG ("@DEBUG proj_mat[%d]=(%f, %f, %f, %f, %f, %f, %f, %f, %f)", _warp_config.frame_id,
                     _warp_config.proj_mat[0], _warp_config.proj_mat[1], _warp_config.proj_mat[2],
                     _warp_config.proj_mat[3], _warp_config.proj_mat[4], _warp_config.proj_mat[5],
@@ -131,8 +152,8 @@ CLImageWarpKernel::prepare_arguments (
     work_size.dim = XCAM_DEFAULT_IMAGE_DIM;
     work_size.local[0] = CL_IMAGE_WARP_WG_WIDTH;
     work_size.local[1] = CL_IMAGE_WARP_WG_HEIGHT;
-    work_size.global[0] = XCAM_ALIGN_UP (cl_desc_in.width, work_size.local[0]);
-    work_size.global[1] = XCAM_ALIGN_UP(cl_desc_in.height, work_size.local[1]);
+    work_size.global[0] = XCAM_ALIGN_UP (cl_desc_out.width, work_size.local[0]);
+    work_size.global[1] = XCAM_ALIGN_UP(cl_desc_out.height, work_size.local[1]);
 
     std::list<SmartPtr<CLImage>>::iterator it = _image_in_list.begin ();
     args[0].arg_adress = &(*it)->get_mem_id ();
@@ -156,89 +177,12 @@ CLImageWarpKernel::post_execute (SmartPtr<DrmBoBuffer> &output)
         _warp_frame_id ++;
         XCAM_LOG_DEBUG ("@DEBUG POP Image channel(%d), input frame id(%d)", _channel, _input_frame_id);
         XCAM_LOG_DEBUG ("@DEBUG Warp config id(%d), Warp image id(%d)", _warp_config.frame_id, _warp_frame_id);
-        XCAM_LOG_DEBUG ("@DEBUG image list size(%d)", _image_in_list.size());
+        XCAM_LOG_DEBUG ("@DEBUG image list size(%lu)", _image_in_list.size());
         _image_in_list.pop_front ();
-        XCAM_ASSERT (abs(_warp_config.frame_id - _warp_frame_id) <= 2);
+        //XCAM_ASSERT (abs(_warp_config.frame_id - _warp_frame_id) <= 2);
     }
 
     return CLImageKernel::post_execute (output);
-}
-
-CLImageTrimKernel::CLImageTrimKernel (SmartPtr<CLContext> &context,
-                                      const char *name,
-                                      uint32_t channel,
-                                      float trim_ratio,
-                                      SmartPtr<CLImageWarpHandler> &handler)
-    : CLImageKernel (context, name)
-    , _channel (channel)
-    , _trim_ratio (trim_ratio)
-    , _handler (handler)
-{
-}
-
-XCamReturn
-CLImageTrimKernel::prepare_arguments (
-    SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
-    CLArgument args[], uint32_t &arg_count,
-    CLWorkSize &work_size)
-{
-    SmartPtr<CLContext> context = get_context ();
-
-    const VideoBufferInfo & video_info_in = input->get_video_info ();
-    const VideoBufferInfo & video_info_out = output->get_video_info ();
-
-    uint32_t info_index = 0;
-    if (_channel == CL_IMAGE_CHANNEL_Y) {
-        info_index = 0;
-    } else if (_channel == CL_IMAGE_CHANNEL_UV) {
-        info_index = 1;
-    }
-
-    CLImageDesc cl_desc_in, cl_desc_out;
-    cl_desc_in.format.image_channel_order = CL_RGBA;
-    cl_desc_in.format.image_channel_data_type = CL_UNORM_INT8;
-    cl_desc_in.width = XCAM_ALIGN_UP (video_info_in.width, 4) / 4;
-    cl_desc_in.height = video_info_in.height >> info_index;
-    cl_desc_in.row_pitch = video_info_in.strides[info_index];
-
-    cl_desc_out.format.image_channel_order = CL_RGBA;
-    cl_desc_out.format.image_channel_data_type = CL_UNORM_INT8;
-    cl_desc_out.width = XCAM_ALIGN_UP (video_info_out.width, 4) / 4;
-    cl_desc_out.height = video_info_out.height >> info_index;
-    cl_desc_out.row_pitch = video_info_out.strides[info_index];
-
-    _image_in = new CLVaImage (context, input, cl_desc_in, video_info_in.offsets[info_index]);
-    _image_out = new CLVaImage (context, output, cl_desc_out, video_info_out.offsets[info_index]);
-
-    _trim_ratio = _handler->get_warp_config ().trim_ratio;
-    if (_trim_ratio < 0 || _trim_ratio >= 0.5) {
-        _trim_ratio = 0;
-    }
-
-    XCAM_ASSERT (_image_in->is_valid () && _image_out->is_valid ());
-    XCAM_FAIL_RETURN (
-        WARNING,
-        _image_in->is_valid () && _image_out->is_valid (),
-        XCAM_RETURN_ERROR_MEM,
-        "cl image kernel(%s) in/out memory not available", get_kernel_name ());
-
-    //set args;
-    work_size.dim = XCAM_DEFAULT_IMAGE_DIM;
-    work_size.local[0] = CL_IMAGE_WARP_WG_WIDTH;
-    work_size.local[1] = CL_IMAGE_WARP_WG_HEIGHT;
-    work_size.global[0] = XCAM_ALIGN_UP (cl_desc_in.width, work_size.local[0]);
-    work_size.global[1] = XCAM_ALIGN_UP(cl_desc_in.height, work_size.local[1]);
-
-    args[0].arg_adress = &_image_in->get_mem_id ();
-    args[0].arg_size = sizeof (cl_mem);
-    args[1].arg_adress = &_image_out->get_mem_id ();
-    args[1].arg_size = sizeof (cl_mem);
-    args[2].arg_adress = &_trim_ratio;
-    args[2].arg_size = sizeof (_trim_ratio);
-
-    arg_count = 3;
-
-    return XCAM_RETURN_NO_ERROR;
 }
 
 CLImageWarpHandler::CLImageWarpHandler ()
@@ -279,6 +223,10 @@ CLImageWarpHandler::set_warp_config (const XCamDVSResult* config)
     for( int i = 0; i < 9; i++ ) {
         _warp_config.proj_mat[i] = config->proj_mat[i];
     }
+    XCAM_LOG_DEBUG ("@DEBUG set_warp_config[%d]=(%f, %f, %f, %f, %f, %f, %f, %f, %f)", _warp_config.frame_id,
+                    _warp_config.proj_mat[0], _warp_config.proj_mat[1], _warp_config.proj_mat[2],
+                    _warp_config.proj_mat[3], _warp_config.proj_mat[4], _warp_config.proj_mat[5],
+                    _warp_config.proj_mat[6], _warp_config.proj_mat[7], _warp_config.proj_mat[8]);
     return true;
 }
 
@@ -294,9 +242,11 @@ create_kernel_image_warp (SmartPtr<CLContext> &context,
 
     snprintf (build_options, sizeof (build_options),
               " -DWARP_Y=%d "
-              " -DWARP_UV=%d ",
+              " -DWARP_UV=%d "
+              " -DWRITE_UINT=%d",
               (channel == CL_IMAGE_CHANNEL_Y ? 1 : 0),
-              (channel == CL_IMAGE_CHANNEL_UV ? 1 : 0));
+              (channel == CL_IMAGE_CHANNEL_UV ? 1 : 0),
+              (CL_IMAGE_WARP_WRITE_UINT == 1 ? 1 : 0));
 
     warp_kernel = new CLImageWarpKernel (context, "kernel_image_warp", channel, handler);
     XCAM_ASSERT (warp_kernel.ptr ());
@@ -306,33 +256,6 @@ create_kernel_image_warp (SmartPtr<CLContext> &context,
     XCAM_ASSERT (warp_kernel->is_valid ());
 
     return warp_kernel;
-}
-
-SmartPtr<CLImageTrimKernel>
-create_kernel_image_trim (SmartPtr<CLContext> &context,
-                          uint32_t channel,
-                          float trim_ratio,
-                          SmartPtr<CLImageWarpHandler> handler)
-{
-    SmartPtr<CLImageTrimKernel> trim_kernel;
-
-    char build_options[1024];
-    xcam_mem_clear (build_options);
-
-    snprintf (build_options, sizeof (build_options),
-              " -DWARP_Y=%d "
-              " -DWARP_UV=%d ",
-              (channel == CL_IMAGE_CHANNEL_Y ? 1 : 0),
-              (channel == CL_IMAGE_CHANNEL_UV ? 1 : 0));
-
-    trim_kernel = new CLImageTrimKernel (context, "kernel_image_trim", channel, trim_ratio, handler);
-    XCAM_ASSERT (trim_kernel.ptr ());
-    XCAM_FAIL_RETURN (
-        ERROR, trim_kernel->build_kernel (kernel_image_warp_info[KernelImageTrim], build_options) == XCAM_RETURN_NO_ERROR,
-        NULL, "build image trim kernel failed");
-    XCAM_ASSERT (trim_kernel->is_valid ());
-
-    return trim_kernel;
 }
 
 SmartPtr<CLImageHandler>
@@ -352,14 +275,6 @@ create_cl_image_warp_handler (SmartPtr<CLContext> &context)
     warp_kernel = create_kernel_image_warp (context, CL_IMAGE_CHANNEL_UV, warp_handler);
     XCAM_ASSERT (warp_kernel.ptr ());
     warp_handler->add_kernel (warp_kernel);
-
-    trim_kernel = create_kernel_image_trim (context, CL_IMAGE_CHANNEL_Y, 0.1, warp_handler);
-    XCAM_ASSERT (trim_kernel.ptr ());
-    warp_handler->add_kernel (trim_kernel);
-
-    trim_kernel = create_kernel_image_trim (context, CL_IMAGE_CHANNEL_UV, 0.1, warp_handler);
-    XCAM_ASSERT (trim_kernel.ptr ());
-    warp_handler->add_kernel (trim_kernel);
 
     return warp_handler;
 }

--- a/modules/ocl/cl_image_warp_handler.cpp
+++ b/modules/ocl/cl_image_warp_handler.cpp
@@ -113,6 +113,27 @@ CLImageWarpKernel::prepare_arguments (
         _warp_config.proj_mat[7] = 2.0 * _warp_config.proj_mat[7];
     }
 
+    /*
+      Trim image: shift toward origin then scale up
+      Trim Matrix (TMat)
+      TMat = [ scale_x, 0.0f,    shift_x;
+               0.0f,    scale_y, shift_y;
+               1.0f,    1.0f,    1.0f;   ]
+
+      Warp Perspective Matrix = TMat * HMat
+    */
+    float shift_x = _warp_config.trim_ratio * cl_desc_out.width * 8.0f;
+    float shift_y = _warp_config.trim_ratio * cl_desc_out.height;
+    float scale_x = 1.0f - 2.0f * _warp_config.trim_ratio;
+    float scale_y = 1.0f - 2.0f * _warp_config.trim_ratio;
+
+    _warp_config.proj_mat[0] = scale_x * _warp_config.proj_mat[0] + shift_x * _warp_config.proj_mat[6];
+    _warp_config.proj_mat[1] = scale_x * _warp_config.proj_mat[1] + shift_x * _warp_config.proj_mat[7];
+    _warp_config.proj_mat[2] = scale_x * _warp_config.proj_mat[2] + shift_x * _warp_config.proj_mat[8];
+    _warp_config.proj_mat[3] = scale_y * _warp_config.proj_mat[3] + shift_y * _warp_config.proj_mat[6];
+    _warp_config.proj_mat[4] = scale_y * _warp_config.proj_mat[4] + shift_y * _warp_config.proj_mat[7];
+    _warp_config.proj_mat[5] = scale_y * _warp_config.proj_mat[5] + shift_y * _warp_config.proj_mat[8];
+
     if (_image_in_list.size () >= CL_BUFFER_POOL_SIZE) {
         XCAM_LOG_DEBUG ("image list pop front");
         _image_in_list.pop_front ();
@@ -163,7 +184,7 @@ CLImageWarpKernel::post_execute (SmartPtr<DrmBoBuffer> &output)
 {
     if (_warp_config.valid > 0) {
         _warp_frame_id ++;
-        XCAM_LOG_DEBUG ("POP Image channel(%d), input frame id(%d)", _channel, _input_frame_id);
+        XCAM_LOG_DEBUG ("POP Image input frame id(%d), channel(%d)", _input_frame_id, _channel);
         XCAM_LOG_DEBUG ("Warp config id(%d), Warp image id(%d)", _warp_config.frame_id, _warp_frame_id);
         XCAM_LOG_DEBUG ("image list size(%lu)", _image_in_list.size());
         _image_in_list.pop_front ();
@@ -178,7 +199,7 @@ CLImageWarpHandler::CLImageWarpHandler ()
 {
     _warp_config.frame_id = -1;
     _warp_config.valid = -1;
-    _warp_config.trim_ratio = 0.05f;
+    _warp_config.trim_ratio = 0.1f;
     reset_projection_matrix ();
 }
 

--- a/modules/ocl/cl_image_warp_handler.h
+++ b/modules/ocl/cl_image_warp_handler.h
@@ -80,7 +80,7 @@ class CLImageWarpHandler
 public:
     explicit CLImageWarpHandler ();
 
-    bool set_warp_config (const XCamDVSResult* config);
+    bool set_warp_config (const XCamDVSResult& config);
     const CLWarpConfig& get_warp_config () const {
         return _warp_config;
     };

--- a/modules/ocl/cl_image_warp_handler.h
+++ b/modules/ocl/cl_image_warp_handler.h
@@ -74,30 +74,6 @@ private:
     CLImagePtrList _image_in_list;
 };
 
-class CLImageTrimKernel
-    : public CLImageKernel
-{
-public:
-    explicit CLImageTrimKernel (SmartPtr<CLContext> &context,
-                                const char *name,
-                                uint32_t channel,
-                                float trim_ratio,
-                                SmartPtr<CLImageWarpHandler> &handler);
-
-protected:
-    virtual XCamReturn prepare_arguments (
-        SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
-        CLArgument args[], uint32_t &arg_count,
-        CLWorkSize &work_size);
-
-private:
-    XCAM_DEAD_COPY (CLImageTrimKernel);
-
-    uint32_t _channel;
-    float _trim_ratio;
-    SmartPtr<CLImageWarpHandler> _handler;
-};
-
 class CLImageWarpHandler
     : public CLImageHandler
 {

--- a/modules/ocl/cl_post_image_processor.cpp
+++ b/modules/ocl/cl_post_image_processor.cpp
@@ -198,7 +198,7 @@ CLPostImageProcessor::apply_3a_result (SmartPtr<X3aResult> &result)
         SmartPtr<X3aDVSResult> dvs_res = result.dynamic_cast_ptr<X3aDVSResult> ();
         XCAM_ASSERT (dvs_res.ptr ());
         if (_image_warp.ptr ()) {
-            _image_warp->set_warp_config (dvs_res->get_standard_result_ptr ());
+            _image_warp->set_warp_config (dvs_res->get_standard_result ());
         }
         break;
     }


### PR DESCRIPTION
     * handler 8 pixels in one work item
     * combine cl warp kernel and cl trim kernel
     * test cmdline, need set <buffercount=32 enable-warp=1>
       $ gst-launch-1.0 filesrc location=test.nv12 ! videoparse \
         width=1920 height=1080 format=nv12 ! xcamfilter copy-mode=1 \
         buffercount=32  enable-warp=1 ! queue ! vaapiencode_h264 \
         rate-control=cbr ! tcpclientsink host="$ip" port=3000
