### PR TITLE
cl-warp: fix bug: trim matrix x shift should multiple by 8 in case of…

### DIFF
--- a/cl_kernel/kernel_image_warp.cl
+++ b/cl_kernel/kernel_image_warp.cl
@@ -101,18 +101,15 @@ kernel_image_warp_1_pixel (
 
     const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
 
-    t_x = d_x;
-    t_y = d_y;
-
     // source coordinate
-    float s_x = warp_config.proj_mat[0] * t_x +
-                warp_config.proj_mat[1] * t_y +
+    float s_x = warp_config.proj_mat[0] * d_x +
+                warp_config.proj_mat[1] * d_y +
                 warp_config.proj_mat[2];
-    float s_y = warp_config.proj_mat[3] * t_x +
-                warp_config.proj_mat[4] * t_y +
+    float s_y = warp_config.proj_mat[3] * d_x +
+                warp_config.proj_mat[4] * d_y +
                 warp_config.proj_mat[5];
-    float w = warp_config.proj_mat[6] * t_x +
-              warp_config.proj_mat[7] * t_y +
+    float w = warp_config.proj_mat[6] * d_x +
+              warp_config.proj_mat[7] * d_y +
               warp_config.proj_mat[8];
     w = w != 0.0f ? 1.0f / w : 0.0f;
 

--- a/modules/ocl/cl_image_warp_handler.cpp
+++ b/modules/ocl/cl_image_warp_handler.cpp
@@ -131,7 +131,11 @@ CLImageWarpKernel::prepare_arguments (
 
       Warp Perspective Matrix = TMat * HMat
     */
+#if CL_IMAGE_WARP_WRITE_UINT
     float shift_x = _warp_config.trim_ratio * cl_desc_out.width * 8.0f;
+#else
+    float shift_x = _warp_config.trim_ratio * cl_desc_out.width;
+#endif
     float shift_y = _warp_config.trim_ratio * cl_desc_out.height;
     float scale_x = 1.0f - 2.0f * _warp_config.trim_ratio;
     float scale_y = 1.0f - 2.0f * _warp_config.trim_ratio;
@@ -208,7 +212,7 @@ CLImageWarpHandler::CLImageWarpHandler ()
 {
     _warp_config.frame_id = -1;
     _warp_config.valid = -1;
-    _warp_config.trim_ratio = 0.1f;
+    _warp_config.trim_ratio = 0.10f;
     reset_projection_matrix ();
 }
 


### PR DESCRIPTION
fix bug for warp 8 pixel kernel