### PR TITLE
cl-framework: optimize processor buffer mangement

### DIFF
--- a/modules/ocl/cl_image_handler.cpp
+++ b/modules/ocl/cl_image_handler.cpp
@@ -260,6 +260,17 @@ CLImageHandler::create_buffer_pool (const VideoBufferInfo &video_info)
     return XCAM_RETURN_NO_ERROR;
 }
 
+bool CLImageHandler::is_ready ()
+{
+    if (_disable_buf_pool)
+        return true;
+    if (!_buf_pool.ptr ())  //execute not triggered
+        return true;
+    if (_buf_pool->has_free_buffers ())
+        return true;
+    return false;
+}
+
 XCamReturn CLImageHandler::prepare_buffer_pool_video_info (
     const VideoBufferInfo &input,
     VideoBufferInfo &output)
@@ -309,6 +320,7 @@ CLImageHandler::prepare_output_buf (SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBo
         XCAM_RETURN_ERROR_UNKNOWN,
         "CLImageHandler(%s) failed to get drm buffer from pool", XCAM_STR (_name));
 
+    // TODO, need consider output is not sync up with input buffer
     new_buf->set_timestamp (input->get_timestamp ());
     new_buf->copy_attaches (input);
 

--- a/modules/ocl/cl_image_handler.h
+++ b/modules/ocl/cl_image_handler.h
@@ -131,6 +131,7 @@ public:
     bool set_kernels_enable (bool enable);
     bool is_kernels_enabled () const;
 
+    virtual bool is_ready ();
     XCamReturn execute (SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output);
     virtual void emit_stop ();
 

--- a/modules/ocl/cl_image_processor.h
+++ b/modules/ocl/cl_image_processor.h
@@ -38,6 +38,7 @@ class CLImageProcessor
 {
 public:
     typedef std::list<SmartPtr<CLImageHandler>>  ImageHandlerList;
+    typedef std::list<SmartPtr<PriorityBuffer>>  UnsafePriorityBufferList;
     friend class CLHandlerThread;
     friend class CLBufferNotifyThread;
 
@@ -68,6 +69,8 @@ private:
 
     XCamReturn process_cl_buffer_queue ();
     XCamReturn process_done_buffer ();
+    void check_ready_buffers ();
+
     XCAM_DEAD_COPY (CLImageProcessor);
 
 protected:
@@ -82,6 +85,7 @@ private:
     ImageHandlerList               _handlers;
     SmartPtr<CLHandlerThread>      _handler_thread;
     PriorityBufferQueue            _process_buffer_queue;
+    UnsafePriorityBufferList       _not_ready_buffers;
     SmartPtr<CLBufferNotifyThread> _done_buf_thread;
     SafeList<DrmBoBuffer>          _done_buffer_queue;
     uint32_t                       _seq_num;

--- a/xcore/buffer_pool.h
+++ b/xcore/buffer_pool.h
@@ -120,6 +120,10 @@ public:
         return _buffer_info;
     }
 
+    bool has_free_buffers () {
+        return !_buf_list.is_empty ();
+    }
+
 protected:
     virtual bool fixate_video_info (VideoBufferInfo &info);
     virtual SmartPtr<BufferData> allocate_data (const VideoBufferInfo &buffer_info) = 0;


### PR DESCRIPTION
 * manange processor buffer sequence and only when buffer-pool is avaiable.
 * add CLImageHandler::is_ready() interface to check handler status.
