### PR TITLE
xcamfilter: support dma buffer sharing on sink pad

### DIFF
--- a/wrapper/gstreamer/Makefile.am
+++ b/wrapper/gstreamer/Makefile.am
@@ -108,6 +108,7 @@ endif
 
 # headers we need but don't want installed
 noinst_HEADERS = \
+    gst_xcam_utils.h  \
     $(NULL)
 
 if ENABLE_IA_AIQ

--- a/wrapper/gstreamer/gst_xcam_utils.h
+++ b/wrapper/gstreamer/gst_xcam_utils.h
@@ -1,0 +1,50 @@
+/*
+ * gst_xcam_utils.h - gst xcam utilities
+ *
+ *  Copyright (c) 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Yinhang Liu <yinhangx.liu@intel.com>
+ */
+
+#ifndef GST_XCAM_UTILS_H
+#define GST_XCAM_UTILS_H
+
+#include "dma_video_buffer.h"
+
+using namespace XCam;
+
+class DmaGstBuffer
+    : public DmaVideoBuffer
+{
+public:
+    DmaGstBuffer (const VideoBufferInfo &info, int dma_fd, GstBuffer *gst_buf)
+        : DmaVideoBuffer (info, dma_fd)
+        , _gst_buf (gst_buf)
+    {
+        gst_buffer_ref (_gst_buf);
+    }
+
+    ~DmaGstBuffer () {
+        gst_buffer_unref (_gst_buf);
+    }
+
+private:
+    XCAM_DEAD_COPY (DmaGstBuffer);
+
+private:
+    GstBuffer *_gst_buf;
+};
+
+#endif // GST_XCAM_UTILS_H

--- a/wrapper/gstreamer/gstxcamfilter.h
+++ b/wrapper/gstreamer/gstxcamfilter.h
@@ -25,6 +25,7 @@
 #include <gst/video/video.h>
 
 #include "main_pipe_manager.h"
+#include "gst_xcam_utils.h"
 
 using namespace XCam;
 using namespace GstXCam;

--- a/xcore/drm_bo_buffer.h
+++ b/xcore/drm_bo_buffer.h
@@ -108,15 +108,15 @@ public:
 
     bool update_swap_init_order (uint32_t init_order);
 
+    SmartPtr<DrmDisplay> &get_drm_display () {
+        return _display;
+    }
+
 protected:
     // derived from BufferPool
     virtual bool fixate_video_info (VideoBufferInfo &info);
     virtual SmartPtr<BufferData> allocate_data (const VideoBufferInfo &buffer_info);
     virtual SmartPtr<BufferProxy> create_buffer_from_data (SmartPtr<BufferData> &data);
-
-    SmartPtr<DrmDisplay> &get_drm_display () {
-        return _display;
-    }
 
     bool init_swap_order (VideoBufferInfo &info);
 


### PR DESCRIPTION
 * fix aligned issue on buf_info initialization
 * command line:
   # gst-launch-1.0 xcamsrc io-mode=4 imageprocessor=1 analyzer=2 \
     pipe-profile=2 ! video/x-raw, format=NV12, width=1920, \
     height=1080, framerate=25/1 ! xcamfilter copy-mode=1 \
     ! queue ! vaapiencode_h264 rate-control=cbr ! tcpclientsink \
     host="host_ip" port=3000 blocksize=1024000 sync=false