### PR TITLE
cl-warp: get CL image width & height with kernel Api

### DIFF
--- a/cl_kernel/kernel_image_warp.cl
+++ b/cl_kernel/kernel_image_warp.cl
@@ -30,8 +30,8 @@ kernel_image_warp_8_pixel (
     int d_x = get_global_id(0);
     int d_y = get_global_id(1);
 
-    size_t width = get_global_size(0);
-    size_t height = get_global_size(1);
+    int out_width = get_image_width (output);
+    int out_height = get_image_height (output);
 
     const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
 
@@ -65,8 +65,8 @@ kernel_image_warp_8_pixel (
             warp_config.proj_mat[8];
         w = w != 0.0f ? 1.0f / w : 0.0f;
 
-        warp_x = (s_x * w) / (float)(PIXEL_X_STEP * width);
-        warp_y = (s_y * w) / (float)height;
+        warp_x = (s_x * w) / (float)(PIXEL_X_STEP * out_width);
+        warp_y = (s_y * w) / (float)out_height;
 
 #if WARP_Y
         output_pixel[i] = read_imagef(input, sampler, (float2)(warp_x, warp_y)).x;
@@ -95,8 +95,8 @@ kernel_image_warp_1_pixel (
     int d_x = get_global_id(0);
     int d_y = get_global_id(1);
 
-    size_t width = get_global_size(0);
-    size_t height = get_global_size(1);
+    int out_width = get_image_width (output);
+    int out_height = get_image_height (output);
 
     const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
 
@@ -112,8 +112,8 @@ kernel_image_warp_1_pixel (
               warp_config.proj_mat[8];
     w = w != 0.0f ? 1.0f / w : 0.0f;
 
-    float warp_x = (s_x * w) / (float)width;
-    float warp_y = (s_y * w) / (float)height;
+    float warp_x = (s_x * w) / (float)out_width;
+    float warp_y = (s_y * w) / (float)out_height;
 
     float4 pixel = read_imagef(input, sampler, (float2)(warp_x, warp_y));
 

--- a/modules/ocl/cl_image_warp_handler.cpp
+++ b/modules/ocl/cl_image_warp_handler.cpp
@@ -88,7 +88,7 @@ CLImageWarpKernel::prepare_arguments (
 #if CL_IMAGE_WARP_WRITE_UINT
     cl_desc_out.format.image_channel_data_type = info_index == 0 ? CL_UNSIGNED_INT16 : CL_UNSIGNED_INT32;
     cl_desc_out.format.image_channel_order = CL_RGBA;
-    cl_desc_out.width = XCAM_ALIGN_DOWN (video_info_out.width >> info_index, 4) / 8;
+    cl_desc_out.width = XCAM_ALIGN_DOWN (video_info_out.width >> info_index, 8) / 8;
     cl_desc_out.height = video_info_out.height >> info_index;
 #else
     cl_desc_out.format.image_channel_order = info_index == 0 ? CL_R : CL_RG;
@@ -171,16 +171,18 @@ CLImageWarpKernel::prepare_arguments (
     work_size.global[0] = XCAM_ALIGN_UP (cl_desc_out.width, work_size.local[0]);
     work_size.global[1] = XCAM_ALIGN_UP(cl_desc_out.height, work_size.local[1]);
 
-    args[0].arg_adress = &_image_in->get_mem_id ();
-    args[0].arg_size = sizeof (cl_mem);
+    arg_count = 0;
+    args[arg_count].arg_adress = &_image_in->get_mem_id ();
+    args[arg_count].arg_size = sizeof (cl_mem);
+    ++arg_count;
 
-    args[1].arg_adress = &_image_out->get_mem_id ();
-    args[1].arg_size = sizeof (cl_mem);
+    args[arg_count].arg_adress = &_image_out->get_mem_id ();
+    args[arg_count].arg_size = sizeof (cl_mem);
+    ++arg_count;
 
-    args[2].arg_adress = &_warp_config;
-    args[2].arg_size = sizeof (_warp_config);
-
-    arg_count = 3;
+    args[arg_count].arg_adress = &_warp_config;
+    args[arg_count].arg_size = sizeof (_warp_config);
+    ++arg_count;
 
     return XCAM_RETURN_NO_ERROR;
 }


### PR DESCRIPTION
retrieve CL image size with kernel APi
  int get_image_width (image2d_t image) / int get_image_height (image2d_t image)