### PR TITLE
xcam-thread: fix crash issue when thread stopped

### DIFF
--- a/xcore/xcam_thread.h
+++ b/xcore/xcam_thread.h
@@ -55,6 +55,7 @@ private:
     XCam::Mutex     _mutex;
     XCam::Cond      _exit_cond;
     bool            _started;
+    bool            _stopped;
 };
 
 };


### PR DESCRIPTION
 * fix bug when thread invoked stop() , object may be deleted
   before stopped().
   bug: https://github.com/01org/libxcam/issues/401