### PR TITLE
cl-360-stitch: auto-scale whole image for quality

### DIFF
--- a/modules/ocl/cl_image_360_stitch.cpp
+++ b/modules/ocl/cl_image_360_stitch.cpp
@@ -22,6 +22,76 @@
 
 namespace XCam {
 
+CLPyramidGlobalScaleKernel::CLPyramidGlobalScaleKernel (SmartPtr<CLContext> &context, bool is_uv)
+    : CLPyramidScaleKernel (context, is_uv)
+{
+}
+
+SmartPtr<CLImage>
+CLPyramidGlobalScaleKernel::get_input_image (SmartPtr<DrmBoBuffer> &input) {
+    SmartPtr<CLContext> context = get_context ();
+
+    CLImageDesc cl_desc;
+    SmartPtr<CLImage> cl_image;
+    const VideoBufferInfo &buf_info = input->get_video_info ();
+
+    cl_desc.format.image_channel_data_type = CL_UNORM_INT8;
+    if (_is_uv) {
+        cl_desc.format.image_channel_order = CL_RG;
+        cl_desc.width = buf_info.width / 2;
+        cl_desc.height = buf_info.height / 2;
+        cl_desc.row_pitch = buf_info.strides[1];
+        cl_image = new CLVaImage (context, input, cl_desc, buf_info.offsets[1]);
+    } else {
+        cl_desc.format.image_channel_order = CL_R;
+        cl_desc.width = buf_info.width;
+        cl_desc.height = buf_info.height;
+        cl_desc.row_pitch = buf_info.strides[0];
+        cl_image = new CLVaImage (context, input, cl_desc, buf_info.offsets[0]);
+    }
+
+    return cl_image;
+}
+
+SmartPtr<CLImage>
+CLPyramidGlobalScaleKernel::get_output_image (SmartPtr<DrmBoBuffer> &output) {
+    SmartPtr<CLContext> context = get_context ();
+
+    CLImageDesc cl_desc;
+    SmartPtr<CLImage> cl_image;
+    const VideoBufferInfo &buf_info = output->get_video_info ();
+
+    cl_desc.format.image_channel_data_type = CL_UNSIGNED_INT16;
+    cl_desc.format.image_channel_order = CL_RGBA;
+    if (_is_uv) {
+        cl_desc.width = buf_info.width / 8;
+        cl_desc.height = buf_info.height / 2;
+        cl_desc.row_pitch = buf_info.strides[1];
+        cl_image = new CLVaImage (context, output, cl_desc, buf_info.offsets[1]);
+    } else {
+        cl_desc.width = buf_info.width / 8;
+        cl_desc.height = buf_info.height;
+        cl_desc.row_pitch = buf_info.strides[0];
+        cl_image = new CLVaImage (context, output, cl_desc, buf_info.offsets[0]);
+    }
+
+    return cl_image;
+}
+
+bool
+CLPyramidGlobalScaleKernel::get_output_info (
+    SmartPtr<DrmBoBuffer> &output,
+    uint32_t &out_width, uint32_t &out_height, int &out_offset_x)
+{
+    const VideoBufferInfo &output_info = output->get_video_info ();
+
+    out_width = output_info.width / 8;
+    out_height = _is_uv ? output_info.height / 2 : output_info.height;
+    out_offset_x = 0;
+
+    return true;
+}
+
 CLImage360Stitch::CLImage360Stitch (CLBlenderScaleMode scale_mode)
     : CLMultiImageHandler ("CLImage360Stitch")
     , _output_width (0)
@@ -232,29 +302,117 @@ CLImage360Stitch::prepare_local_scale_blender_parameters (
     return ret;
 }
 
+SmartPtr<DrmBoBuffer>
+CLImage360Stitch::create_scale_input_buffer (SmartPtr<DrmBoBuffer> &output)
+{
+    VideoBufferInfo buf_info;
+    const VideoBufferInfo &output_info = output->get_video_info ();
+
+    uint32_t preset_width = XCAM_ALIGN_UP (output_info.width + XCAM_PYRAMID_GLOBAL_SCALE_EXT_WIDTH, 16);
+    buf_info.init (
+        output_info.format, preset_width, output_info.height,
+        XCAM_ALIGN_UP (preset_width, 16),
+        XCAM_ALIGN_UP (output_info.height, 16));
+
+    SmartPtr<DrmDisplay> display = DrmDisplay::instance ();
+    SmartPtr<BufferPool> buf_pool = new DrmBoBufferPool (display);
+    XCAM_ASSERT (buf_pool.ptr ());
+    buf_pool->set_video_info (buf_info);
+    if (!buf_pool->reserve (1)) {
+        XCAM_LOG_ERROR ("init buffer pool failed");
+        return NULL;
+    }
+
+    return buf_pool->get_buffer (buf_pool).dynamic_cast_ptr<DrmBoBuffer> ();
+}
+
+XCamReturn
+CLImage360Stitch::reset_buffer_info (SmartPtr<DrmBoBuffer> &input)
+{
+    VideoBufferInfo reset_info;
+    const VideoBufferInfo &buf_info = input->get_video_info ();
+
+    Rect img0_left = get_image_overlap (ImageIdxMain, 0);
+    Rect img0_right = get_image_overlap (ImageIdxMain, 1);
+    Rect img1_left = get_image_overlap (ImageIdxSecondary, 0);
+    Rect img1_right = get_image_overlap (ImageIdxSecondary, 1);
+
+    uint32_t reset_width = img0_right.pos_x - img0_left.pos_x + img1_right.pos_x - img1_left.pos_x;
+    reset_width = XCAM_ALIGN_UP (reset_width, XCAM_BLENDER_ALIGNED_WIDTH);
+    reset_info.init (buf_info.format, reset_width, buf_info.height,
+                     buf_info.aligned_width, buf_info.aligned_height);
+
+    input->set_video_info (reset_info);
+    return XCAM_RETURN_NO_ERROR;
+}
+
+
 XCamReturn
 CLImage360Stitch::prepare_parameters (SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output)
 {
     XCamReturn ret = XCAM_RETURN_NO_ERROR;
 
-    SmartPtr<DrmBoBuffer> input1 = input->find_typed_attach<DrmBoBuffer> ();
+    SmartPtr<DrmBoBuffer> input0 = input;
+    SmartPtr<DrmBoBuffer> input1 = input0->find_typed_attach<DrmBoBuffer> ();
     XCAM_FAIL_RETURN(
         WARNING,
         input1.ptr (),
         XCAM_RETURN_ERROR_PARAM,
         "CLImage360Stitch(%s) does NOT find second buffer in attachment", get_name());
 
+    SmartPtr<DrmBoBuffer> scale_input;
     if (_scale_mode == CLBlenderScaleLocal)
-        ret = prepare_local_scale_blender_parameters (input, input1, output);
-    else
-        ret = prepare_global_scale_blender_parameters (input, input1, output);
+        ret = prepare_local_scale_blender_parameters (input0, input1, output);
+    else {
+        scale_input = create_scale_input_buffer (output);
+        XCAM_ASSERT (scale_input.ptr ());
+        ret = prepare_global_scale_blender_parameters (input0, input1, scale_input);
+    }
     XCAM_FAIL_RETURN(
         WARNING,
         ret == XCAM_RETURN_NO_ERROR,
         XCAM_RETURN_ERROR_PARAM,
         "CLImage360Stitch(%s) failed to prepare blender parameters", get_name());
 
-    return CLMultiImageHandler::prepare_parameters (input, output);
+    if (_scale_mode == CLBlenderScaleLocal) {
+        ret = CLMultiImageHandler::prepare_parameters (input0, output);
+    } else {
+        ret = CLMultiImageHandler::prepare_parameters (input0, scale_input);
+        XCAM_FAIL_RETURN(
+            WARNING,
+            ret == XCAM_RETURN_NO_ERROR,
+            XCAM_RETURN_ERROR_PARAM,
+            "CLImage360Stitch(%s) failed to prepare parameters", get_name());
+
+        input = scale_input;
+        reset_buffer_info (input);
+    }
+
+    return ret;
+}
+
+SmartPtr<CLImageKernel>
+create_pyramid_global_scale_kernel (SmartPtr<CLContext> &context, bool is_uv)
+{
+    char transform_option[1024];
+    snprintf (transform_option, sizeof(transform_option), "-DPYRAMID_UV=%d", is_uv ? 1 : 0);
+
+    const XCamKernelInfo &kernel_info = {
+        "kernel_pyramid_scale",
+#include "kernel_gauss_lap_pyramid.clx"
+        , 0
+    };
+
+    SmartPtr<CLImageKernel> kernel;
+    kernel = new CLPyramidGlobalScaleKernel (context, is_uv);
+    XCAM_ASSERT (kernel.ptr ());
+    XCAM_FAIL_RETURN (
+        ERROR,
+        kernel->build_kernel (kernel_info, transform_option) == XCAM_RETURN_NO_ERROR,
+        NULL,
+        "load pyramid global scaling kernel(%s) failed", is_uv ? "UV" : "Y");
+
+    return kernel;
 }
 
 SmartPtr<CLImageHandler>
@@ -276,6 +434,16 @@ create_image_360_stitch (SmartPtr<CLContext> &context, bool need_seam, CLBlender
     XCAM_FAIL_RETURN (ERROR, right_blender.ptr (), NULL, "image_360_stitch create right blender failed");
     right_blender->disable_buf_pool (true);
     stitch->set_right_blender (right_blender);
+
+    if (scale_mode == CLBlenderScaleGlobal) {
+        int max_plane = need_uv ? 2 : 1;
+        bool uv_status[2] = {false, true};
+        for (int plane = 0; plane < max_plane; ++plane) {
+            SmartPtr<CLImageKernel> kernel = create_pyramid_global_scale_kernel (context, uv_status[plane]);
+            XCAM_FAIL_RETURN (ERROR, kernel.ptr (), NULL, "create pyramid global scaling kernel failed");
+            stitch->add_kernel (kernel);
+        }
+    }
 
     return stitch;
 }

--- a/modules/ocl/cl_image_360_stitch.h
+++ b/modules/ocl/cl_image_360_stitch.h
@@ -24,8 +24,28 @@
 #include "xcam_utils.h"
 #include "cl_multi_image_handler.h"
 #include "cl_blender.h"
+#include "cl_pyramid_blender.h"
+
+#define XCAM_PYRAMID_GLOBAL_SCALE_EXT_WIDTH 64
 
 namespace XCam {
+
+class CLPyramidGlobalScaleKernel
+    : public CLPyramidScaleKernel
+{
+public:
+    explicit CLPyramidGlobalScaleKernel (SmartPtr<CLContext> &context, bool is_uv);
+
+protected:
+    virtual SmartPtr<CLImage> get_input_image (SmartPtr<DrmBoBuffer> &input);
+    virtual SmartPtr<CLImage> get_output_image (SmartPtr<DrmBoBuffer> &output);
+
+    virtual bool get_output_info (
+        SmartPtr<DrmBoBuffer> &output, uint32_t &out_width, uint32_t &out_height, int &out_offset_x);
+
+private:
+    XCAM_DEAD_COPY (CLPyramidGlobalScaleKernel);
+};
 
 class CLImage360Stitch
     : public CLMultiImageHandler
@@ -59,6 +79,8 @@ protected:
         VideoBufferInfo &output);
     virtual XCamReturn prepare_parameters (SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output);
 
+    SmartPtr<DrmBoBuffer> create_scale_input_buffer (SmartPtr<DrmBoBuffer> &output);
+    XCamReturn reset_buffer_info (SmartPtr<DrmBoBuffer> &input);
     XCamReturn prepare_global_scale_blender_parameters (
         SmartPtr<DrmBoBuffer> &input0, SmartPtr<DrmBoBuffer> &input1, SmartPtr<DrmBoBuffer> &output);
 
@@ -76,6 +98,9 @@ private:
     Rect                   _overlaps[ImageIdxCount][2];   // 2=>Overlap0 and overlap1
     CLBlenderScaleMode     _scale_mode;
 };
+
+SmartPtr<CLImageKernel>
+create_pyramid_global_scale_kernel (SmartPtr<CLContext> &context, bool is_uv = false);
 
 SmartPtr<CLImageHandler>
 create_image_360_stitch (

--- a/modules/ocl/cl_pyramid_blender.cpp
+++ b/modules/ocl/cl_pyramid_blender.cpp
@@ -1650,23 +1650,13 @@ CLPyramidBlender::dump_buffers ()
 
 }
 
-CLPyramidScaleKernel::CLPyramidScaleKernel (
-    SmartPtr<CLContext> &context, SmartPtr<CLPyramidBlender> &blender, bool is_uv)
+CLPyramidScaleKernel::CLPyramidScaleKernel (SmartPtr<CLContext> &context, bool is_uv)
     : CLImageKernel (context)
-    , _blender (blender)
     , _is_uv (is_uv)
-    , _out_offset_x (0)
+    , _output_offset_x (0)
     , _output_width (0)
     , _output_height (0)
 {
-}
-
-int
-CLPyramidScaleKernel::get_output_offset_x ()
-{
-    const Rect &window = _blender->get_merge_window ();
-    XCAM_ASSERT (window.pos_x % XCAM_BLENDER_ALIGNED_WIDTH == 0);
-    return window.pos_x;
 }
 
 XCamReturn
@@ -1679,48 +1669,22 @@ CLPyramidScaleKernel::prepare_arguments (
     XCAM_UNUSED (output);
     SmartPtr<CLContext> context = get_context ();
 
-    SmartPtr<CLImage> image_in = get_input_scale ();
-    SmartPtr<CLImage> image_out = get_output_scale ();
-    const CLImageDesc &desc_in = image_in->get_image_desc ();
-
-    const Rect &window = _blender->get_merge_window ();
-    _output_width = window.width / 8;
-    _output_height = desc_in.height;
-    XCAM_ASSERT (_output_width != 0);
-
-    CLImageDesc cl_desc;
-    cl_desc.format.image_channel_data_type = CL_UNORM_INT8;
-    if (_is_uv) {
-        cl_desc.format.image_channel_order = CL_RG;
-        cl_desc.width = desc_in.width * 4;
-    } else {
-        cl_desc.format.image_channel_order = CL_R;
-        cl_desc.width = desc_in.width * 8;
-    }
-    cl_desc.height = desc_in.height;
-    cl_desc.row_pitch = desc_in.row_pitch;
-    _input_scale.release ();
-    change_image_format (context, image_in, _input_scale, cl_desc);
-    XCAM_FAIL_RETURN (
-        ERROR,
-        _input_scale.ptr () && _input_scale->is_valid (),
-        XCAM_RETURN_ERROR_CL,
-        "CLPyramidScaleKernel scale image failed");
-
-    _out_offset_x = get_output_offset_x () / 8;
-    XCAM_ASSERT (_out_offset_x * 8 == get_output_offset_x ());
+    _image_in = get_input_image (input);
+    _image_out = get_output_image (output);
+    XCAM_ASSERT (_image_in.ptr () && _image_out.ptr ());
+    get_output_info (output, _output_width, _output_height, _output_offset_x);
 
     arg_count = 0;
-    args[arg_count].arg_adress = &_input_scale->get_mem_id ();
+    args[arg_count].arg_adress = &_image_in->get_mem_id ();
     args[arg_count].arg_size = sizeof (cl_mem);
     ++arg_count;
 
-    args[arg_count].arg_adress = &image_out->get_mem_id ();
+    args[arg_count].arg_adress = &_image_out->get_mem_id ();
     args[arg_count].arg_size = sizeof (cl_mem);
     ++arg_count;
 
-    args[arg_count].arg_adress = &_out_offset_x;
-    args[arg_count].arg_size = sizeof (_out_offset_x);
+    args[arg_count].arg_adress = &_output_offset_x;
+    args[arg_count].arg_size = sizeof (_output_offset_x);
     ++arg_count;
 
     args[arg_count].arg_adress = &_output_width;
@@ -1740,11 +1704,66 @@ CLPyramidScaleKernel::prepare_arguments (
     return XCAM_RETURN_NO_ERROR;
 }
 
-XCamReturn
-CLPyramidScaleKernel::post_execute (SmartPtr<DrmBoBuffer> &output)
+CLPyramidLocalScaleKernel::CLPyramidLocalScaleKernel (
+    SmartPtr<CLContext> &context, SmartPtr<CLPyramidBlender> &blender, bool is_uv)
+    : CLPyramidScaleKernel (context, is_uv)
+    , _blender (blender)
 {
-    _input_scale.release ();
-    return CLImageKernel::post_execute (output);
+}
+
+SmartPtr<CLImage>
+CLPyramidLocalScaleKernel::get_input_image (SmartPtr<DrmBoBuffer> &input)
+{
+    XCAM_UNUSED (input);
+    SmartPtr<CLContext> context = get_context ();
+
+    SmartPtr<CLImage> rec_image = _blender->get_reconstruct_image (0, _is_uv);
+    const CLImageDesc &rec_desc = rec_image->get_image_desc ();
+
+    CLImageDesc new_desc;
+    new_desc.format.image_channel_data_type = CL_UNORM_INT8;
+    if (_is_uv) {
+        new_desc.format.image_channel_order = CL_RG;
+        new_desc.width = rec_desc.width * 4;
+    } else {
+        new_desc.format.image_channel_order = CL_R;
+        new_desc.width = rec_desc.width * 8;
+    }
+    new_desc.height = rec_desc.height;
+    new_desc.row_pitch = rec_desc.row_pitch;
+    SmartPtr<CLImage> new_image;
+    change_image_format (context, rec_image, new_image, new_desc);
+    XCAM_FAIL_RETURN (
+        ERROR,
+        new_image.ptr () && new_image->is_valid (),
+        NULL,
+        "CLPyramidLocalScaleKernel change image format failed");
+
+    return new_image;
+}
+
+SmartPtr<CLImage>
+CLPyramidLocalScaleKernel::get_output_image (SmartPtr<DrmBoBuffer> &output)
+{
+    XCAM_UNUSED (output);
+    return _blender->get_scale_image (_is_uv);
+}
+
+bool
+CLPyramidLocalScaleKernel::get_output_info (
+    SmartPtr<DrmBoBuffer> &output,
+    uint32_t &out_width, uint32_t &out_height, int &out_offset_x)
+{
+    XCAM_UNUSED (output);
+    const Rect &window = _blender->get_merge_window ();
+    const CLImageDesc &desc_in = _image_in->get_image_desc ();
+
+    out_width = window.width / 8;
+    out_height = desc_in.height;
+    out_offset_x = window.pos_x / 8;
+
+    XCAM_FAIL_RETURN (ERROR, out_width != 0, false, "get output info failed");
+    return true;
 }
 
 CLPyramidCopyKernel::CLPyramidCopyKernel (
@@ -1930,24 +1949,22 @@ create_pyramid_blend_kernel (
 }
 
 static SmartPtr<CLImageKernel>
-create_pyramid_scale_kernel (
+create_pyramid_local_scale_kernel (
     SmartPtr<CLContext> &context,
     SmartPtr<CLPyramidBlender> &blender,
     bool is_uv)
 {
     char transform_option[1024];
-    snprintf (
-        transform_option, sizeof(transform_option),
-        "-DPYRAMID_UV=%d -DCL_PYRAMID_ENABLE_DUMP=%d", (is_uv ? 1 : 0), CL_PYRAMID_ENABLE_DUMP);
+    snprintf (transform_option, sizeof(transform_option), "-DPYRAMID_UV=%d", is_uv ? 1 : 0);
 
     SmartPtr<CLImageKernel> kernel;
-    kernel = new CLPyramidScaleKernel (context, blender, is_uv);
+    kernel = new CLPyramidLocalScaleKernel (context, blender, is_uv);
     XCAM_ASSERT (kernel.ptr ());
     XCAM_FAIL_RETURN (
         ERROR,
         kernel->build_kernel (kernels_info[KernelPyramidScale], transform_option) == XCAM_RETURN_NO_ERROR,
         NULL,
-        "load pyramid scale kernel(%s) failed", (is_uv ? "UV" : "Y"));
+        "load pyramid local scaling kernel(%s) failed", is_uv ? "UV" : "Y");
     return kernel;
 }
 
@@ -2091,8 +2108,8 @@ create_pyramid_blender (
         }
 
         if (scale_mode == CLBlenderScaleLocal) {
-            kernel = create_pyramid_scale_kernel (context, blender, uv_status[plane]);
-            XCAM_FAIL_RETURN (ERROR, kernel.ptr (), NULL, "create pyramid scale kernel failed");
+            kernel = create_pyramid_local_scale_kernel (context, blender, uv_status[plane]);
+            XCAM_FAIL_RETURN (ERROR, kernel.ptr (), NULL, "create pyramid local scaling kernel failed");
             blender->add_kernel (kernel);
         }
 

--- a/modules/ocl/cl_pyramid_blender.h
+++ b/modules/ocl/cl_pyramid_blender.h
@@ -376,35 +376,49 @@ class CLPyramidScaleKernel
     : public CLImageKernel
 {
 public:
-    explicit CLPyramidScaleKernel (
-        SmartPtr<CLContext> &context, SmartPtr<CLPyramidBlender> &blender, bool is_uv);
+    explicit CLPyramidScaleKernel (SmartPtr<CLContext> &context, bool is_uv);
 
 protected:
     virtual XCamReturn prepare_arguments (
         SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output,
         CLArgument args[], uint32_t &arg_count,
         CLWorkSize &work_size);
-    virtual XCamReturn post_execute (SmartPtr<DrmBoBuffer> &output);
+
+    virtual SmartPtr<CLImage> get_input_image (SmartPtr<DrmBoBuffer> &input) = 0;
+    virtual SmartPtr<CLImage> get_output_image (SmartPtr<DrmBoBuffer> &output) = 0;
+
+    virtual bool get_output_info (
+        SmartPtr<DrmBoBuffer> &output, uint32_t &out_width, uint32_t &out_height, int &out_offset_x) = 0;
 
 private:
-    SmartPtr<CLImage>  get_input_scale () {
-        return _blender->get_reconstruct_image (0, _is_uv);
-    }
-    SmartPtr<CLImage>  get_output_scale () {
-        return _blender->get_scale_image (_is_uv);
-    }
-
-    int get_output_offset_x ();
-
     XCAM_DEAD_COPY (CLPyramidScaleKernel);
+
+protected:
+    bool                               _is_uv;
+    int                                _output_offset_x;
+    uint32_t                           _output_width;
+    uint32_t                           _output_height;
+};
+
+class CLPyramidLocalScaleKernel
+    : public CLPyramidScaleKernel
+{
+public:
+    explicit CLPyramidLocalScaleKernel (
+        SmartPtr<CLContext> &context, SmartPtr<CLPyramidBlender> &blender, bool is_uv);
+
+protected:
+    virtual SmartPtr<CLImage> get_input_image (SmartPtr<DrmBoBuffer> &input);
+    virtual SmartPtr<CLImage> get_output_image (SmartPtr<DrmBoBuffer> &output);
+
+    virtual bool get_output_info (
+        SmartPtr<DrmBoBuffer> &output, uint32_t &out_width, uint32_t &out_height, int &out_offset_x);
+
+private:
+    XCAM_DEAD_COPY (CLPyramidLocalScaleKernel);
 
 private:
     SmartPtr<CLPyramidBlender>         _blender;
-    bool                               _is_uv;
-    int                                _out_offset_x;
-    uint32_t                           _output_width;
-    uint32_t                           _output_height;
-    SmartPtr<CLImage>                  _input_scale;
 };
 
 class CLPyramidCopyKernel


### PR DESCRIPTION
 * auto-scale whole image to match output size, which can remove
   sharp boundary for player in sphere mode.
 * cmdline:
   $ test-image-stitching --input input.nv12 --output output.mp4 \
     --input-w 1920 --input-h 1080 --output-w 1920 --output-h 960 \
     --scale-mode global --save true