### PR TITLE
libdvs: enable DVS opencl path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,33 @@ if test "$enable_opencv" = "yes"; then
     PKG_CHECK_MODULES(OPENCV, [opencv], [HAVE_OPENCV=1], [HAVE_OPENCV=0])
 fi
 
+# check dvs opencl path
+ENABLE_DVS_CL_PATH=0
+if test "$HAVE_OPENCV" -eq 1; then
+    AC_LANG(C++)
+    saved_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $OPENCV_CFLAGS"
+    saved_LIBS="$LIBS"
+    LIBS="$LIBS $OPENCV_LIBS"
+    AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM(
+            [[#include <opencv2/core.hpp>
+              #include <opencv2/opencv.hpp>
+            ]],
+            [[cv::UMat frame0;
+              cv::UMat frame1;
+              cv::videostab::MotionEstimatorRansacL2 est;
+              cv::videostab::KeypointBasedMotionEstimator kpest(&est);
+              kpest.estimate(frame0, frame1);
+            ]]
+           )],
+        [ENABLE_DVS_CL_PATH=1],
+        [ENABLE_DVS_CL_PATH=0]
+    )
+    CPPFLAGS="$saved_CPPFLAGS"
+    LIBS="$saved_LIBS"
+fi
+
 # check capi build
 ENABLE_CAPI=0
 if test "$enable_capi" = "yes"; then
@@ -274,6 +301,10 @@ AM_CONDITIONAL([HAVE_LIBCL], [test "$HAVE_LIBCL" -eq 1])
 AC_DEFINE_UNQUOTED([HAVE_OPENCV], $HAVE_OPENCV,
     [have opencv])
 AM_CONDITIONAL([HAVE_OPENCV], [test "$HAVE_OPENCV" -eq 1])
+
+AC_DEFINE_UNQUOTED([ENABLE_DVS_CL_PATH], $ENABLE_DVS_CL_PATH,
+    [enable dvs cl path])
+AM_CONDITIONAL([ENABLE_DVS_CL_PATH], [test "$ENABLE_DVS_CL_PATH" -eq 1])
 
 AC_DEFINE_UNQUOTED([ENABLE_CAPI], $ENABLE_CAPI,
     [enable capi build])

--- a/plugins/smart/dvs/libdvs/libdvs.cpp
+++ b/plugins/smart/dvs/libdvs/libdvs.cpp
@@ -119,10 +119,13 @@ void DigitalVideoStabilizer::nextStabilizedMotion(DvsData* frame, DvsResult* res
         }
     }
 #if 0
-    printf ("proj_mat[%d]=(%f, %f, %f, %f, %f, %f, %f, %f, %f \n)", result->frame_id,
+    printf ("proj_mat(%d, :)={%f, %f, %f, %f, %f, %f, %f, %f, %f}; \n", result->frame_id + 1,
             result->proj_mat[0][0], result->proj_mat[0][1], result->proj_mat[0][2],
             result->proj_mat[1][0], result->proj_mat[1][1], result->proj_mat[1][2],
             result->proj_mat[2][0], result->proj_mat[2][1], result->proj_mat[2][2]);
+
+    printf ("amplitude(%d, :)={%f, %f}; \n", result->frame_id + 1,
+            result->proj_mat[0][2], result->proj_mat[1][2]);
 #endif
 }
 

--- a/plugins/smart/dvs/libdvs/stabilizer.cpp
+++ b/plugins/smart/dvs/libdvs/stabilizer.cpp
@@ -20,8 +20,6 @@
 
 #include "stabilizer.h"
 
-#define XCAM_DVS_CL_PATH_ENABLE 0
-
 Mat
 OnePassVideoStabilizer::nextStabilizedMotion(DvsData* frame, int& stablizedPos)
 {
@@ -86,7 +84,7 @@ OnePassVideoStabilizer::nextStabilizedMotion(DvsData* frame, int& stablizedPos)
 Mat
 OnePassVideoStabilizer::estimateMotion()
 {
-#if XCAM_DVS_CL_PATH_ENABLE
+#if ENABLE_DVS_CL_PATH
     cv::UMat frame0 = at(curPos_ - 1, frames_).getUMat(ACCESS_READ);
     cv::UMat frame1 = at(curPos_, frames_).getUMat(ACCESS_READ);
 
@@ -204,7 +202,7 @@ TwoPassVideoStabilizer::nextStabilizedMotion(DvsData* frame, int& stablizedPos)
 Mat
 TwoPassVideoStabilizer::estimateMotion()
 {
-#if XCAM_DVS_CL_PATH_ENABLE
+#if ENABLE_DVS_CL_PATH
     cv::UMat frame0 = at(curPos_ - 1, frames_).getUMat(ACCESS_READ);
     cv::UMat frame1 = at(curPos_, frames_).getUMat(ACCESS_READ);
 


### PR DESCRIPTION
  * OpenCV patch KeypointBasedMotionEstimator CL path already merged,
    enable libxcam DVS cl path accordingly.
  * test commandline:
    $ gst-launch-1.0 filesrc location=test.mp4 ! videoparse width=1920 \
      height=1080 format=nv12 ! xcamfilter copy-mode=1 buffercount=32 \
      enable-warp=1 ! queue ! vaapih264enc rate-control=cbr ! \
      qtmux ! filesink location=test_dvs.mp4