### PR TITLE
Fix build errors

### DIFF
--- a/plugins/smart/dvs/libdvs/stabilizer.cpp
+++ b/plugins/smart/dvs/libdvs/stabilizer.cpp
@@ -18,6 +18,7 @@
  * Author: Zong Wei <wei.zong@intel.com>
  */
 
+#include <opencv2/videostab/ring_buffer.hpp>
 #include "stabilizer.h"
 
 Mat

--- a/plugins/smart/dvs/libdvs/stabilizer.h
+++ b/plugins/smart/dvs/libdvs/stabilizer.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include <opencv2/core.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv2/videostab/stabilizer.hpp>
 
 #include "libdvs.h"
 


### PR DESCRIPTION
When packaging libxcam for SLE/openSUSE I found out some `#include` statements are needed to fix some build errors for undefined expressions. This pull request fixes that problem.