### PR TITLE
cl-stitch: restructure feature match

### DIFF
--- a/capi/context_priv.cpp
+++ b/capi/context_priv.cpp
@@ -217,6 +217,10 @@ StitchContext::create_handler (SmartPtr<CLContext> &context)
     image_360->set_output_size (sttch_width, sttch_height);
     XCAM_LOG_INFO ("stitch output size width:%d height:%d", sttch_width, sttch_height);
 
+#if HAVE_OPENCV
+    image_360->set_feature_match_ocl (_fm_ocl);
+#endif
+
     return image_360;
 }
 

--- a/capi/context_priv.h
+++ b/capi/context_priv.h
@@ -163,6 +163,7 @@ public:
         : ContextBase (HandleTypeStitch)
         , _need_seam (false)
         , _fisheye_map (false)
+        , _fm_ocl (false)
         , _scale_mode (CLBlenderScaleLocal)
     {}
 
@@ -171,6 +172,7 @@ public:
 private:
     bool                  _need_seam;
     bool                  _fisheye_map;
+    bool                  _fm_ocl;
     CLBlenderScaleMode    _scale_mode;
 };
 

--- a/modules/ocl/cl_image_360_stitch.h
+++ b/modules/ocl/cl_image_360_stitch.h
@@ -25,6 +25,9 @@
 #include "cl_multi_image_handler.h"
 #include "cl_fisheye_handler.h"
 #include "cl_blender.h"
+#if HAVE_OPENCV
+#include "cv_feature_match.h"
+#endif
 
 namespace XCam {
 
@@ -109,9 +112,12 @@ public:
         return _overlaps[image][num];
     }
 
+    void set_feature_match_ocl (bool use_ocl);
+
 protected:
     virtual XCamReturn prepare_buffer_pool_video_info (const VideoBufferInfo &input, VideoBufferInfo &output);
     virtual XCamReturn prepare_parameters (SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output);
+    virtual XCamReturn execute_done (SmartPtr<DrmBoBuffer> &output);
     XCamReturn execute_self_prepare_parameters (
         SmartPtr<CLImageHandler> specified_handler, SmartPtr<DrmBoBuffer> &input, SmartPtr<DrmBoBuffer> &output);
 
@@ -137,6 +143,9 @@ private:
     CLFisheyeParams             _fisheye[ImageIdxCount];
     SmartPtr<CLBlender>         _left_blender;
     SmartPtr<CLBlender>         _right_blender;
+#if HAVE_OPENCV
+    SmartPtr<CVFeatureMatch>    _feature_match;
+#endif
 
     uint32_t                    _output_width;
     uint32_t                    _output_height;

--- a/modules/ocl/cl_post_image_processor.h
+++ b/modules/ocl/cl_post_image_processor.h
@@ -26,7 +26,7 @@
 #include <base/xcam_3a_types.h>
 #include "cl_image_processor.h"
 #include "stats_callback_interface.h"
-#include "cl_image_360_stitch.h"
+#include "cl_blender.h"
 
 namespace XCam {
 
@@ -40,6 +40,7 @@ class CL3DDenoiseImageHandler;
 class CLImageScaler;
 class CLWireFrameImageHandler;
 class CLImageWarpHandler;
+class CLImage360Stitch;
 
 class CLPostImageProcessor
     : public CLImageProcessor
@@ -91,9 +92,8 @@ public:
     virtual bool set_wireframe (bool enable);
     virtual bool set_image_warp (bool enable);
     virtual bool set_image_stitch (
-        bool enable_stitch, bool enable_seam,
-        CLBlenderScaleMode scale_mode, bool enable_fisheye_map,
-        uint32_t stitch_width, uint32_t stitch_height);
+        bool enable_stitch, bool enable_seam, CLBlenderScaleMode scale_mode, bool enable_fisheye_map,
+        bool fm_ocl, uint32_t stitch_width, uint32_t stitch_height);
 
 protected:
     virtual bool can_process_result (SmartPtr<X3aResult> &result);
@@ -137,6 +137,7 @@ private:
     bool                                      _enable_stitch;
     bool                                      _stitch_enable_seam;
     bool                                      _stitch_fisheye_map;
+    bool                                      _stitch_fm_ocl;
     CLBlenderScaleMode                        _stitch_scale_mode;
     uint32_t                                  _stitch_width;
     uint32_t                                  _stitch_height;

--- a/modules/ocl/cv_feature_match.h
+++ b/modules/ocl/cv_feature_match.h
@@ -26,6 +26,7 @@
 #include <base/xcam_buffer.h>
 #include <dma_video_buffer.h>
 #include <smartptr.h>
+#include "xcam_obj_debug.h"
 
 #include <cl_context.h>
 #include <cl_device.h>
@@ -34,16 +35,78 @@
 #include <opencv2/opencv.hpp>
 #include <opencv2/core/ocl.hpp>
 
-using namespace XCam;
+#define XCAM_CV_FM_MATCH_NUM  2
 
-void init_opencv_ocl (SmartPtr<CLContext> context);
+namespace XCam {
 
-bool convert_to_mat (SmartPtr<CLContext> context, SmartPtr<DrmBoBuffer> buffer, cv::Mat &mat);
+struct CVFMConfig {
+    int sitch_min_width;
+    int min_corners;           // number of minimum efficient corners
+    float offset_factor;       // last_offset * offset_factor + cur_offset * (1.0f - offset_factor)
+    float delta_mean_offset;   // cur_mean_offset - last_mean_offset
+    float max_adjusted_offset; // max offset of each adjustment
 
-void optical_flow_feature_match (
-    SmartPtr<CLContext> context, int output_width,
-    SmartPtr<DrmBoBuffer> buf0, SmartPtr<DrmBoBuffer> buf1,
-    cv::Rect &image0_crop_left, cv::Rect &image0_crop_right,
-    cv::Rect &image1_crop_left, cv::Rect &image1_crop_right);
+    CVFMConfig ()
+        : sitch_min_width (56)
+        , min_corners (8)
+        , offset_factor (0.8f)
+        , delta_mean_offset (5.0f)
+        , max_adjusted_offset (12.0f)
+    {}
+};
+
+class CVFeatureMatch
+{
+public:
+    explicit CVFeatureMatch (SmartPtr<CLContext> &context);
+
+    void set_ocl (bool use_ocl) {
+        _use_ocl = use_ocl;
+    }
+    bool is_ocl_path () {
+        return _use_ocl;
+    }
+
+    void optical_flow_feature_match (
+        int output_width, SmartPtr<DrmBoBuffer> buf0, SmartPtr<DrmBoBuffer> buf1,
+        cv::Rect &img0_crop_left, cv::Rect &img0_crop_right, cv::Rect &img1_crop_left, cv::Rect &img1_crop_right);
+
+protected:
+    void init_opencv_ocl ();
+
+    bool get_crop_image (SmartPtr<DrmBoBuffer> buffer,
+        cv::Rect img_crop_left, cv::Rect img_crop_right, cv::UMat &img_left, cv::UMat &img_right);
+
+    void add_detected_data (cv::InputArray image, cv::Ptr<cv::Feature2D> detector, std::vector<cv::Point2f> &corners);
+    void get_valid_offsets (cv::InputOutputArray out_image, cv::Size img0_size,
+        std::vector<cv::Point2f> corner0, std::vector<cv::Point2f> corner1,
+        std::vector<uchar> status, std::vector<float> error, std::vector<float> &offsets, float &sum, int &count);
+    bool get_mean_offset (std::vector<float> offsets, float sum, int &count, float &mean_offset);
+
+    void calc_of_match (cv::InputArray image0, cv::InputArray image1,
+        std::vector<cv::Point2f> corner0, std::vector<cv::Point2f> corner1,
+        std::vector<uchar> &status, std::vector<float> &error,
+        int &last_count, float &last_mean_offset, float &out_x_offset, int frame_num, int idx);
+    void adjust_stitch_area (int dst_width, float &x_offset, cv::Rect &stitch0, cv::Rect &stitch1);
+    void detect_and_match (
+        cv::InputArray img_left, cv::InputArray img_right, cv::Rect &crop_left, cv::Rect &crop_right,
+        int &valid_count, float &mean_offset, float &x_offset, int dst_width);
+
+private:
+    XCAM_DEAD_COPY (CVFeatureMatch);
+
+private:
+    SmartPtr<CLContext>  _context;
+    CVFMConfig           _config;
+
+    float                _x_offset[XCAM_CV_FM_MATCH_NUM];
+    float                _mean_offset[XCAM_CV_FM_MATCH_NUM];
+    int                  _valid_count[XCAM_CV_FM_MATCH_NUM];
+
+    bool                 _use_ocl;
+    bool                 _is_ocl_inited;
+};
+
+}
 
 #endif // XCAM_CV_FEATURE_MATCH_H

--- a/wrapper/gstreamer/gstxcamfilter.cpp
+++ b/wrapper/gstreamer/gstxcamfilter.cpp
@@ -41,6 +41,7 @@ using namespace GstXCam;
 #define DEFAULT_PROP_STITCH_ENABLE_SEAM     FALSE
 #define DEFAULT_PROP_STITCH_SCALE_MODE      CLBlenderScaleLocal
 #define DEFAULT_PROP_STITCH_FISHEYE_MAP     FALSE
+#define DEFAULT_PROP_STITCH_FM_OCL          FALSE
 
 XCAM_BEGIN_DECLARE
 
@@ -57,6 +58,7 @@ enum {
     PROP_STITCH_ENABLE_SEAM,
     PROP_STITCH_SCALE_MODE,
     PROP_STITCH_FISHEYE_MAP,
+    PROP_STITCH_FM_OCL
 };
 
 #define GST_TYPE_XCAM_FILTER_COPY_MODE (gst_xcam_filter_copy_mode_get_type ())
@@ -270,10 +272,18 @@ gst_xcam_filter_class_init (GstXCamFilterClass *klass)
         g_param_spec_enum ("stitch-scale", "stitch scale mode", "Stitch Scale Mode",
                            GST_TYPE_XCAM_FILTER_STITCH_SCALE_MODE, DEFAULT_PROP_STITCH_SCALE_MODE,
                            (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
     g_object_class_install_property (
         gobject_class, PROP_STITCH_FISHEYE_MAP,
         g_param_spec_boolean ("stitch-fisheye-map", "stitch fisheye map", "Enable fisheye map for stitch",
                               DEFAULT_PROP_STITCH_FISHEYE_MAP, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+#if HAVE_OPENCV
+    g_object_class_install_property (
+        gobject_class, PROP_STITCH_FM_OCL,
+        g_param_spec_boolean ("stitch-fm-ocl", "stitch enable ocl for feature match", "Enable ocl for feature match",
+                              DEFAULT_PROP_STITCH_FM_OCL, (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+#endif
 
     gst_element_class_set_details_simple (element_class,
                                           "Libxcam Filter",
@@ -309,6 +319,7 @@ gst_xcam_filter_init (GstXCamFilter *xcamfilter)
     xcamfilter->enable_stitch = DEFAULT_PROP_ENABLE_IMAGE_STITCH;
     xcamfilter->stitch_enable_seam = DEFAULT_PROP_STITCH_ENABLE_SEAM;
     xcamfilter->stitch_fisheye_map = DEFAULT_PROP_STITCH_FISHEYE_MAP;
+    xcamfilter->stitch_fm_ocl = DEFAULT_PROP_STITCH_FM_OCL;
     xcamfilter->stitch_scale_mode = DEFAULT_PROP_STITCH_SCALE_MODE;
 
     xcamfilter->delay_buf_num = DEFAULT_DELAY_BUFFER_NUM;
@@ -372,6 +383,11 @@ gst_xcam_filter_set_property (GObject *object, guint prop_id, const GValue *valu
     case PROP_STITCH_FISHEYE_MAP:
         xcamfilter->stitch_fisheye_map = g_value_get_boolean (value);
         break;
+#if HAVE_OPENCV
+    case PROP_STITCH_FM_OCL:
+        xcamfilter->stitch_fm_ocl = g_value_get_boolean (value);
+        break;
+#endif
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
         break;
@@ -417,6 +433,11 @@ gst_xcam_filter_get_property (GObject *object, guint prop_id, GValue *value, GPa
     case PROP_STITCH_FISHEYE_MAP:
         g_value_set_boolean (value, xcamfilter->stitch_fisheye_map);
         break;
+#if HAVE_OPENCV
+    case PROP_STITCH_FM_OCL:
+        g_value_set_boolean (value, xcamfilter->stitch_fm_ocl);
+        break;
+#endif
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
         break;
@@ -660,10 +681,10 @@ gst_xcam_filter_set_caps (GstBaseTransform *trans, GstCaps *incaps, GstCaps *out
     //processor->set_scaler_factor (0.5f);
 
     if (xcamfilter->enable_stitch) {
-        processor->set_image_stitch (xcamfilter->enable_stitch, xcamfilter->stitch_enable_seam,
-                                     xcamfilter->stitch_scale_mode, xcamfilter->stitch_fisheye_map,
-                                     GST_VIDEO_INFO_WIDTH (&out_info),
-                                     GST_VIDEO_INFO_HEIGHT (&out_info));
+        processor->set_image_stitch (
+            xcamfilter->enable_stitch, xcamfilter->stitch_enable_seam,
+            xcamfilter->stitch_scale_mode, xcamfilter->stitch_fisheye_map, xcamfilter->stitch_fm_ocl,
+            GST_VIDEO_INFO_WIDTH (&out_info), GST_VIDEO_INFO_HEIGHT (&out_info));
         XCAM_LOG_INFO ("xcamfilter stitch output size width:%d height:%d",
                        GST_VIDEO_INFO_WIDTH (&out_info), GST_VIDEO_INFO_HEIGHT (&out_info));
     }

--- a/wrapper/gstreamer/gstxcamfilter.h
+++ b/wrapper/gstreamer/gstxcamfilter.h
@@ -85,6 +85,7 @@ struct _GstXCamFilter
     gboolean                     enable_stitch;
     gboolean                     stitch_enable_seam;
     gboolean                     stitch_fisheye_map;
+    gboolean                     stitch_fm_ocl;
     CLBlenderScaleMode           stitch_scale_mode;
 
     uint32_t                     delay_buf_num;


### PR DESCRIPTION
 * extract feature-match as CVFeatureMatch class
 * support CPU and GPU path
 * tune parameters for quality
 * fix crash issue for CPU path when profiling disabled
 * gst-launch-1.0 cmdline:
   $ gst-launch-1.0 filesrc location=input.nv12 \
     ! videoparse format=nv12 width=1920 height=1080 \
     ! xcamfilter copy-mode=1 enable-stitch=true stitch-scale=local \
     stitch-fisheye-map=true stitch-fm-ocl=true \
     ! video/x-raw, foramt=NV12, width=1920, height=960 \
     ! queue ! vaapih264enc rate-control=cbr \
     ! tcpclientsink host="host-ip" port=3000 blocksize=1024000 sync=false