### PR TITLE
cl-binary: simplify usage of binary kernel

### DIFF
--- a/modules/ocl/cl_demo_handler.cpp
+++ b/modules/ocl/cl_demo_handler.cpp
@@ -84,7 +84,7 @@ create_cl_demo_image_handler (const SmartPtr<CLContext> &context)
 }
 
 SmartPtr<CLImageHandler>
-create_cl_binary_demo_image_handler (const SmartPtr<CLContext> &context)
+create_cl_binary_demo_image_handler (const SmartPtr<CLContext> &context, const uint8_t *binary, size_t size)
 {
     SmartPtr<CLDemoImageHandler> demo_handler;
     SmartPtr<CLImageKernel> demo_kernel;
@@ -92,10 +92,13 @@ create_cl_binary_demo_image_handler (const SmartPtr<CLContext> &context)
 
     demo_kernel = new CLImageKernel (context, "kernel_demo");
     {
+#if 0
         XCAM_CL_KERNEL_FUNC_BINARY_BEGIN(kernel_demo)
 #include "kernel_demo.clx.bin"
         XCAM_CL_KERNEL_FUNC_END;
         ret = demo_kernel->load_from_binary (kernel_demo_body, sizeof (kernel_demo_body));
+#endif
+        ret = demo_kernel->load_from_binary (binary, size);
         XCAM_FAIL_RETURN (
             WARNING,
             ret == XCAM_RETURN_NO_ERROR,

--- a/modules/ocl/cl_demo_handler.h
+++ b/modules/ocl/cl_demo_handler.h
@@ -47,7 +47,7 @@ SmartPtr<CLImageHandler>
 create_cl_demo_image_handler (const SmartPtr<CLContext> &context);
 
 SmartPtr<CLImageHandler>
-create_cl_binary_demo_image_handler (const SmartPtr<CLContext> &context);
+create_cl_binary_demo_image_handler (const SmartPtr<CLContext> &context, const uint8_t *binary, size_t size);
 
 };
 

--- a/tests/test_inline.h
+++ b/tests/test_inline.h
@@ -47,4 +47,132 @@ ensure_gpu_buffer_done (SmartPtr<BufferProxy> buf)
     buf->unmap ();
 }
 
+class FileHandle {
+public:
+    FileHandle ()
+        : _fp (NULL)
+        , _file_name (NULL)
+    {}
+    ~FileHandle ();
+
+    bool is_valid () const {
+        return (_fp ? true : false);
+    }
+    bool end_of_file ();
+    XCamReturn open (const char *name, const char *option);
+    XCamReturn close ();
+    XCamReturn rewind ();
+    XCamReturn get_file_size (size_t &size);
+    XCamReturn read_file (void *buf, const size_t &size);
+    XCamReturn write_file (const void *buf, const size_t &size);
+
+private:
+    XCAM_DEAD_COPY (FileHandle);
+
+private:
+    FILE    *_fp;
+    char    *_file_name;
+};
+
+FileHandle::~FileHandle ()
+{
+    close ();
+}
+
+bool
+FileHandle::end_of_file()
+{
+    if (!is_valid ())
+        return true;
+
+    return feof (_fp);
+}
+
+XCamReturn
+FileHandle::open (const char *name, const char *option)
+{
+    XCAM_ASSERT (name);
+    if (!name)
+        return XCAM_RETURN_ERROR_FILE;
+
+    close ();
+    XCAM_ASSERT (!_file_name && !_fp);
+    _fp = fopen (name, option);
+
+    if (!_fp)
+        return XCAM_RETURN_ERROR_FILE;
+    _file_name = strndup (name, 512);
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+XCamReturn
+FileHandle::close ()
+{
+    if (_fp) {
+        fclose (_fp);
+        _fp = NULL;
+    }
+
+    if (_file_name) {
+        xcam_free (_file_name);
+        _file_name = NULL;
+    }
+
+    return XCAM_RETURN_NO_ERROR;
+}
+
+XCamReturn
+FileHandle::rewind ()
+{
+    if (!is_valid ())
+        return XCAM_RETURN_ERROR_FILE;
+    return (fseek (_fp, 0L, SEEK_SET) == 0) ? XCAM_RETURN_NO_ERROR : XCAM_RETURN_ERROR_FILE;
+}
+
+XCamReturn
+FileHandle::get_file_size (size_t &size)
+{
+    if (fseek (_fp, 0L, SEEK_END) != 0)
+        goto read_error;
+
+    if ((size = ftell (_fp)) <= 0)
+        goto read_error;
+
+    if (fseek (_fp, 0L, SEEK_SET) != 0)
+        goto read_error;
+
+    return XCAM_RETURN_NO_ERROR;
+
+read_error:
+    XCAM_LOG_ERROR ("get file size failed");
+    return XCAM_RETURN_ERROR_FILE;
+}
+
+XCamReturn
+FileHandle::read_file (void *buf, const size_t &size)
+{
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+
+    if (fread (buf, 1, size, _fp) != size) {
+        XCAM_LOG_ERROR ("read file failed, size doesn't match");
+        ret = XCAM_RETURN_ERROR_FILE;
+    }
+
+    return ret;
+}
+
+XCamReturn
+FileHandle::write_file (const void *buf, const size_t &size)
+{
+    XCamReturn ret = XCAM_RETURN_NO_ERROR;
+
+    if (fwrite (buf, 1, size, _fp) != size) {
+        XCAM_LOG_ERROR ("write file failed, size doesn't match");
+        ret = XCAM_RETURN_ERROR_FILE;
+    }
+
+    return ret;
+}
+
 #endif // XCAM_TEST_INLINE_H

--- a/tools/convert-binary-to-text.sh
+++ b/tools/convert-binary-to-text.sh
@@ -2,6 +2,17 @@
 # Convert binary to binary-text.
 # Command line:
 #     convert-binary-to-text.sh xxx.cl.bin xxx.clx.bin
+#
+# Usage of binary-text file (if needed):
+# 1. generate binary file, related script: libxcam/tests/test-binary-kernel
+#    $ test-binary-kernel --src-kernel kernel_demo.cl --bin-kernel kernel_demo.cl.bin --kernel-name kernel_demo
+#
+# 2. generate binary-text file, related script: libxcam/tools/convert-binary-to-text.sh
+#    $ convert-binary-to-text.sh kernel_demo.cl.bin kernel_demo.clx.bin
+#
+# 3. include binary-text file when create image handler, please refer to demo handler:
+#    SmartPtr<CLImageHandler> create_cl_binary_demo_image_handler (SmartPtr<CLContext> &context)
+
 
 BINARY_FILE=$1
 TEXT_FILE=$2


### PR DESCRIPTION
 * simplify test-binary-kernel source code
 * remove clx_bin directory
 * build binary kernel at runtime
 * create_cl_binary_demo_image_handler is an example
 * test-binary-kernel cmdline:
   $ test-binary-kernel --src-kernel kernel_demo.cl \
     --bin-kernel kernel_demo.cl.bin --kernel-name kernel_demo
 * test-cl-image cmdline:
   $ test-cl-image -t demo -f BA10 -i input.raw \
     -o output.raw -k kernel_demo.cl.bin