### PR TITLE
cl-stitch: support multiple cameras

### DIFF
--- a/doc/yocto/libxcam_sample.bb
+++ b/doc/yocto/libxcam_sample.bb
@@ -1,0 +1,47 @@
+SUMMARY = "Libxcam"
+DESCRIPTION = "Libxcam: Extended camera features and cross platform computer vision project"
+HOMEPAGE = "https://github.com/01org/libxcam/wiki"
+LICENSE = "Apache-2.0"
+
+PR = "r0"
+S = "${WORKDIR}/git"
+
+LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=a739187a9544e0731270d11a8f5be792"
+
+SRC_URI = "git://github.com/01org/libxcam.git;branch=master"
+SRCREV = "${AUTOREV}"
+
+DEPENDS = "glib-2.0 libdrm beignet opencv gstreamer1.0 gstreamer1.0-plugins-base"
+
+inherit autotools pkgconfig
+
+EXTRA_OECONF = "--enable-gst --enable-drm --enable-libcl --enable-smartlib --enable-opencv"
+
+CFLAGS += "-fPIE -fPIC"
+CFLAGS += "-O2 -D_FORTIFY_SOURCE=2"
+CFLAGS += "-Wformat -Wformat-security"
+CFLAGS += "-fstack-protector"
+
+LDFLAGS += "-z noexecstack"
+LDFLAGS += "-z relro -z now"
+
+PACKAGES += "${PN}-test"
+
+FILES_${PN} += "${libdir}/libxcam_core.so.*"
+FILES_${PN} += "${libdir}/libxcam_ocl.so.*"
+FILES_${PN} += "${libdir}/gstreamer-1.0/libgstxcamfilter.*"
+
+FILES_${PN}-dev += "${includedir}/xcam/*"
+FILES_${PN}-dev += "${libdir}/pkgconfig/libxcam.pc"
+FILES_${PN}-dev += "${libdir}/libxcam_core.so"
+FILES_${PN}-dev += "${libdir}/libxcam_core.la"
+FILES_${PN}-dev += "${libdir}/libxcam_core.a"
+FILES_${PN}-dev += "${libdir}/libxcam_ocl.so"
+FILES_${PN}-dev += "${libdir}/libxcam_ocl.la"
+
+FILES_${PN}-test = "${bindir}/test-*"
+
+FILES_${PN}-dbg += "${libdir}/gstreamer-1.0/.debug/*"
+FILES_${PN}-dbg += "${libdir}/.debug/"
+FILES_${PN}-dbg += "${bindir}/.debug/"
+

--- a/modules/interface/stitcher.h
+++ b/modules/interface/stitcher.h
@@ -26,24 +26,21 @@
 #include "interface/data_types.h"
 #include "video_buffer.h"
 
+#define XCAM_STITCH_FISHEYE_MAX_NUM    6
+
 namespace XCam {
 
 enum StitchResMode {
     StitchRes1080P,
+    StitchRes1080P4,
     StitchRes4K
 };
 
-enum ImageIdx {
-    ImageIdxMain,
-    ImageIdxSecondary,
-    ImageIdxCount,
-};
-
 struct StitchInfo {
-    uint32_t merge_width[ImageIdxCount];
+    uint32_t merge_width[XCAM_STITCH_FISHEYE_MAX_NUM];
 
-    ImageCropInfo crop[ImageIdxCount];
-    FisheyeInfo fisheye_info[ImageIdxCount];
+    ImageCropInfo crop[XCAM_STITCH_FISHEYE_MAX_NUM];
+    FisheyeInfo fisheye_info[XCAM_STITCH_FISHEYE_MAX_NUM];
 
     StitchInfo () {
         xcam_mem_clear (merge_width);
@@ -81,8 +78,8 @@ private:
     uint32_t                    _output_width;
     uint32_t                    _output_height;
 
-    ImageMergeInfo              _img_merge_info[ImageIdxCount];
-    Rect                        _overlaps[ImageIdxCount][2];   // 2=>Overlap0 and overlap1
+    ImageMergeInfo              _img_merge_info[XCAM_STITCH_FISHEYE_MAX_NUM];
+    Rect                        _overlaps[XCAM_STITCH_FISHEYE_MAX_NUM][2];   // 2=>Overlap0 and overlap1
 
     StitchInfo                  _stitch_info;
     bool                        _is_stitch_inited;

--- a/modules/ocl/cl_pyramid_blender.cpp
+++ b/modules/ocl/cl_pyramid_blender.cpp
@@ -322,8 +322,6 @@ PyramidLayer::bind_buf_to_layer0 (
     uint32_t divider_vert[2] = {1, 2};
 
     XCAM_ASSERT (in0_info.height == in1_info.height);
-    XCAM_ASSERT (in0_info.width + in1_info.width >= out_info.width);
-    //XCAM_ASSERT (out_info.height == in0_info.height);
     XCAM_ASSERT (merge0_rect.width == merge1_rect.width);
 
     this->blend_width = XCAM_ALIGN_UP (merge0_rect.width, XCAM_BLENDER_ALIGNED_WIDTH);

--- a/modules/ocl/cv_feature_match.h
+++ b/modules/ocl/cv_feature_match.h
@@ -65,24 +65,26 @@ public:
     void set_config (CVFMConfig config);
     CVFMConfig get_config ();
 
+    void set_fm_index (int idx);
+
     void optical_flow_feature_match (
-        int output_width, SmartPtr<DrmBoBuffer> buf0, SmartPtr<DrmBoBuffer> buf1,
-        cv::Rect &img0_crop_left, cv::Rect &img0_crop_right, cv::Rect &img1_crop_left, cv::Rect &img1_crop_right);
+        SmartPtr<DrmBoBuffer> left_buf, SmartPtr<DrmBoBuffer> right_buf,
+        cv::Rect &left_img_crop, cv::Rect &right_img_crop, int dst_width);
 
 protected:
-    bool get_crop_image (SmartPtr<DrmBoBuffer> buffer,
-                         cv::Rect img_crop_left, cv::Rect img_crop_right, cv::UMat &img_left, cv::UMat &img_right);
+    bool get_crop_image (SmartPtr<DrmBoBuffer> buffer, cv::Rect img_crop, cv::UMat &img);
 
     void add_detected_data (cv::InputArray image, cv::Ptr<cv::Feature2D> detector, std::vector<cv::Point2f> &corners);
     void get_valid_offsets (cv::InputOutputArray out_image, cv::Size img0_size,
                             std::vector<cv::Point2f> corner0, std::vector<cv::Point2f> corner1,
-                            std::vector<uchar> status, std::vector<float> error, std::vector<float> &offsets, float &sum, int &count);
+                            std::vector<uchar> status, std::vector<float> error,
+                            std::vector<float> &offsets, float &sum, int &count);
     bool get_mean_offset (std::vector<float> offsets, float sum, int &count, float &mean_offset);
 
     void calc_of_match (cv::InputArray image0, cv::InputArray image1,
                         std::vector<cv::Point2f> corner0, std::vector<cv::Point2f> corner1,
                         std::vector<uchar> &status, std::vector<float> &error,
-                        int &last_count, float &last_mean_offset, float &out_x_offset, int frame_num, int idx);
+                        int &last_count, float &last_mean_offset, float &out_x_offset);
     void adjust_stitch_area (int dst_width, float &x_offset, cv::Rect &stitch0, cv::Rect &stitch1);
     void detect_and_match (
         cv::InputArray img_left, cv::InputArray img_right, cv::Rect &crop_left, cv::Rect &crop_right,
@@ -94,9 +96,13 @@ private:
 private:
     CVFMConfig           _config;
 
-    float                _x_offset[XCAM_CV_FM_MATCH_NUM];
-    float                _mean_offset[XCAM_CV_FM_MATCH_NUM];
-    int                  _valid_count[XCAM_CV_FM_MATCH_NUM];
+    float                _x_offset;
+    float                _mean_offset;
+    int                  _valid_count;
+
+    // debug parameters
+    int                  _fm_idx;
+    uint                 _frame_num;
 };
 
 }

--- a/wrapper/gstreamer/gstxcamfilter.h
+++ b/wrapper/gstreamer/gstxcamfilter.h
@@ -66,7 +66,7 @@ typedef enum {
 
 enum StitchResMode {
     StitchRes1080P = 0,
-    StitchRes4K
+    StitchRes4K = 2
 };
 
 typedef struct _GstXCamFilter      GstXCamFilter;


### PR DESCRIPTION
 * add 4 cameras mode
 * optimize feature match to support single match at a time
 * prepare parameters for each blender independently
 * swap buffer index for the last blender in configuration phase
 * test-image-stitching cmdline:
   $ test-image-stitching --input input0.nv12 --input input1.nv12 \
     --input input2.nv12 --input input3.nv12 --output output.mp4 \
     --input-w 1280 --input-h 800 --output-w 4864 --output-h 1408 \
     --scale-mode local --enable-fisheyemap --res-mode 1080p4 \
     --fm-ocl false --framerate 30.0 --save true \
     --fisheye-num 4 --all-in-one false