### PR TITLE
libdvs: include opencv2/videostab.hpp

### DIFF
--- a/plugins/smart/dvs/libdvs/stabilizer.h
+++ b/plugins/smart/dvs/libdvs/stabilizer.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include <opencv2/core.hpp>
 #include <opencv2/opencv.hpp>
+#include <opencv2/videostab.hpp>
 
 #include "libdvs.h"
 


### PR DESCRIPTION
The opencv2/videostab.hpp header is not indirectly included
via the opencv2/opencv.hpp header until OpenCV version 3.2+.

Thus, explicitly include opencv2/videostab.hpp so libdvs can
compile with OpenCV version 3.1.

Fixes #475

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>