### PR TITLE
standard-OCL: switch to CLVideoBuffer path

### DIFF
--- a/capi/context_priv.cpp
+++ b/capi/context_priv.cpp
@@ -58,8 +58,7 @@ ContextBase::ContextBase (HandleType type)
     , _alloc_out_buf (false)
 {
     if (!_inbuf_pool.ptr()) {
-        SmartPtr<DrmDisplay> display = DrmDisplay::instance ();
-        _inbuf_pool = new DrmBoBufferPool (display);
+        _inbuf_pool = new CLVideoBufferPool ();
         XCAM_ASSERT (_inbuf_pool.ptr ());
     }
 }

--- a/cl_kernel/kernel_bi_filter.cl
+++ b/cl_kernel/kernel_bi_filter.cl
@@ -12,9 +12,9 @@
 #define PATCH_RADIUS 7
 #define PATCH_DIAMETER (2 * PATCH_RADIUS + 1)
 
-#define CALC_SUM(y1,y2,dark1,dark2) \
-    cur_y = (float8)(y1, y2); \
-    cur_dark = (float8)(dark1, dark2); \
+#define CALC_SUM(y1,y2,y3,dark1,dark2,dark3) \
+    cur_y = (float8)(y1, y2, y3); \
+    cur_dark = (float8)(dark1, dark2, dark3); \
     calc_sum (cur_y, cur_dark, center_y, &weight_sum, &data_sum);
 
 __inline void calc_sum (float8 cur_y, float8 cur_dark, float8 center_y, float8 *weight_sum, float8 *data_sum)
@@ -48,24 +48,24 @@ __kernel void kernel_bi_filter (
         y2 = convert_float8(as_uchar8(convert_ushort4(read_imageui(input_y, sampler, (int2)(pos_x, pos_y - PATCH_RADIUS + i)))));
         dark1 = convert_float8(as_uchar8(convert_ushort4(read_imageui(input_dark, sampler, (int2)(pos_x - 1, pos_y - PATCH_RADIUS + i)))));
         dark2 = convert_float8(as_uchar8(convert_ushort4(read_imageui(input_dark, sampler, (int2)(pos_x, pos_y - PATCH_RADIUS + i)))));
-        CALC_SUM (y1.s1234567, y2.s0, dark1.s1234567, dark2.s0);
-        CALC_SUM (y1.s234567, y2.s01, dark1.s234567, dark2.s01);
-        CALC_SUM (y1.s34567, y2.s012, dark1.s34567, dark2.s012);
-        CALC_SUM (y1.s4567, y2.s0123, dark1.s4567, dark2.s0123);
-        CALC_SUM (y1.s567, y2.s01234, dark1.s567, dark2.s01234);
-        CALC_SUM (y1.s67, y2.s012345, dark1.s67, dark2.s012345);
-        CALC_SUM (y1.s7, y2.s0123456, dark1.s7, dark2.s0123456);
-        CALC_SUM (y2.s0123, y2.s4567, dark2.s0123, dark2.s4567);
+        CALC_SUM (y1.s1234, y1.s567, y2.s0, dark1.s1234, dark1.s567, dark2.s0);
+        CALC_SUM (y1.s2345, y1.s67, y2.s01, dark1.s2345, dark1.s67, dark2.s01);
+        CALC_SUM (y1.s3456, y1.s7, y2.s012, dark1.s3456, dark1.s7, dark2.s012);
+        CALC_SUM (y1.s4567, y2.s01, y2.s23, dark1.s4567, dark2.s01, dark2.s23);
+        CALC_SUM (y1.s567, y2.s0123, y2.s4, dark1.s567, dark2.s0123, dark2.s4);
+        CALC_SUM (y1.s67, y2.s0123, y2.s45, dark1.s67, dark2.s0123, dark2.s45);
+        CALC_SUM (y1.s7, y2.s0123, y2.s456, dark1.s7, dark2.s0123, dark2.s456);
+        CALC_SUM (y2.s0123, y2.s45, y2.s67, dark2.s0123, dark2.s45, dark2.s67);
 
         y1 = convert_float8(as_uchar8(convert_ushort4(read_imageui(input_y, sampler, (int2)(pos_x + 1, pos_y - PATCH_RADIUS + i)))));
         dark1 = convert_float8(as_uchar8(convert_ushort4(read_imageui(input_dark, sampler, (int2)(pos_x + 1, pos_y - PATCH_RADIUS + i)))));
-        CALC_SUM (y2.s1234567, y1.s0, dark2.s1234567, dark1.s0);
-        CALC_SUM (y2.s234567, y1.s01, dark2.s234567, dark1.s01);
-        CALC_SUM (y2.s34567, y1.s012, dark2.s34567, dark1.s012);
-        CALC_SUM (y2.s4567, y1.s0123, dark2.s4567, dark1.s0123);
-        CALC_SUM (y2.s567, y1.s01234, dark2.s567, dark1.s01234);
-        CALC_SUM (y2.s67, y1.s012345, dark2.s67, dark1.s012345);
-        CALC_SUM (y2.s7, y1.s0123456, dark2.s7, dark1.s0123456);
+        CALC_SUM (y2.s1234, y2.s567, y1.s0, dark2.s1234, dark2.s567, dark1.s0);
+        CALC_SUM (y2.s2345, y2.s67, y1.s01, dark2.s2345, dark2.s67, dark1.s01);
+        CALC_SUM (y2.s3456, y2.s7, y1.s012, dark2.s3456, dark2.s7, dark1.s012);
+        CALC_SUM (y2.s4567, y1.s01, y1.s23, dark2.s4567, dark1.s01, dark1.s23);
+        CALC_SUM (y2.s567, y1.s0123, y1.s4, dark2.s567, dark1.s0123, dark1.s4);
+        CALC_SUM (y2.s67, y1.s0123, y1.s45, dark2.s67, dark1.s0123, dark1.s45);
+        CALC_SUM (y2.s7, y1.s0123, y1.s456, dark2.s7, dark1.s0123, dark1.s456);
     }
 
     float8 out_data = data_sum / weight_sum;

--- a/cl_kernel/kernel_gauss_lap_pyramid.cl
+++ b/cl_kernel/kernel_gauss_lap_pyramid.cl
@@ -291,7 +291,8 @@ kernel_lap_transform (
     const sampler_t gauss0_sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
     const sampler_t gauss1_sampler = CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
 
-    float8 orig = convert_float8(as_uchar8(convert_ushort4(read_imageui(input_gauss0, gauss0_sampler, (int2)(g_x + gauss0_offset_x, g_y)))));
+    float8 orig = convert_float8(as_uchar8(convert_ushort4(
+                      read_imageui(input_gauss0, gauss0_sampler, (int2)(g_x + gauss0_offset_x, g_y)))));
     float8 zoom_in;
     float2 gauss1_pos;
     float sampler_step;
@@ -516,12 +517,18 @@ kernel_mask_gauss_scale_slm (
         result_pre = convert_float4(slm_gauss_y[i_line][clamp (g_x * 2 - 1, 0, image_width * 2)]) / CONV_COEFF;
         result_next = convert_float4(slm_gauss_y[i_line][clamp (g_x * 2 + 2, 0, image_width * 2)]) / CONV_COEFF;
         final_g[i_line] = result_cur[i_line] * mask_coeffs[MASK_COEFF_MID] +
-                          (float8)(result_pre.s3, result_cur[i_line].s0123456) * mask_coeffs[MASK_COEFF_MID + 1] +
-                          (float8)(result_cur[i_line].s1234567, result_next.s0) * mask_coeffs[MASK_COEFF_MID + 1] +
-                          (float8)(result_pre.s23, result_cur[i_line].s012345) * mask_coeffs[MASK_COEFF_MID + 2] +
-                          (float8)(result_cur[i_line].s234567, result_next.s01) * mask_coeffs[MASK_COEFF_MID + 2] +
-                          (float8)(result_pre.s123, result_cur[i_line].s01234) * mask_coeffs[MASK_COEFF_MID + 3] +
-                          (float8)(result_cur[i_line].s34567, result_next.s012) * mask_coeffs[MASK_COEFF_MID + 3] +
+                          (float8)(result_pre.s3, result_cur[i_line].s0123, result_cur[i_line].s456) *
+                                  mask_coeffs[MASK_COEFF_MID + 1] +
+                          (float8)(result_cur[i_line].s1234, result_cur[i_line].s567, result_next.s0) *
+                                  mask_coeffs[MASK_COEFF_MID + 1] +
+                          (float8)(result_pre.s23, result_cur[i_line].s0123, result_cur[i_line].s45) *
+                                  mask_coeffs[MASK_COEFF_MID + 2] +
+                          (float8)(result_cur[i_line].s2345, result_cur[i_line].s67, result_next.s01) *
+                                  mask_coeffs[MASK_COEFF_MID + 2] +
+                          (float8)(result_pre.s123, result_cur[i_line].s0123, result_cur[i_line].s4) *
+                                  mask_coeffs[MASK_COEFF_MID + 3] +
+                          (float8)(result_cur[i_line].s3456, result_cur[i_line].s7, result_next.s012) *
+                                  mask_coeffs[MASK_COEFF_MID + 3] +
                           (float8)(result_pre.s0123, result_cur[i_line].s0123) * mask_coeffs[MASK_COEFF_MID + 4] +
                           (float8)(result_cur[i_line].s4567, result_next.s0123) * mask_coeffs[MASK_COEFF_MID + 4];
         final_g[i_line] = clamp (final_g[i_line] + 0.5f, 0.0f, 255.0f);
@@ -581,12 +588,18 @@ kernel_mask_gauss_scale (
 #pragma unroll
     for (i_line = 0; i_line < 2; ++i_line) {
         final_g[i_line] = result_cur[i_line] * mask_coeffs[MASK_COEFF_MID] +
-                          (float8)(result_pre[i_line].s7, result_cur[i_line].s0123456) * mask_coeffs[MASK_COEFF_MID + 1] +
-                          (float8)(result_cur[i_line].s1234567, result_next[i_line].s0) * mask_coeffs[MASK_COEFF_MID + 1] +
-                          (float8)(result_pre[i_line].s67, result_cur[i_line].s012345) * mask_coeffs[MASK_COEFF_MID + 2] +
-                          (float8)(result_cur[i_line].s234567, result_next[i_line].s01) * mask_coeffs[MASK_COEFF_MID + 2] +
-                          (float8)(result_pre[i_line].s567, result_cur[i_line].s01234) * mask_coeffs[MASK_COEFF_MID + 3] +
-                          (float8)(result_cur[i_line].s34567, result_next[i_line].s012) * mask_coeffs[MASK_COEFF_MID + 3] +
+                          (float8)(result_pre[i_line].s7, result_cur[i_line].s0123, result_cur[i_line].s456) *
+                                  mask_coeffs[MASK_COEFF_MID + 1] +
+                          (float8)(result_cur[i_line].s1234, result_cur[i_line].s567, result_next[i_line].s0) *
+                                  mask_coeffs[MASK_COEFF_MID + 1] +
+                          (float8)(result_pre[i_line].s67, result_cur[i_line].s0123, result_cur[i_line].s45) *
+                                  mask_coeffs[MASK_COEFF_MID + 2] +
+                          (float8)(result_cur[i_line].s2345, result_cur[i_line].s67, result_next[i_line].s01) *
+                                  mask_coeffs[MASK_COEFF_MID + 2] +
+                          (float8)(result_pre[i_line].s567, result_cur[i_line].s0123, result_cur[i_line].s4) *
+                                  mask_coeffs[MASK_COEFF_MID + 3] +
+                          (float8)(result_cur[i_line].s3456,result_cur[i_line].s7, result_next[i_line].s012) *
+                                  mask_coeffs[MASK_COEFF_MID + 3] +
                           (float8)(result_pre[i_line].s4567, result_cur[i_line].s0123) * mask_coeffs[MASK_COEFF_MID + 4] +
                           (float8)(result_cur[i_line].s4567, result_next[i_line].s0123) * mask_coeffs[MASK_COEFF_MID + 4];
         final_g[i_line] = clamp (final_g[i_line] + 0.5f, 0.0f, 255.0f);

--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,7 @@ if test "$HAVE_LIBCL" -eq 1; then
     if test "$HAVE_CL_INTEL_H" -eq 0; then
         # https://raw.githubusercontent.com/intel/beignet/Release_v1.3/include/CL/cl_intel.h
         XCAM_WGET(
-            [https://cgit.freedesktop.org/beignet/plain/include/CL/cl_intel.h?h=Release_v1.3],
+            [https://cgit.freedesktop.org/beignet/plain/include/CL/cl_intel.h?id=Release_v1.3.0],
             [./ext/beignet/include/CL/cl_intel.h],
             [6a6619073cb35e6987b7379a5a1a1497])
 

--- a/modules/ocl/cl_3a_image_processor.cpp
+++ b/modules/ocl/cl_3a_image_processor.cpp
@@ -342,7 +342,6 @@ CL3aImageProcessor::create_handlers ()
 
     _bayer_pipe->enable_denoise (XCAM_DENOISE_TYPE_BNR & _snr_mode);
     image_handler->set_pool_size (XCAM_CL_3A_IMAGE_MAX_POOL_SIZE * 2);
-    //image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
     add_handler (image_handler);
     if(_capture_stage == BasicbayerStage)
         return XCAM_RETURN_NO_ERROR;
@@ -368,7 +367,7 @@ CL3aImageProcessor::create_handlers ()
         XCAM_RETURN_ERROR_CL,
         "CL3aImageProcessor create ee handler failed");
     _ee->enable_handler (XCAM_DENOISE_TYPE_EE & _snr_mode);
-    image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+    image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
     image_handler->set_pool_size (XCAM_CL_3A_IMAGE_MAX_POOL_SIZE);
     add_handler (image_handler);
 #endif

--- a/modules/ocl/cl_context.cpp
+++ b/modules/ocl/cl_context.cpp
@@ -536,7 +536,7 @@ CLContext::destroy_mem (cl_mem mem_id)
 }
 
 cl_mem
-CLContext::create_buffer (uint32_t size, cl_mem_flags  flags, void *host_ptr)
+CLContext::create_buffer (uint32_t size, cl_mem_flags flags, void *host_ptr)
 {
     cl_mem mem_id = NULL;
     cl_int errcode = CL_SUCCESS;
@@ -554,6 +554,25 @@ CLContext::create_buffer (uint32_t size, cl_mem_flags  flags, void *host_ptr)
         NULL,
         "create cl buffer failed");
     return mem_id;
+}
+
+cl_mem
+CLContext::create_sub_buffer (
+    cl_mem main_mem,
+    cl_buffer_region region,
+    cl_mem_flags flags)
+{
+    cl_mem sub_mem = NULL;
+    cl_int errcode = CL_SUCCESS;
+
+    sub_mem = clCreateSubBuffer (main_mem, flags, CL_BUFFER_CREATE_TYPE_REGION, &region, &errcode);
+    XCAM_FAIL_RETURN (
+        WARNING,
+        errcode == CL_SUCCESS,
+        NULL,
+        "create sub buffer failed");
+
+    return sub_mem;
 }
 
 XCamReturn

--- a/modules/ocl/cl_context.h
+++ b/modules/ocl/cl_context.h
@@ -47,6 +47,7 @@ class CLContext {
     friend class CLKernel;
     friend class CLMemory;
     friend class CLBuffer;
+    friend class CLSubBuffer;
     friend class CLVaBuffer;
     friend class CLImage;
     friend class CLVaImage;
@@ -119,7 +120,13 @@ private:
     void destroy_mem (cl_mem mem_id);
 
     // Buffer
-    cl_mem create_buffer (uint32_t size, cl_mem_flags  flags, void *host_ptr);
+    cl_mem create_buffer (uint32_t size, cl_mem_flags flags, void *host_ptr);
+
+    cl_mem create_sub_buffer (
+        cl_mem main_mem,
+        cl_buffer_region region,
+        cl_mem_flags flags = CL_MEM_READ_WRITE);
+
     XCamReturn enqueue_read_buffer (
         cl_mem buf_id, void *ptr,
         uint32_t offset, uint32_t size,

--- a/modules/ocl/cl_csc_handler.cpp
+++ b/modules/ocl/cl_csc_handler.cpp
@@ -199,6 +199,7 @@ CLCscImageHandler::prepare_parameters (SmartPtr<VideoBuffer> &input, SmartPtr<Vi
 
         SmartPtr<CLImage> image_uv;
         if(_csc_type == CL_CSC_TYPE_NV12TORGBA) {
+            in_desc.height /= 2;
             image_uv = convert_to_climage (context, input, in_desc, in_video_info.offsets[1]);
             args.push_back (new CLMemArgument (image_uv));
 
@@ -208,6 +209,7 @@ CLCscImageHandler::prepare_parameters (SmartPtr<VideoBuffer> &input, SmartPtr<Vi
         }
 
         if (_csc_type == CL_CSC_TYPE_RGBATONV12) {
+            out_desc.height /= 2;
             image_uv = convert_to_climage (context, output, out_desc, out_video_info.offsets[1]);
             args.push_back (new CLMemArgument (image_uv));
             args.push_back (new CLMemArgument (matrix_buffer));

--- a/modules/ocl/cl_csc_image_processor.cpp
+++ b/modules/ocl/cl_csc_image_processor.cpp
@@ -51,8 +51,10 @@ CLCscImageProcessor::create_handlers ()
         _csc .ptr (),
         XCAM_RETURN_ERROR_CL,
         "CLCscImageProcessor create csc handler failed");
-    image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+
+    image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
     add_handler (image_handler);
+
     return XCAM_RETURN_NO_ERROR;
 }
 

--- a/modules/ocl/cl_geo_map_handler.h
+++ b/modules/ocl/cl_geo_map_handler.h
@@ -139,6 +139,7 @@ private:
     uint32_t                         _output_width;
     uint32_t                         _output_height;
     uint32_t                         _map_width, _map_height;
+    uint32_t                         _map_aligned_width;
     float                            _uint_x, _uint_y;
     SmartPtr<CLImage>                _input[CLNV12PlaneMax];
     SmartPtr<CLImage>                _output[CLNV12PlaneMax];

--- a/modules/ocl/cl_image_360_stitch.cpp
+++ b/modules/ocl/cl_image_360_stitch.cpp
@@ -598,8 +598,7 @@ CLImage360Stitch::create_buffer_pool (SmartPtr<BufferPool> &buf_pool, uint32_t w
     buf_info.init (V4L2_PIX_FMT_NV12, width, height,
                    XCAM_ALIGN_UP (width, 16), XCAM_ALIGN_UP (height, 16));
 
-    SmartPtr<DrmDisplay> display = DrmDisplay::instance ();
-    buf_pool = new DrmBoBufferPool (display);
+    buf_pool = new CLVideoBufferPool ();
     XCAM_ASSERT (buf_pool.ptr ());
     buf_pool->set_video_info (buf_info);
     if (!buf_pool->reserve (6)) {

--- a/modules/ocl/cl_image_handler.cpp
+++ b/modules/ocl/cl_image_handler.cpp
@@ -90,7 +90,7 @@ CLImageHandler::CLImageHandler (const SmartPtr<CLContext> &context, const char *
     : _name (NULL)
     , _enable (true)
     , _context (context)
-    , _buf_pool_type (CLImageHandler::CLBoPoolType)
+    , _buf_pool_type (CLImageHandler::CLVideoPoolType)
     , _disable_buf_pool (false)
     , _buf_pool_size (XCAM_CL_IMAGE_HANDLER_DEFAULT_BUF_NUM)
     , _buf_swap_flags ((uint32_t)(SwappedBuffer::OrderY0Y1) | (uint32_t)(SwappedBuffer::OrderUV0UV1))
@@ -164,11 +164,11 @@ CLImageHandler::create_buffer_pool (const VideoBufferInfo &video_info)
         "CLImageHandler(%s) failed to get drm dispay", XCAM_STR (_name));
 
     SmartPtr<BufferPool> buffer_pool;
-    if (_buf_pool_type == CLImageHandler::CLVideoPoolType)
+    if (_buf_pool_type == CLImageHandler::CLVideoPoolType) {
         buffer_pool = new CLVideoBufferPool ();
-    else if (_buf_pool_type == CLImageHandler::DrmBoPoolType)
+    } else if (_buf_pool_type == CLImageHandler::DrmBoPoolType) {
         buffer_pool = new DrmBoBufferPool (display);
-    else if (_buf_pool_type == CLImageHandler::CLBoPoolType) {
+    } else if (_buf_pool_type == CLImageHandler::CLBoPoolType) {
         buffer_pool = new CLBoBufferPool (display, get_context ());
     }
 

--- a/modules/ocl/cl_image_processor.cpp
+++ b/modules/ocl/cl_image_processor.cpp
@@ -156,14 +156,7 @@ XCamReturn
 CLImageProcessor::process_buffer (SmartPtr<VideoBuffer> &input, SmartPtr<VideoBuffer> &output)
 {
     XCamReturn ret = XCAM_RETURN_NO_ERROR;
-    SmartPtr<DrmDisplay> display = DrmDisplay::instance ();
-
-    SmartPtr<VideoBuffer> drm_bo_in = display->convert_to_drm_bo_buf (display, input);
-    XCAM_FAIL_RETURN (
-        WARNING,
-        drm_bo_in.ptr (),
-        XCAM_RETURN_ERROR_MEM,
-        "CL image processor can't handle this buffer, maybe type error");
+    XCAM_ASSERT (input.ptr ());
 
     // Always set to NULL,  output buf should be handled in CLBufferNotifyThread
     output = NULL;
@@ -182,7 +175,7 @@ CLImageProcessor::process_buffer (SmartPtr<VideoBuffer> &input, SmartPtr<VideoBu
 
     SmartPtr<PriorityBuffer> p_buf = new PriorityBuffer;
     p_buf->set_seq_num (_seq_num++);
-    p_buf->data = drm_bo_in;
+    p_buf->data = input;
     p_buf->handler = *(_handlers.begin ());
 
     XCAM_FAIL_RETURN (

--- a/modules/ocl/cl_image_scaler.cpp
+++ b/modules/ocl/cl_image_scaler.cpp
@@ -219,8 +219,7 @@ CLImageScaler::prepare_scaler_buf (const VideoBufferInfo &video_info, SmartPtr<V
 
         scaler_video_info.init (video_info.format, new_width, new_height);
 
-        SmartPtr<DrmDisplay> display = DrmDisplay::instance ();
-        _scaler_buf_pool = new DrmBoBufferPool (display);
+        _scaler_buf_pool = new CLVideoBufferPool ();
         XCAM_ASSERT (_scaler_buf_pool.ptr ());
         _scaler_buf_pool->set_video_info (scaler_video_info);
         _scaler_buf_pool->reserve (6);

--- a/modules/ocl/cl_memory.cpp
+++ b/modules/ocl/cl_memory.cpp
@@ -163,6 +163,43 @@ CLBuffer::init_buffer (
     return true;
 }
 
+CLSubBuffer::CLSubBuffer (
+    const SmartPtr<CLContext> &context, SmartPtr<CLBuffer> main_buf,
+    cl_mem_flags flags, uint32_t offset, uint32_t size)
+    : CLBuffer (context)
+    , _main_buf (main_buf)
+    , _flags (flags)
+    , _size (size)
+{
+    init_sub_buffer (context, main_buf, flags, offset, size);
+}
+
+bool
+CLSubBuffer::init_sub_buffer (
+    const SmartPtr<CLContext> &context,
+    SmartPtr<CLBuffer> main_buf,
+    cl_mem_flags flags,
+    uint32_t offset,
+    uint32_t size)
+{
+    cl_mem sub_mem = NULL;
+    cl_mem main_mem = main_buf->get_mem_id ();
+    XCAM_FAIL_RETURN (ERROR, main_mem != NULL, false, "get memory from main image failed");
+
+    cl_buffer_region region;
+    region.origin = offset;
+    region.size = size;
+
+    sub_mem = context->create_sub_buffer (main_mem, region, flags);
+    if (sub_mem == NULL) {
+        XCAM_LOG_WARNING ("CLBuffer create sub buffer failed");
+        return false;
+    }
+
+    set_mem_id (sub_mem);
+    return true;
+}
+
 XCamReturn
 CLBuffer::enqueue_read (
     void *ptr, uint32_t offset, uint32_t size,

--- a/modules/ocl/cl_memory.cpp
+++ b/modules/ocl/cl_memory.cpp
@@ -18,6 +18,7 @@
  * Author: Wind Yuan <feng.yuan@intel.com>
  */
 
+#include "cl_utils.h"
 #include "cl_memory.h"
 #include "drm_display.h"
 #include "cl_image_bo_buffer.h"

--- a/modules/ocl/cl_memory.h
+++ b/modules/ocl/cl_memory.h
@@ -115,6 +115,9 @@ public:
         CLEventList &event_waits = CLEvent::EmptyList,
         SmartPtr<CLEvent> &event_out = CLEvent::NullEvent);
 
+    void set_buf_size (uint32_t size) {
+        _size = size;
+    }
     uint32_t get_buf_size () {
         return _size;
     }
@@ -129,6 +132,36 @@ private:
 private:
     cl_mem_flags    _flags;
     uint32_t        _size;
+};
+
+class CLSubBuffer
+    : public CLBuffer
+{
+protected:
+    explicit CLSubBuffer (const SmartPtr<CLContext> &context);
+
+public:
+    explicit CLSubBuffer (
+        const SmartPtr<CLContext> &context,
+        SmartPtr<CLBuffer> main_buf,
+        cl_mem_flags flags = CL_MEM_READ_WRITE,
+        uint32_t offset = 0,
+        uint32_t size = 0);
+
+private:
+    bool init_sub_buffer (
+        const SmartPtr<CLContext> &context,
+        SmartPtr<CLBuffer> main_buf,
+        cl_mem_flags flags,
+        uint32_t offset,
+        uint32_t size);
+
+    XCAM_DEAD_COPY (CLSubBuffer);
+
+private:
+    SmartPtr<CLBuffer>   _main_buf;
+    cl_mem_flags         _flags;
+    uint32_t             _size;
 };
 
 class CLVaBuffer

--- a/modules/ocl/cl_memory.h
+++ b/modules/ocl/cl_memory.h
@@ -21,7 +21,6 @@
 #ifndef XCAM_CL_MEMORY_H
 #define XCAM_CL_MEMORY_H
 
-#include "xcam_utils.h"
 #include "ocl/cl_context.h"
 #include "ocl/cl_event.h"
 #include "drm_bo_buffer.h"

--- a/modules/ocl/cl_post_image_processor.cpp
+++ b/modules/ocl/cl_post_image_processor.cpp
@@ -245,7 +245,7 @@ CLPostImageProcessor::create_handlers ()
         XCAM_RETURN_ERROR_CL,
         "CLPostImageProcessor create retinex handler failed");
     _retinex->enable_handler (_defog_mode == CLPostImageProcessor::DefogRetinex);
-    image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+    image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
     image_handler->set_pool_size (XCAM_CL_POST_IMAGE_MAX_POOL_SIZE);
     add_handler (image_handler);
 
@@ -258,7 +258,7 @@ CLPostImageProcessor::create_handlers ()
         XCAM_RETURN_ERROR_CL,
         "CLPostImageProcessor create defog handler failed");
     _defog_dcp->enable_handler (_defog_mode == CLPostImageProcessor::DefogDarkChannelPrior);
-    image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+    image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
     image_handler->set_pool_size (XCAM_CL_POST_IMAGE_MAX_POOL_SIZE);
     add_handler (image_handler);
 
@@ -273,7 +273,7 @@ CLPostImageProcessor::create_handlers ()
                 _tnr.ptr (),
                 XCAM_RETURN_ERROR_CL,
                 "CLPostImageProcessor create tnr handler failed");
-            image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+            image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
             image_handler->set_pool_size (XCAM_CL_POST_IMAGE_DEFAULT_POOL_SIZE);
             add_handler (image_handler);
             break;
@@ -298,7 +298,7 @@ CLPostImageProcessor::create_handlers ()
             XCAM_RETURN_ERROR_CL,
             "CLPostImageProcessor create wavelet denoise handler failed");
         _wavelet->enable_handler (true);
-        image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+        image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
         image_handler->set_pool_size (XCAM_CL_POST_IMAGE_DEFAULT_POOL_SIZE);
         add_handler (image_handler);
         break;
@@ -312,7 +312,7 @@ CLPostImageProcessor::create_handlers ()
             XCAM_RETURN_ERROR_CL,
             "CLPostImageProcessor create new wavelet denoise handler failed");
         _newwavelet->enable_handler (true);
-        image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+        image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
         image_handler->set_pool_size (XCAM_CL_POST_IMAGE_DEFAULT_POOL_SIZE);
         add_handler (image_handler);
         break;
@@ -340,7 +340,7 @@ CLPostImageProcessor::create_handlers ()
             _3d_denoise.ptr (),
             XCAM_RETURN_ERROR_CL,
             "CL3aImageProcessor create 3D noise reduction handler failed");
-        image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+        image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
         image_handler->set_pool_size (XCAM_CL_POST_IMAGE_MAX_POOL_SIZE);
         image_handler->enable_handler (true);
         add_handler (image_handler);
@@ -356,7 +356,7 @@ CLPostImageProcessor::create_handlers ()
         "CLPostImageProcessor create scaler handler failed");
     _scaler->set_scaler_factor (_scaler_factor, _scaler_factor);
     _scaler->set_buffer_callback (_stats_callback);
-    image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+    image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
     image_handler->enable_handler (_enable_scaler);
     add_handler (image_handler);
 
@@ -369,7 +369,7 @@ CLPostImageProcessor::create_handlers ()
         XCAM_RETURN_ERROR_CL,
         "CLPostImageProcessor create wire frame handler failed");
     _wireframe->enable_handler (_enable_wireframe);
-    image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+    image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
     image_handler->set_pool_size (XCAM_CL_POST_IMAGE_DEFAULT_POOL_SIZE);
     add_handler (image_handler);
 
@@ -382,7 +382,7 @@ CLPostImageProcessor::create_handlers ()
         XCAM_RETURN_ERROR_CL,
         "CLPostImageProcessor create image warp handler failed");
     _image_warp->enable_handler (_enable_image_warp);
-    image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+    image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
     image_handler->set_pool_size (XCAM_CL_POST_IMAGE_MAX_POOL_SIZE);
     add_handler (image_handler);
 
@@ -395,7 +395,7 @@ CLPostImageProcessor::create_handlers ()
         XCAM_RETURN_ERROR_CL,
         "CLPostImageProcessor create video stabilizer failed");
     _video_stab->enable_handler (false);
-    image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+    image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
     image_handler->set_pool_size (XCAM_CL_POST_IMAGE_MAX_POOL_SIZE);
     add_handler (image_handler);
 
@@ -413,7 +413,7 @@ CLPostImageProcessor::create_handlers ()
 #if HAVE_OPENCV
     _stitch->set_feature_match_ocl (_stitch_fm_ocl);
 #endif
-    image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+    image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
     image_handler->set_pool_size (XCAM_CL_POST_IMAGE_MAX_POOL_SIZE);
     image_handler->enable_handler (_enable_stitch);
     add_handler (image_handler);
@@ -428,7 +428,7 @@ CLPostImageProcessor::create_handlers ()
         "CLPostImageProcessor create csc handler failed");
     _csc->enable_handler (_out_sample_type == OutSampleRGB);
     _csc->set_output_format (_output_fourcc);
-    image_handler->set_pool_type (CLImageHandler::DrmBoPoolType);
+    image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
     image_handler->set_pool_size (XCAM_CL_POST_IMAGE_DEFAULT_POOL_SIZE);
     add_handler (image_handler);
 

--- a/modules/ocl/cl_utils.cpp
+++ b/modules/ocl/cl_utils.cpp
@@ -85,7 +85,18 @@ convert_to_climage (
 
     SmartPtr<CLVideoBuffer> cl_video_buf = buf.dynamic_cast_ptr<CLVideoBuffer> ();
     if (cl_video_buf.ptr ()) {
-        SmartPtr<CLBuffer> cl_buf = cl_video_buf->get_cl_buffer ();
+        SmartPtr<CLBuffer> cl_buf;
+
+        if (offset == 0) {
+            cl_buf = cl_video_buf;
+        } else {
+            uint32_t row_pitch = CLImage::calculate_pixel_bytes (desc.format) *
+                                     XCAM_ALIGN_UP (desc.width, XCAM_CL_IMAGE_ALIGNMENT_X);
+            uint32_t size = row_pitch * desc.height;
+
+            cl_buf = new CLSubBuffer (context, cl_video_buf, flags, offset, size);
+        }
+
         cl_image = new CLImage2D (context, desc, flags, cl_buf);
     } else {
         SmartPtr<DrmBoBuffer> bo_buf = buf.dynamic_cast_ptr<DrmBoBuffer> ();

--- a/modules/ocl/cl_utils.h
+++ b/modules/ocl/cl_utils.h
@@ -26,6 +26,8 @@
 #include "ocl/cl_memory.h"
 #include "ocl/cl_video_buffer.h"
 
+#define XCAM_CL_IMAGE_ALIGNMENT_X 4
+
 namespace XCam {
 
 bool write_image (SmartPtr<CLImage> image, const char *file_name);

--- a/modules/ocl/cl_video_buffer.cpp
+++ b/modules/ocl/cl_video_buffer.cpp
@@ -78,20 +78,16 @@ CLVideoBufferData::unmap ()
 }
 
 CLVideoBuffer::CLVideoBuffer (
-    const VideoBufferInfo &info, const SmartPtr<CLVideoBufferData> &data)
+    const SmartPtr<CLContext> &context, const VideoBufferInfo &info, const SmartPtr<CLVideoBufferData> &data)
     : BufferProxy (info, data)
+    , CLBuffer (context)
 {
     XCAM_ASSERT (data.ptr ());
-}
 
-cl_mem &
-CLVideoBuffer::get_mem_id ()
-{
-    SmartPtr<BufferData> data = get_buffer_data ();
-    SmartPtr<CLVideoBufferData> cl_data = data.dynamic_cast_ptr<CLVideoBufferData> ();
-    XCAM_ASSERT (cl_data.ptr ());
-
-    return cl_data->get_mem_id ();
+    SmartPtr<CLBuffer> cl_buf = data->get_cl_buffer ();
+    XCAM_ASSERT (cl_buf.ptr ());
+    set_mem_id (cl_buf->get_mem_id (), false);
+    set_buf_size (cl_buf->get_buf_size ());
 }
 
 SmartPtr<CLBuffer>
@@ -140,11 +136,12 @@ CLVideoBufferPool::allocate_data (const VideoBufferInfo &buffer_info)
 SmartPtr<BufferProxy>
 CLVideoBufferPool::create_buffer_from_data (SmartPtr<BufferData> &data)
 {
+    SmartPtr<CLContext> context = CLDevice::instance ()->get_context ();
     const VideoBufferInfo & info = get_video_info ();
     SmartPtr<CLVideoBufferData> cl_data = data.dynamic_cast_ptr<CLVideoBufferData> ();
     XCAM_ASSERT (cl_data.ptr ());
 
-    SmartPtr<CLVideoBuffer> buf = new CLVideoBuffer (info, cl_data);
+    SmartPtr<CLVideoBuffer> buf = new CLVideoBuffer (context, info, cl_data);
     XCAM_ASSERT (buf.ptr ());
 
     return buf;

--- a/modules/ocl/cl_video_buffer.h
+++ b/modules/ocl/cl_video_buffer.h
@@ -64,15 +64,16 @@ private:
 
 class CLVideoBuffer
     : public BufferProxy
+    , public CLBuffer
 {
     friend class CLVideoBufferPool;
 
 public:
+    explicit CLVideoBuffer (
+        const SmartPtr<CLContext> &context, const VideoBufferInfo &info, const SmartPtr<CLVideoBufferData> &data);
     virtual ~CLVideoBuffer () {}
 
-    cl_mem &get_mem_id ();
     SmartPtr<CLBuffer> get_cl_buffer ();
-
     SmartPtr<X3aStats> find_3a_stats ();
 
 protected:

--- a/tests/test-cl-image.cpp
+++ b/tests/test-cl-image.cpp
@@ -496,12 +496,9 @@ int main (int argc, char *argv[])
     }
 
     input_buf_info.init (input_format, width, height);
-    SmartPtr<DrmDisplay> display = DrmDisplay::instance ();
-    SmartPtr<DrmBoBufferPool> bo_buf_pool = new DrmBoBufferPool (display);
-    XCAM_ASSERT (bo_buf_pool.ptr ());
-    bo_buf_pool->set_swap_flags (
-        SwappedBuffer::SwapY | SwappedBuffer::SwapUV, SwappedBuffer::OrderY0Y1 | SwappedBuffer::OrderUV0UV1);
-    buf_pool = bo_buf_pool;
+
+    buf_pool = new CLVideoBufferPool ();
+    image_handler->set_pool_type (CLImageHandler::CLVideoPoolType);
     buf_pool->set_video_info (input_buf_info);
     if (!buf_pool->reserve (6)) {
         XCAM_LOG_ERROR ("init buffer pool failed");
@@ -544,7 +541,7 @@ int main (int argc, char *argv[])
     XCAM_LOG_INFO ("processed %d buffers successfully", buf_count);
 
     if (enable_psnr) {
-        buf_pool = new DrmBoBufferPool (display);
+        buf_pool = new CLVideoBufferPool ();
         XCAM_ASSERT (buf_pool.ptr ());
         buf_pool->set_video_info (input_buf_info);
         if (!buf_pool->reserve (6)) {

--- a/tests/test-device-manager.cpp
+++ b/tests/test-device-manager.cpp
@@ -648,7 +648,6 @@ int main (int argc, char *argv[])
     device_manager->set_frame_save (save_frames);
     device_manager->set_frame_width (frame_width);
     device_manager->set_frame_height (frame_height);
-    device_manager->enable_display (need_display);
     device_manager->set_display_mode (display_mode);
 
     if (!device.ptr ())  {
@@ -840,8 +839,13 @@ int main (int argc, char *argv[])
         }
 
         if (need_display) {
-            cl_post_processor->set_output_format (V4L2_PIX_FMT_XBGR32);
+            need_display = false;
+            XCAM_LOG_WARNING ("CLVideoBuffer doesn't support local preview, disable local preview now");
+
+            // cl_post_processor->set_output_format (V4L2_PIX_FMT_XBGR32);
         }
+        device_manager->enable_display (need_display);
+
         device_manager->add_image_processor (cl_post_processor);
     }
 #endif

--- a/tests/test-image-blend.cpp
+++ b/tests/test-image-blend.cpp
@@ -32,7 +32,7 @@
 
 using namespace XCam;
 
-#define ENABLE_DMA_TEST 1
+#define ENABLE_DMA_TEST 0
 
 static uint32_t input_format = V4L2_PIX_FMT_NV12;
 //static uint32_t output_format = V4L2_PIX_FMT_NV12;
@@ -99,6 +99,7 @@ geo_correct_image (
     return 0;
 }
 
+#if ENABLE_DMA_TEST
 static SmartPtr<VideoBuffer>
 dma_buf_to_xcam_buf (
     SmartPtr<DrmDisplay> display, int dma_fd,
@@ -140,6 +141,7 @@ create_dma_buffer (SmartPtr<DrmDisplay> &display, const VideoBufferInfo &info)
     buf_pool->reserve (1);
     return buf_pool->get_buffer (buf_pool);
 }
+#endif
 
 static XCamReturn
 blend_images (
@@ -161,7 +163,6 @@ int main (int argc, char *argv[])
     SmartPtr<CLBlender> blender;
     VideoBufferInfo input_buf_info0, input_buf_info1, output_buf_info;
     SmartPtr<CLContext> context;
-    SmartPtr<DrmDisplay> display;
     SmartPtr<BufferPool> buf_pool0, buf_pool1;
     ImageFileHandle file_in0, file_in1, file_out;
     SmartPtr<VideoBuffer> input0, input1;
@@ -256,9 +257,14 @@ int main (int argc, char *argv[])
     input_buf_info0.init (input_format, input_width0, input_height);
     input_buf_info1.init (input_format, input_width1, input_height);
     output_buf_info.init (input_format, output_width, output_height);
-    display = DrmDisplay::instance ();
+#if ENABLE_DMA_TEST
+    SmartPtr<DrmDisplay> display = DrmDisplay::instance ();
     buf_pool0 = new DrmBoBufferPool (display);
     buf_pool1 = new DrmBoBufferPool (display);
+#else
+    buf_pool0 = new CLVideoBufferPool ();
+    buf_pool1 = new CLVideoBufferPool ();
+#endif
     XCAM_ASSERT (buf_pool0.ptr () && buf_pool1.ptr ());
     buf_pool0->set_video_info (input_buf_info0);
     buf_pool1->set_video_info (input_buf_info1);

--- a/tests/test-image-stitching.cpp
+++ b/tests/test-image-stitching.cpp
@@ -332,13 +332,12 @@ int main (int argc, char *argv[])
 #if HAVE_OPENCV
     image_360->set_feature_match_ocl (fm_ocl);
 #endif
-    image_360->set_pool_type (CLImageHandler::DrmBoPoolType);
+    image_360->set_pool_type (CLImageHandler::CLVideoPoolType);
 
     input_buf_info.init (input_format, input_width, input_height);
     output_buf_info.init (input_format, output_width, output_height);
     for (int i = 0; i < input_count; i++) {
-        SmartPtr<DrmDisplay> display = DrmDisplay::instance ();
-        buf_pool[i] = new DrmBoBufferPool (display);
+        buf_pool[i] = new CLVideoBufferPool ();
         XCAM_ASSERT (buf_pool[i].ptr ());
         buf_pool[i]->set_video_info (input_buf_info);
         if (!buf_pool[i]->reserve (6)) {

--- a/tests/test-video-stabilization.cpp
+++ b/tests/test-video-stabilization.cpp
@@ -208,8 +208,7 @@ int main (int argc, char *argv[])
     context = CLDevice::instance ()->get_context ();
     video_stab = create_cl_video_stab_handler (context).dynamic_cast_ptr<CLVideoStabilizer> ();
     XCAM_ASSERT (video_stab.ptr ());
-
-    video_stab->set_pool_type (CLImageHandler::DrmBoPoolType);
+    video_stab->set_pool_type (CLImageHandler::CLVideoPoolType);
 
     /*
         Color CameraIntrinsics:
@@ -239,8 +238,7 @@ int main (int argc, char *argv[])
 
     input_buf_info.init (input_format, input_width, input_height);
     output_buf_info.init (input_format, output_width, output_height);
-    SmartPtr<DrmDisplay> display = DrmDisplay::instance ();
-    buf_pool = new DrmBoBufferPool (display);
+    buf_pool = new CLVideoBufferPool ();
     XCAM_ASSERT (buf_pool.ptr ());
     buf_pool->set_video_info (input_buf_info);
     if (!buf_pool->reserve (36)) {

--- a/wrapper/gstreamer/gstxcamfilter.cpp
+++ b/wrapper/gstreamer/gstxcamfilter.cpp
@@ -571,6 +571,13 @@ gst_xcam_filter_start (GstBaseTransform *trans)
     pipe_manager->add_image_processor (image_processor);
     pipe_manager->set_image_processor (image_processor);
 
+    xcamfilter->buf_pool = new CLVideoBufferPool ();
+    XCAM_ASSERT (xcamfilter->buf_pool.ptr ());
+    if (xcamfilter->copy_mode == COPY_MODE_DMA) {
+        XCAM_LOG_WARNING ("CLVideoBuffer doesn't support DMA copy mode, switch to CPU copy mode");
+        xcamfilter->copy_mode = COPY_MODE_CPU;
+    }
+
     if (xcamfilter->copy_mode == COPY_MODE_DMA) {
         xcamfilter->allocator = gst_dmabuf_allocator_new ();
         if (!xcamfilter->allocator) {
@@ -578,10 +585,6 @@ gst_xcam_filter_start (GstBaseTransform *trans)
             return false;
         }
     }
-
-    SmartPtr<DrmDisplay> display = DrmDisplay::instance ();
-    xcamfilter->buf_pool = new DrmBoBufferPool (display);
-    XCAM_ASSERT (xcamfilter->buf_pool.ptr ());
 
     return true;
 }


### PR DESCRIPTION
* build: download cl_intel.h from v1.3.0 release branch
* standard-OCL: fix invalid length for vector component access
* standard-OCL: fix row pitch aligned issue
* standard-OCL: switch to CLVideoBuffer path

