### PR TITLE
cv-context: fix bug with cv::ocl::setUseOpenCL

### DIFF
--- a/modules/ocl/cv_base_class.cpp
+++ b/modules/ocl/cv_base_class.cpp
@@ -25,15 +25,14 @@ namespace XCam {
 
 CVBaseClass::CVBaseClass ()
 {
-    SmartPtr<CVContext> cv_context = CVContext::instance();
-    _use_ocl = cv_context->use_ocl ();
-    _context = cv_context->get_context ();
+    SmartPtr<CVContext> _cv_context = CVContext::instance ();
+    _use_ocl = cv::ocl::useOpenCL ();
 }
 
 bool
 CVBaseClass::convert_to_mat (SmartPtr<VideoBuffer> buffer, cv::Mat &image)
 {
-    SmartPtr<CLBuffer> cl_buffer = convert_to_clbuffer (_context, buffer);
+    SmartPtr<CLBuffer> cl_buffer = convert_to_clbuffer (_cv_context->get_cl_context (), buffer);
     VideoBufferInfo info = buffer->get_video_info ();
     cl_mem cl_mem_id = cl_buffer->get_mem_id ();
 

--- a/modules/ocl/cv_base_class.h
+++ b/modules/ocl/cv_base_class.h
@@ -54,7 +54,7 @@ public:
 
 protected:
     XCAM_DEAD_COPY (CVBaseClass);
-    SmartPtr<CLContext>  _context;
+    SmartPtr<CVContext>  _cv_context;
     bool                 _use_ocl;
 };
 

--- a/modules/ocl/cv_context.cpp
+++ b/modules/ocl/cv_context.cpp
@@ -34,7 +34,7 @@ CVContext::instance ()
     if (_instance.ptr())
         return _instance;
 
-    _instance = new CVContext();
+    _instance = new CVContext ();
     _instance->init_opencv_ocl ();
     return _instance;
 }
@@ -48,25 +48,11 @@ CVContext::init_opencv_ocl ()
     cl_device_id device_id = CLDevice::instance()->get_device_id ();
     cl_context _context_id = _context->get_context_id ();
     cv::ocl::attachContext (platform_name, platform_id, _context_id, device_id);
-    _is_ocl_inited = true;
-
-    if (!cv::ocl::useOpenCL ()) {
-        cv::ocl::setUseOpenCL (false);
-
-        if (_use_ocl) {
-            XCAM_LOG_WARNING ("cv context: change to non-ocl mode");
-            _use_ocl = false;
-        }
-
-        return;
-    }
-
-    cv::ocl::setUseOpenCL (_use_ocl);
+    cv::ocl::setUseOpenCL (cv::ocl::haveOpenCL());
+    XCAM_LOG_DEBUG("Use OpenCL is:  %s", cv::ocl::haveOpenCL() ? "true" : "false");
 }
 
 CVContext::CVContext ()
-    : _is_ocl_inited (false)
-    , _use_ocl (false)
 {
 
 }

--- a/modules/ocl/cv_context.h
+++ b/modules/ocl/cv_context.h
@@ -45,13 +45,7 @@ class CVContext
 public:
     static SmartPtr<CVContext> instance ();
 
-    bool is_inited () {
-        return _is_ocl_inited;
-    }
-    bool use_ocl () {
-        return _use_ocl;
-    }
-    SmartPtr<CLContext> get_context () {
+    SmartPtr<CLContext> get_cl_context () {
         return _context;
     }
     ~CVContext();
@@ -62,9 +56,7 @@ private:
     static Mutex                _init_mutex;
     static SmartPtr<CVContext>  _instance;
 
-    bool                        _is_ocl_inited;
     SmartPtr<CLContext>         _context;
-    bool                        _use_ocl;
 
     XCAM_DEAD_COPY (CVContext);
 

--- a/modules/ocl/cv_feature_match.cpp
+++ b/modules/ocl/cv_feature_match.cpp
@@ -36,7 +36,7 @@ bool
 CVFeatureMatch::get_crop_image (
     SmartPtr<VideoBuffer> buffer, Rect crop_rect, cv::UMat &img)
 {
-    SmartPtr<CLBuffer> cl_buffer = convert_to_clbuffer (_context, buffer);
+    SmartPtr<CLBuffer> cl_buffer = convert_to_clbuffer (_cv_context->get_cl_context (), buffer);
     VideoBufferInfo info = buffer->get_video_info ();
     cl_mem cl_mem_id = cl_buffer->get_mem_id ();
 


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

There is a bug with cv_context class cv::ocl::setUseOpenCL (_use_ocl) will always set "false" here and there is no way to change it later. This patch use cv::ocl::setUseOpenCL (cv::ocl::haveOpenCL()); instead. 