### PR TITLE
CVContext: fix duplicate definition

### DIFF
--- a/modules/ocl/cv_base_class.cpp
+++ b/modules/ocl/cv_base_class.cpp
@@ -25,7 +25,8 @@ namespace XCam {
 
 CVBaseClass::CVBaseClass ()
 {
-    SmartPtr<CVContext> _cv_context = CVContext::instance ();
+    _cv_context = CVContext::instance ();
+    XCAM_ASSERT (_cv_context.ptr ());
     _use_ocl = cv::ocl::useOpenCL ();
 }
 

--- a/modules/ocl/cv_context.h
+++ b/modules/ocl/cv_context.h
@@ -45,7 +45,7 @@ class CVContext
 public:
     static SmartPtr<CVContext> instance ();
 
-    SmartPtr<CLContext> &get_cl_context () {
+    SmartPtr<CLContext> get_cl_context () {
         return _context;
     }
     ~CVContext();

--- a/modules/ocl/cv_feature_match.cpp
+++ b/modules/ocl/cv_feature_match.cpp
@@ -27,9 +27,10 @@ namespace XCam {
 #define XCAM_CV_OF_DRAW_SCALE 2
 
 CVFeatureMatch::CVFeatureMatch ()
-    : CVBaseClass()
-    , FeatureMatch()
+    : CVBaseClass ()
+    , FeatureMatch ()
 {
+    XCAM_ASSERT (_cv_context.ptr ());
 }
 
 bool


### PR DESCRIPTION
 * the _cv_context redefined in constructor is local variable,
   which will cause member variable is not uninitialized