### PR TITLE
stitcher: add bowl model vertex

### DIFF
--- a/modules/ocl/cl_utils.h
+++ b/modules/ocl/cl_utils.h
@@ -59,24 +59,18 @@ XCamReturn convert_nv12_mem_to_video_buffer (
     void *nv12_mem, uint32_t width, uint32_t height, uint32_t row_pitch, uint32_t offset_uv,
     SmartPtr<VideoBuffer> &buf);
 
-XCamReturn bowl_view_coords_to_image (
-    const VideoBufferInfo& info,
-    const BowlDataConfig &config,
-    float x_pos, float y_pos, float z_pos,
-    float &x_trans, float &y_trans);
-
 XCamReturn
 generate_topview_map_table (
     const VideoBufferInfo &stitch_info,
     const BowlDataConfig &config,
-    std::vector<float> &map_table,
+    std::vector<PointFloat2> &map_table,
     int width, int height);
 
 XCamReturn
 generate_rectifiedview_map_table (
     const VideoBufferInfo &stitch_info,
     const BowlDataConfig &config,
-    std::vector<float> &map_table,
+    std::vector<PointFloat2> &map_table,
     float angle_start, float angle_end,
     int width, int height);
 
@@ -84,14 +78,14 @@ XCamReturn sample_generate_top_view (
     SmartPtr<VideoBuffer> &stitch_buf,
     SmartPtr<VideoBuffer> top_view_buf,
     const BowlDataConfig &config,
-    std::vector<float> &map_table, int frame_id);
+    std::vector<PointFloat2> &map_table);
 
 XCamReturn sample_generate_rectified_view (
     SmartPtr<VideoBuffer> &stitch_buf,
     SmartPtr<VideoBuffer> rectified_view_buf,
     const BowlDataConfig &config,
     float angle_start, float angle_end,
-    std::vector<float> &map_table, int frame_id);
+    std::vector<PointFloat2> &map_table);
 }
 
 #endif //XCAM_CL_UTILS_H

--- a/tests/test-image-stitching.cpp
+++ b/tests/test-image-stitching.cpp
@@ -489,8 +489,8 @@ int main (int argc, char *argv[])
     SmartPtr<VideoBuffer> input_bufs[XCAM_STITCH_FISHEYE_MAX_NUM];
 #endif
     int frame_id = 0;
-    std::vector<float> top_view_map_table (top_view_height * top_view_width * 2);
-    std::vector<float> rectified_view_map_table (rectified_view_height * rectified_view_width * 2);
+    std::vector<PointFloat2> top_view_map_table;
+    std::vector<PointFloat2> rectified_view_map_table;
     float rectified_start_angle = -45.0f, rectified_end_angle = 45.0f;
 
     while (loop--) {
@@ -529,9 +529,9 @@ int main (int argc, char *argv[])
             CHECK (ret, "image_360 stitch execute failed");
 
             BowlDataConfig config = image_360->get_fisheye_bowl_config ();
-            sample_generate_top_view (output_buf, top_view_buf, config, top_view_map_table, frame_id);
+            sample_generate_top_view (output_buf, top_view_buf, config, top_view_map_table);
             sample_generate_rectified_view (output_buf, rectified_view_buf, config, rectified_start_angle,
-                                            rectified_end_angle, rectified_view_map_table, frame_id);
+                                            rectified_end_angle, rectified_view_map_table);
 
 #if HAVE_OPENCV
             if (need_save_output) {

--- a/xcore/interface/data_types.h
+++ b/xcore/interface/data_types.h
@@ -64,23 +64,6 @@ struct FisheyeInfo {
     }
 };
 
-struct BowlDataConfig {
-    float a, b, c;
-    float angle_start, angle_end; // angle degree
-
-    float center_z;
-    float wall_height;
-    float ground_length;
-
-    BowlDataConfig ()
-    //: a (5050.0f), b (3656.7f), c (3003.4f)
-        : a (6060.0f), b (4388.0f), c (3003.4f)
-        , angle_start (90.0f), angle_end (270.0f)
-        , center_z (1500.0f), wall_height (3000.0f)
-        , ground_length (2801.0f) // (2168.0f)
-    {}
-};
-
 #define XCAM_INTRINSIC_MAX_POLY_SIZE 16
 
 // current intrinsic parameters definition from Scaramuzza's approach
@@ -136,6 +119,33 @@ typedef Point2DT<float> PointFloat2;
 
 typedef Point3DT<int32_t> PointInt3;
 typedef Point3DT<float> PointFloat3;
+
+/*
+ * Ellipsoid model
+ *  x^2 / a^2 + y^2 / b^2 + (z-center_z)^2 / c^2 = 1
+ */
+struct BowlDataConfig {
+    float a, b, c;
+    float angle_start, angle_end; // angle degree
+
+    // unit mm
+    float center_z;
+    float wall_height;
+    float ground_length;
+
+    BowlDataConfig ()
+        : a (6060.0f), b (4388.0f), c (3003.4f)
+        , angle_start (90.0f), angle_end (270.0f)
+        , center_z (1500.0f), wall_height (3000.0f)
+        , ground_length (2801.0f) // (2168.0f)
+    {
+        XCAM_ASSERT (fabs(center_z) <= c);
+        XCAM_ASSERT (a > 0.0f && b > 0.0f && c > 0.0f);
+        XCAM_ASSERT (wall_height >= 0.0f && ground_length >= 0.0f);
+        XCAM_ASSERT (ground_length <= b * sqrt(1.0f - center_z * center_z / (c * c)));
+        XCAM_ASSERT (wall_height <= center_z + c);
+    }
+};
 
 }
 

--- a/xcore/interface/stitcher.h
+++ b/xcore/interface/stitcher.h
@@ -85,9 +85,6 @@ struct ImageOverlapInfo {
     Rect left;
     Rect right;
     Rect out_area;
-    //Rect left_overlap, right_overlap;
-    //Rect seam_buf;
-    //Rect out_area;
 };
 
 class Stitcher
@@ -204,6 +201,30 @@ private:
     CenterMark                  _center_marks[XCAM_STITCH_MAX_CAMERAS];
     bool                        _is_center_marked;
     CopyAreaArray               _copy_areas;
+};
+
+class BowlModel {
+public:
+    typedef std::vector<PointFloat3> VertexMap;
+    typedef std::vector<PointFloat2> PointMap;
+
+public:
+    BowlModel (const BowlDataConfig &config, const uint32_t image_width, const uint32_t image_height);
+    bool get_max_topview_area_mm (float &length_mm, float &width_mm);
+    bool get_topview_vertex_map (
+        VertexMap &vertices, PointMap &texture_points,
+        uint32_t res_width, uint32_t res_height,
+        float length_mm = 0.0f, float width_mm = 0.0f);
+
+    bool get_bowlview_vertex_map (
+        VertexMap &vertices, PointMap &texture_points,
+        uint32_t res_width, uint32_t res_height);
+
+private:
+    BowlDataConfig    _config;
+    uint32_t          _bowl_img_width, _bowl_img_height;
+    float             _max_topview_width_mm;
+    float             _max_topview_length_mm;
 };
 
 }

--- a/xcore/surview_fisheye_dewarp.h
+++ b/xcore/surview_fisheye_dewarp.h
@@ -49,7 +49,6 @@ private:
 
     virtual void cal_image_coord (const PointFloat3 &cam_coord, PointFloat2 &image_coord);
 
-    void cal_world_coord (uint32_t x, uint32_t y, PointFloat3 &world_coord, uint32_t image_w, uint32_t image_h, const BowlDataConfig &bowl_config);
     void cal_cam_world_coord (const PointFloat3 &world_coord, PointFloat3 &cam_world_coord);
     void world_coord2cam (const PointFloat3 &cam_world_coord, PointFloat3 &cam_coord);
 

--- a/xcore/xcam_utils.h
+++ b/xcore/xcam_utils.h
@@ -22,8 +22,20 @@
 #define XCAM_UTILS_H
 
 #include <xcam_std.h>
+#include <interface/data_types.h>
 
 namespace XCam {
+
+PointFloat2 bowl_view_coords_to_image (
+    const BowlDataConfig &config,
+    const PointFloat3 &bowl_pos,
+    const uint32_t img_width, const uint32_t img_height);
+
+PointFloat3 bowl_view_image_to_world (
+    const BowlDataConfig &config,
+    const uint32_t img_width, const uint32_t img_height,
+    const PointFloat2 &img_pos);
+
 
 double
 linear_interpolate_p2 (


### PR DESCRIPTION
 * add BowlModel for topview and bowlview construction
    - get_max_topview_area_mm (length_mm, width_mm);
    - get_topview_vertex_map (
         vertices, texture_points, res_width, res_height,
         length_mm = 0.0f, width_mm = 0.0f);
    - get_bowlview_vertex_map (vertices, texture_points, res_width, res_height);
 * check test-soft-image.cpp:dump_topview_image to see how to use topview
